### PR TITLE
Add Homebrew formula for hsab

### DIFF
--- a/Formula/hsab.rb
+++ b/Formula/hsab.rb
@@ -1,0 +1,24 @@
+class Hsab < Formula
+  desc "Stack-based postfix shell with persistent state between commands"
+  homepage "https://github.com/johnhenry/bash-backwards"
+  url "https://github.com/johnhenry/bash-backwards.git",
+      tag:      "v0.1.0",
+      revision: ""
+  license "MIT"
+  head "https://github.com/johnhenry/bash-backwards.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  def post_install
+    ohai "Run 'hsab init' to install the standard library to ~/.hsab/lib/"
+  end
+
+  test do
+    assert_match "hsab-0.1.0", shell_output("#{bin}/hsab --version")
+    assert_equal "hello", shell_output("#{bin}/hsab -c '\"hello\" echo'").strip
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a Homebrew formula (`Formula/hsab.rb`) so users can install hsab via `brew install`
- Builds from source using Cargo with the default feature set (includes plugin system)
- Includes a post-install message reminding users to run `hsab init`

## Usage

Once a git tag `v0.1.0` is created, users can install with:

```sh
brew tap johnhenry/bash-backwards https://github.com/johnhenry/bash-backwards
brew install hsab
```

Or install from HEAD (latest main):

```sh
brew install --HEAD johnhenry/bash-backwards/hsab
```

## Test plan
- [ ] Verify `brew install --HEAD johnhenry/bash-backwards/hsab` builds successfully
- [ ] Verify `hsab --version` outputs expected version
- [ ] Verify `hsab -c '"hello" echo'` outputs `hello`
- [ ] Verify `brew test hsab` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)