### PR TITLE
Execute wave 1: robustness & infrastructure — issues #23, #29–#32, #34, #35 (+#33 partial)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: test (default features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
+
+  build-no-default-features:
+    name: build (--no-default-features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,15 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,12 +224,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -518,17 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
-dependencies = [
- "dispatch2",
- "nix 0.30.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,18 +598,6 @@ dependencies = [
  "block-buffer 0.11.0",
  "const-oid",
  "crypto-common 0.2.0",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
-dependencies = [
- "bitflags 2.11.0",
- "block2",
- "libc",
- "objc2",
 ]
 
 [[package]]
@@ -945,7 +907,6 @@ dependencies = [
  "assert_cmd",
  "base64",
  "chrono",
- "ctrlc",
  "glob",
  "hex",
  "hostname",
@@ -1442,18 +1403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,21 +1464,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "objc2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "glob",
  "hex",
  "hostname",
+ "indexmap",
  "libc",
  "nix 0.27.1",
  "nom",
@@ -2080,6 +2081,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ thiserror = "1"
 glob = "0.3"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 indexmap = { version = "2", features = ["serde"] }
-ctrlc = "3.4"
 chrono = "0.4"
 hostname = "0.4"
 terminal_size = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ nom = "7"
 rustyline = "12"
 thiserror = "1"
 glob = "0.3"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
+indexmap = { version = "2", features = ["serde"] }
 ctrlc = "3.4"
 chrono = "0.4"
 hostname = "0.4"

--- a/docs/async.md
+++ b/docs/async.md
@@ -147,6 +147,28 @@ For running multiple independent operations concurrently.
 # -> Response from whichever mirror responded first
 ```
 
+## Listing Futures
+
+```bash
+# futures-list: enumerate every future spawned in this session
+futures-list -> [{id status}...]
+```
+
+```bash
+#[long-task] async            # -> Future<0001>
+#[other-task] async           # -> Future<0002>
+futures-list                  # -> [{id 0001 status pending} {id 0002 status pending}]
+futures-list count            # -> 2
+```
+
+Each entry is a record with `id` and `status` (`pending`, `completed`,
+`failed`, or `cancelled`).
+
+**Lifecycle policy:** futures stay registered for the lifetime of the shell
+session, including after `await` or `future-cancel` — terminal entries report
+their final status (`completed`/`failed`/`cancelled`) rather than disappearing
+from the list. The list is ordered by spawn time.
+
 ## Future Combinators
 
 Operations for working with collections of futures.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,7 +6,7 @@
 //! - Executables pop args, run, push output
 //! - Blocks are deferred execution units
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use serde_json::Value as JsonValue;
 use num_bigint::BigUint;
 
@@ -151,7 +151,7 @@ pub enum Value {
     /// A list of values (for structured data)
     List(Vec<Value>),
     /// A map/object of key-value pairs (for structured data)
-    Map(HashMap<String, Value>),
+    Map(IndexMap<String, Value>),
     /// A numeric value
     Number(f64),
     /// A boolean value

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,10 +6,10 @@
 //! - Executables pop args, run, push output
 //! - Blocks are deferred execution units
 
-use indexmap::IndexMap;
-use serde_json::Value as JsonValue;
-use num_bigint::BigUint;
 use crate::util::lock_or_recover;
+use indexmap::IndexMap;
+use num_bigint::BigUint;
+use serde_json::Value as JsonValue;
 
 /// Convert a Value to a JSON value for serialization
 pub fn value_to_json(v: &Value) -> JsonValue {
@@ -29,16 +29,26 @@ pub fn value_to_json(v: &Value) -> JsonValue {
         ),
         Value::Table { columns, rows } => {
             // Convert table to array of objects
-            let records: Vec<JsonValue> = rows.iter().map(|row| {
-                let obj: serde_json::Map<String, JsonValue> = columns.iter()
-                    .zip(row.iter())
-                    .map(|(col, val)| (col.clone(), value_to_json(val)))
-                    .collect();
-                JsonValue::Object(obj)
-            }).collect();
+            let records: Vec<JsonValue> = rows
+                .iter()
+                .map(|row| {
+                    let obj: serde_json::Map<String, JsonValue> = columns
+                        .iter()
+                        .zip(row.iter())
+                        .map(|(col, val)| (col.clone(), value_to_json(val)))
+                        .collect();
+                    JsonValue::Object(obj)
+                })
+                .collect();
             JsonValue::Array(records)
         }
-        Value::Error { kind, message, code, source, command } => {
+        Value::Error {
+            kind,
+            message,
+            code,
+            source,
+            command,
+        } => {
             let mut obj = serde_json::Map::new();
             obj.insert("kind".into(), JsonValue::String(kind.clone()));
             obj.insert("message".into(), JsonValue::String(message.clone()));
@@ -62,7 +72,7 @@ pub fn value_to_json(v: &Value) -> JsonValue {
             JsonValue::Object(obj)
         }
         Value::Bytes(data) => {
-            use base64::{Engine as _, engine::general_purpose::STANDARD};
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
             let mut obj = serde_json::Map::new();
             obj.insert("type".into(), JsonValue::String("bytes".into()));
             obj.insert("data".into(), JsonValue::String(STANDARD.encode(data)));
@@ -79,8 +89,15 @@ pub fn value_to_json(v: &Value) -> JsonValue {
             }
             JsonValue::Object(obj)
         }
-        Value::Media { mime_type, data, width, height, alt, source } => {
-            use base64::{Engine as _, engine::general_purpose::STANDARD};
+        Value::Media {
+            mime_type,
+            data,
+            width,
+            height,
+            alt,
+            source,
+        } => {
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
             let mut obj = serde_json::Map::new();
             obj.insert("type".into(), JsonValue::String("media".into()));
             obj.insert("mime_type".into(), JsonValue::String(mime_type.clone()));
@@ -104,7 +121,7 @@ pub fn value_to_json(v: &Value) -> JsonValue {
             let mut obj = serde_json::Map::new();
             obj.insert("type".into(), JsonValue::String("future".into()));
             obj.insert("id".into(), JsonValue::String(id.clone()));
-            let status = match &*lock_or_recover(&state) {
+            let status = match &*lock_or_recover(state) {
                 FutureState::Pending => "pending",
                 FutureState::Completed(_) => "completed",
                 FutureState::Failed(_) => "failed",
@@ -123,9 +140,7 @@ pub fn json_to_value(json: JsonValue) -> Value {
         JsonValue::Bool(b) => Value::Bool(b),
         JsonValue::Number(n) => Value::Number(n.as_f64().unwrap_or(0.0)),
         JsonValue::String(s) => Value::Literal(s),
-        JsonValue::Array(arr) => {
-            Value::List(arr.into_iter().map(json_to_value).collect())
-        }
+        JsonValue::Array(arr) => Value::List(arr.into_iter().map(json_to_value).collect()),
         JsonValue::Object(obj) => {
             let map = obj
                 .into_iter()
@@ -230,17 +245,50 @@ impl PartialEq for Value {
             (Value::Map(a), Value::Map(b)) => a == b,
             (Value::Number(a), Value::Number(b)) => a == b,
             (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Table { columns: c1, rows: r1 }, Value::Table { columns: c2, rows: r2 }) => {
-                c1 == c2 && r1 == r2
-            }
-            (Value::Error { kind: k1, message: m1, code: c1, source: s1, command: cmd1 },
-             Value::Error { kind: k2, message: m2, code: c2, source: s2, command: cmd2 }) => {
-                k1 == k2 && m1 == m2 && c1 == c2 && s1 == s2 && cmd1 == cmd2
-            }
-            (Value::Media { mime_type: m1, data: d1, width: w1, height: h1, alt: a1, source: s1 },
-             Value::Media { mime_type: m2, data: d2, width: w2, height: h2, alt: a2, source: s2 }) => {
-                m1 == m2 && d1 == d2 && w1 == w2 && h1 == h2 && a1 == a2 && s1 == s2
-            }
+            (
+                Value::Table {
+                    columns: c1,
+                    rows: r1,
+                },
+                Value::Table {
+                    columns: c2,
+                    rows: r2,
+                },
+            ) => c1 == c2 && r1 == r2,
+            (
+                Value::Error {
+                    kind: k1,
+                    message: m1,
+                    code: c1,
+                    source: s1,
+                    command: cmd1,
+                },
+                Value::Error {
+                    kind: k2,
+                    message: m2,
+                    code: c2,
+                    source: s2,
+                    command: cmd2,
+                },
+            ) => k1 == k2 && m1 == m2 && c1 == c2 && s1 == s2 && cmd1 == cmd2,
+            (
+                Value::Media {
+                    mime_type: m1,
+                    data: d1,
+                    width: w1,
+                    height: h1,
+                    alt: a1,
+                    source: s1,
+                },
+                Value::Media {
+                    mime_type: m2,
+                    data: d2,
+                    width: w2,
+                    height: h2,
+                    alt: a2,
+                    source: s2,
+                },
+            ) => m1 == m2 && d1 == d2 && w1 == w2 && h1 == h2 && a1 == a2 && s1 == s2,
             (Value::Link { url: u1, text: t1 }, Value::Link { url: u2, text: t2 }) => {
                 u1 == u2 && t1 == t2
             }
@@ -305,9 +353,7 @@ impl Value {
             Value::Bool(b) => Some(b.to_string()),
             Value::List(items) => {
                 // Join list items with newlines for shell compatibility
-                let parts: Vec<String> = items.iter()
-                    .filter_map(|v| v.as_arg())
-                    .collect();
+                let parts: Vec<String> = items.iter().filter_map(|v| v.as_arg()).collect();
                 if parts.is_empty() {
                     None
                 } else {
@@ -316,14 +362,21 @@ impl Value {
             }
             Value::Map(map) => {
                 // Check if map is flat (no nested structures)
-                let is_flat = map.values().all(|v| matches!(v,
-                    Value::Literal(_) | Value::Output(_) | Value::Number(_) |
-                    Value::Bool(_) | Value::Nil
-                ));
+                let is_flat = map.values().all(|v| {
+                    matches!(
+                        v,
+                        Value::Literal(_)
+                            | Value::Output(_)
+                            | Value::Number(_)
+                            | Value::Bool(_)
+                            | Value::Nil
+                    )
+                });
 
                 if is_flat {
                     // Flat map: use key=value format for shell compatibility
-                    let mut pairs: Vec<_> = map.iter()
+                    let mut pairs: Vec<_> = map
+                        .iter()
                         .map(|(k, v)| {
                             let val_str = v.as_arg().unwrap_or_default();
                             format!("{}={}", k, val_str)
@@ -337,7 +390,8 @@ impl Value {
                     }
                 } else {
                     // Nested map: use JSON for shell compatibility
-                    let json: serde_json::Map<String, serde_json::Value> = map.iter()
+                    let json: serde_json::Map<String, serde_json::Value> = map
+                        .iter()
                         .map(|(k, v)| (k.clone(), value_to_json(v)))
                         .collect();
                     serde_json::to_string(&json).ok()
@@ -347,15 +401,21 @@ impl Value {
                 // Convert table to TSV for shell compatibility
                 let mut lines = vec![columns.join("\t")];
                 for row in rows {
-                    let line: Vec<String> = row.iter()
-                        .map(|v| v.as_arg().unwrap_or_default())
-                        .collect();
+                    let line: Vec<String> =
+                        row.iter().map(|v| v.as_arg().unwrap_or_default()).collect();
                     lines.push(line.join("\t"));
                 }
                 Some(lines.join("\n"))
             }
             Value::Error { message, .. } => Some(message.clone()),
-            Value::Media { mime_type, data, width, height, source, .. } => {
+            Value::Media {
+                mime_type,
+                data,
+                width,
+                height,
+                source,
+                ..
+            } => {
                 // For shell compatibility, return a description
                 let size_str = if data.len() < 1024 {
                     format!("{} bytes", data.len())
@@ -368,8 +428,14 @@ impl Value {
                     (Some(w), Some(h)) => format!("{}x{}", w, h),
                     _ => "?x?".to_string(),
                 };
-                let src = source.as_ref().map(|s| format!(" ({})", s)).unwrap_or_default();
-                Some(format!("[Media: {} {} {}{}]", mime_type, dims, size_str, src))
+                let src = source
+                    .as_ref()
+                    .map(|s| format!(" ({})", s))
+                    .unwrap_or_default();
+                Some(format!(
+                    "[Media: {} {} {}{}]",
+                    mime_type, dims, size_str, src
+                ))
             }
             Value::Link { url, .. } => Some(url.clone()),
             Value::Bytes(data) => {
@@ -409,7 +475,10 @@ pub enum Expr {
     Literal(String),
 
     /// A quoted string (preserves quotes in output)
-    Quoted { content: String, double: bool },
+    Quoted {
+        content: String,
+        double: bool,
+    },
 
     /// A variable reference ($VAR or ${VAR})
     Variable(String),
@@ -433,7 +502,7 @@ pub enum Expr {
     Pipe,
 
     /// Redirect operators
-    RedirectOut,       // >
+    RedirectOut, // >
     RedirectAppend,    // >>
     RedirectIn,        // <
     RedirectErr,       // 2>
@@ -446,7 +515,7 @@ pub enum Expr {
 
     /// Logical operators
     And, // &&
-    Or,  // ||
+    Or, // ||
 
     /// Stack operations
     Dup,
@@ -464,11 +533,11 @@ pub enum Expr {
     Realpath, // Resolve to canonical absolute path (handles .., ., symlinks)
 
     /// String operations
-    Split1,  // Split at first occurrence: "a.b.c" "." split1 → "a", "b.c"
+    Split1, // Split at first occurrence: "a.b.c" "." split1 → "a", "b.c"
     Rsplit1, // Split at last occurrence: "a.b.c" "." rsplit1 → "a.b", "c"
 
     /// List operations
-    Marker,  // Push a marker onto the stack (boundary for each/keep/collect)
+    Marker, // Push a marker onto the stack (boundary for each/keep/collect)
     Spread,  // Split multi-line value into separate stack items (pushes marker first)
     Each,    // Apply block to each item on stack (until marker)
     Collect, // Gather stack items back into single value
@@ -477,7 +546,7 @@ pub enum Expr {
     Filter,  // #[predicate] filter - keep + collect (filter items)
 
     /// Control flow
-    If,     // #[else] #[then] condition if  (condition is a value; else-block optional)
+    If, // #[else] #[then] condition if  (condition is a value; else-block optional)
     ElseIf, // #[then] condition elseif     (chained conditional, only if prior branch not taken)
     Else,   // #[block] else                (fallback, only if no prior branch taken)
     Times,  // #[block] N times - repeat block N times
@@ -487,14 +556,14 @@ pub enum Expr {
 
     /// Parallel execution
     Parallel, // #[#[cmd1] #[cmd2] ...] parallel - run blocks in parallel, wait for all
-    Fork,     // #[cmd1] #[cmd2] ... fork - background multiple blocks
+    Fork, // #[cmd1] #[cmd2] ... fork - background multiple blocks
 
     /// Process substitution
     Subst, // #[cmd] subst - run cmd, push temp file path (like <(cmd))
-    Fifo,  // #[cmd] fifo - run cmd, push named pipe path (faster than subst)
+    Fifo, // #[cmd] fifo - run cmd, push named pipe path (faster than subst)
 
     /// JSON / Structured data
-    Json,   // Parse JSON string to structured data
+    Json, // Parse JSON string to structured data
     Unjson, // Convert structured data to JSON string
 
     /// Resource limits
@@ -538,8 +607,14 @@ mod tests {
 
     #[test]
     fn test_value_as_arg() {
-        assert_eq!(Value::Literal("hello".into()).as_arg(), Some("hello".into()));
-        assert_eq!(Value::Output("world\n".into()).as_arg(), Some("world".into()));
+        assert_eq!(
+            Value::Literal("hello".into()).as_arg(),
+            Some("hello".into())
+        );
+        assert_eq!(
+            Value::Output("world\n".into()).as_arg(),
+            Some("world".into())
+        );
         assert_eq!(Value::Nil.as_arg(), None);
         assert_eq!(Value::Output("".into()).as_arg(), None);
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -255,6 +255,30 @@ impl PartialEq for Value {
 }
 
 impl Value {
+    /// Human-readable hsab-level type name (issue #33).
+    ///
+    /// Used for user-facing error messages (`TypeError.got`) and `typeof`,
+    /// instead of leaking the Rust `{:?}` Debug representation.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Value::Literal(_) | Value::Output(_) => "string",
+            Value::Number(_) => "number",
+            Value::Bool(_) => "boolean",
+            Value::List(_) => "list",
+            Value::Map(_) => "record",
+            Value::Table { .. } => "table",
+            Value::Block(_) => "block",
+            Value::Nil => "nil",
+            Value::Marker => "marker",
+            Value::Error { .. } => "error",
+            Value::Media { .. } => "media",
+            Value::Link { .. } => "link",
+            Value::Bytes(_) => "bytes",
+            Value::BigInt(_) => "bigint",
+            Value::Future { .. } => "future",
+        }
+    }
+
     /// Convert value to string for use as command argument
     pub fn as_arg(&self) -> Option<String> {
         match self {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,6 +9,7 @@
 use indexmap::IndexMap;
 use serde_json::Value as JsonValue;
 use num_bigint::BigUint;
+use crate::util::lock_or_recover;
 
 /// Convert a Value to a JSON value for serialization
 pub fn value_to_json(v: &Value) -> JsonValue {
@@ -103,7 +104,7 @@ pub fn value_to_json(v: &Value) -> JsonValue {
             let mut obj = serde_json::Map::new();
             obj.insert("type".into(), JsonValue::String("future".into()));
             obj.insert("id".into(), JsonValue::String(id.clone()));
-            let status = match &*state.lock().unwrap() {
+            let status = match &*lock_or_recover(&state) {
                 FutureState::Pending => "pending",
                 FutureState::Completed(_) => "completed",
                 FutureState::Failed(_) => "failed",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
-use hsab::Evaluator;
-use crate::rcfile::{load_hsabrc, load_hsab_profile, load_stdlib, dirs_home, STDLIB_CONTENT};
+use crate::rcfile::{dirs_home, load_hsab_profile, load_hsabrc, load_stdlib, STDLIB_CONTENT};
 use crate::terminal::execute_line;
+use hsab::Evaluator;
 use std::fs;
 use std::process::ExitCode;
 
@@ -447,8 +447,9 @@ pub(crate) fn execute_script(path: &str, trace: bool) -> ExitCode {
     for (line_num, line) in content.lines().enumerate() {
         let trimmed = line.trim();
 
-        // Skip empty lines and comments
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Skip empty lines and comments. `#[` starts a block, not a comment
+        // (previously such lines were silently skipped; issue #34).
+        if trimmed.is_empty() || (trimmed.starts_with('#') && !trimmed.starts_with("#[")) {
             continue;
         }
 
@@ -459,8 +460,11 @@ pub(crate) fn execute_script(path: &str, trace: bool) -> ExitCode {
                 eval.clear_stack();
 
                 if exit_code != 0 {
-                    eprintln!("Error at line {}: command failed with exit code {}",
-                             line_num + 1, exit_code);
+                    eprintln!(
+                        "Error at line {}: command failed with exit code {}",
+                        line_num + 1,
+                        exit_code
+                    );
                     return ExitCode::FAILURE;
                 }
             }

--- a/src/display.rs
+++ b/src/display.rs
@@ -13,7 +13,7 @@
 //! Protocol detection is automatic based on TERM_PROGRAM and capability queries.
 
 use crate::ast::Value;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::sync::OnceLock;
 
 /// Terminal graphics protocol supported by the current terminal
@@ -347,7 +347,7 @@ fn format_table(columns: &[String], rows: &[Vec<Value>], max_width: usize) -> St
 }
 
 /// Format a record (map) with aligned key-value pairs
-fn format_record(map: &HashMap<String, Value>, _max_width: usize) -> String {
+fn format_record(map: &IndexMap<String, Value>, _max_width: usize) -> String {
     if map.is_empty() {
         return "{}".to_string();
     }
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_format_value_map() {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("key".to_string(), Value::Literal("value".to_string()));
         let result = format_value(&Value::Map(map), 80);
         assert!(result.contains("key"));
@@ -738,13 +738,13 @@ mod tests {
 
     #[test]
     fn test_format_empty_record() {
-        let result = format_record(&HashMap::new(), 80);
+        let result = format_record(&IndexMap::new(), 80);
         assert_eq!(result, "{}");
     }
 
     #[test]
     fn test_format_simple_record() {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("name".to_string(), Value::Literal("hsab".to_string()));
         map.insert("version".to_string(), Value::Literal("0.2".to_string()));
         let result = format_record(&map, 80);
@@ -865,7 +865,7 @@ mod tests {
 
     #[test]
     fn test_format_value_inline_map() {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("key".to_string(), Value::Literal("value".to_string()));
         let result = format_value_inline(&Value::Map(map));
         assert!(result.contains("{...}"));
@@ -980,7 +980,7 @@ mod tests {
 
     #[test]
     fn test_format_value_hint_map() {
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("a".to_string(), Value::Number(1.0));
         map.insert("b".to_string(), Value::Number(2.0));
         let result = format_value_hint(&Value::Map(map));

--- a/src/display.rs
+++ b/src/display.rs
@@ -15,6 +15,7 @@
 use crate::ast::Value;
 use indexmap::IndexMap;
 use std::sync::OnceLock;
+use crate::util::lock_or_recover;
 
 /// Terminal graphics protocol supported by the current terminal
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -548,7 +549,7 @@ fn format_value_compact(val: &Value, mode: CompactMode) -> String {
         }
         Value::Future { id, state } => {
             use crate::ast::FutureState;
-            let guard = state.lock().unwrap();
+            let guard = lock_or_recover(&state);
             let status = match &*guard {
                 FutureState::Pending => "pending",
                 FutureState::Completed(_) => "completed",

--- a/src/display.rs
+++ b/src/display.rs
@@ -13,9 +13,9 @@
 //! Protocol detection is automatic based on TERM_PROGRAM and capability queries.
 
 use crate::ast::Value;
+use crate::util::lock_or_recover;
 use indexmap::IndexMap;
 use std::sync::OnceLock;
-use crate::util::lock_or_recover;
 
 /// Terminal graphics protocol supported by the current terminal
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -74,13 +74,31 @@ pub fn format_value(val: &Value, max_width: usize) -> String {
         Value::Table { columns, rows } => format_table(columns, rows, max_width),
         Value::Map(map) => format_record(map, max_width),
         Value::List(items) => format_list(items, max_width),
-        Value::Error { kind, message, code, .. } => {
+        Value::Error {
+            kind,
+            message,
+            code,
+            ..
+        } => {
             let code_str = code.map(|c| format!(" (exit {})", c)).unwrap_or_default();
             format!("\x1b[31mError[{}]\x1b[0m: {}{}", kind, message, code_str)
         }
-        Value::Media { mime_type, data, width, height, alt, source } => {
-            format_media(mime_type, data, *width, *height, alt.as_deref(), source.as_deref(), max_width)
-        }
+        Value::Media {
+            mime_type,
+            data,
+            width,
+            height,
+            alt,
+            source,
+        } => format_media(
+            mime_type,
+            data,
+            *width,
+            *height,
+            alt.as_deref(),
+            source.as_deref(),
+            max_width,
+        ),
         Value::Link { url, text } => format_link(url, text.as_deref()),
         Value::Bytes(data) => format_bytes(data, max_width),
         _ => val.as_arg().unwrap_or_default(),
@@ -91,7 +109,11 @@ pub fn format_value(val: &Value, max_width: usize) -> String {
 /// Shows: [Bytes: 32B abc123...] with hex preview
 fn format_bytes(data: &[u8], max_width: usize) -> String {
     let size = data.len();
-    let size_str = if size == 1 { "1B".to_string() } else { format!("{}B", size) };
+    let size_str = if size == 1 {
+        "1B".to_string()
+    } else {
+        format!("{}B", size)
+    };
 
     // Calculate space for hex preview
     let prefix = format!("[Bytes: {} ", size_str);
@@ -138,15 +160,19 @@ fn format_media(
     match protocol {
         GraphicsProtocol::ITerm2 => format_media_iterm2(data, width, height),
         GraphicsProtocol::Kitty => format_media_kitty(data, mime_type),
-        GraphicsProtocol::Sixel => format_media_placeholder(mime_type, data, width, height, alt, source, "sixel"),
-        GraphicsProtocol::None => format_media_placeholder(mime_type, data, width, height, alt, source, "none"),
+        GraphicsProtocol::Sixel => {
+            format_media_placeholder(mime_type, data, width, height, alt, source, "sixel")
+        }
+        GraphicsProtocol::None => {
+            format_media_placeholder(mime_type, data, width, height, alt, source, "none")
+        }
     }
 }
 
 /// Format media using iTerm2 inline image protocol
 /// Protocol: ESC ] 1337 ; File = [args] : base64data BEL
 fn format_media_iterm2(data: &[u8], width: Option<u32>, height: Option<u32>) -> String {
-    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
     let mut args = vec!["inline=1".to_string()];
 
@@ -156,12 +182,12 @@ fn format_media_iterm2(data: &[u8], width: Option<u32>, height: Option<u32>) -> 
     // Optional dimensions (in cells or pixels with px suffix)
     if let Some(w) = width {
         // Scale down for terminal display (assume ~10px per cell width)
-        let cells = (w / 10).max(10).min(80);
+        let cells = (w / 10).clamp(10, 80);
         args.push(format!("width={}", cells));
     }
     if let Some(h) = height {
         // Scale down for terminal display (assume ~20px per cell height)
-        let cells = (h / 20).max(5).min(40);
+        let cells = (h / 20).clamp(5, 40);
         args.push(format!("height={}", cells));
     }
 
@@ -178,14 +204,12 @@ fn format_media_iterm2(data: &[u8], width: Option<u32>, height: Option<u32>) -> 
 /// Format media using Kitty graphics protocol
 /// Protocol: ESC _ G a=T,f=100,... ; base64data ESC \
 fn format_media_kitty(data: &[u8], mime_type: &str) -> String {
-    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
 
-    // Kitty format codes: 100=PNG, 24=RGB, 32=RGBA
-    let format = if mime_type.contains("png") {
-        "100" // PNG
-    } else {
-        "100" // Default to PNG format (Kitty can auto-detect)
-    };
+    // Kitty format codes: 100=PNG, 24=RGB, 32=RGBA.
+    // We always send 100 (PNG); Kitty auto-detects other formats.
+    let _ = mime_type;
+    let format = "100";
 
     let b64_data = STANDARD.encode(data);
 
@@ -197,7 +221,8 @@ fn format_media_kitty(data: &[u8], mime_type: &str) -> String {
     } else {
         // Multi-chunk transmission
         let mut output = String::new();
-        let chunks: Vec<&str> = b64_data.as_bytes()
+        let chunks: Vec<&str> = b64_data
+            .as_bytes()
             .chunks(4096)
             .map(|c| std::str::from_utf8(c).unwrap_or(""))
             .collect();
@@ -305,7 +330,11 @@ fn format_table(columns: &[String], rows: &[Vec<Value>], max_width: usize) -> St
     for (i, col) in columns.iter().enumerate() {
         let w = widths.get(i).copied().unwrap_or(10);
         let truncated = truncate_str(col, w);
-        out.push_str(&format!(" \x1b[1m{:width$}\x1b[0m \x1b[90m│\x1b[0m", truncated, width = w));
+        out.push_str(&format!(
+            " \x1b[1m{:width$}\x1b[0m \x1b[90m│\x1b[0m",
+            truncated,
+            width = w
+        ));
     }
     out.push('\n');
 
@@ -326,7 +355,11 @@ fn format_table(columns: &[String], rows: &[Vec<Value>], max_width: usize) -> St
             let w = widths.get(i).copied().unwrap_or(10);
             let s = val.as_arg().unwrap_or_default();
             let truncated = truncate_str(&s, w);
-            out.push_str(&format!(" {:width$} \x1b[90m│\x1b[0m", truncated, width = w));
+            out.push_str(&format!(
+                " {:width$} \x1b[90m│\x1b[0m",
+                truncated,
+                width = w
+            ));
         }
         out.push('\n');
     }
@@ -379,14 +412,10 @@ fn format_list(items: &[Value], _max_width: usize) -> String {
     }
 
     if items.len() <= 10 {
-        let parts: Vec<String> = items.iter()
-            .map(format_value_inline)
-            .collect();
+        let parts: Vec<String> = items.iter().map(format_value_inline).collect();
         format!("\x1b[90m[\x1b[0m{}...\x1b[90m]\x1b[0m", parts.join(", "))
     } else {
-        let first: Vec<String> = items.iter().take(5)
-            .map(format_value_inline)
-            .collect();
+        let first: Vec<String> = items.iter().take(5).map(format_value_inline).collect();
         format!(
             "\x1b[90m[\x1b[0m{}, \x1b[90m... ({} more)]\x1b[0m",
             first.join(", "),
@@ -492,7 +521,13 @@ fn format_value_compact(val: &Value, mode: CompactMode) -> String {
             CompactMode::Inline => color(mode, "31", &format!("Error: {}", message)),
             CompactMode::Hint => "err".to_string(),
         },
-        Value::Media { mime_type, data, width, height, .. } => {
+        Value::Media {
+            mime_type,
+            data,
+            width,
+            height,
+            ..
+        } => {
             let size_kb = data.len() as f64 / 1024.0;
             match mode {
                 CompactMode::Inline => {
@@ -500,8 +535,16 @@ fn format_value_compact(val: &Value, mode: CompactMode) -> String {
                         (Some(w), Some(h)) => format!(" {}x{}", w, h),
                         _ => String::new(),
                     };
-                    color(mode, "36", &format!("<img:{}{} {:.1}KB>",
-                        mime_type.split('/').last().unwrap_or("?"), dims, size_kb))
+                    color(
+                        mode,
+                        "36",
+                        &format!(
+                            "<img:{}{} {:.1}KB>",
+                            mime_type.split('/').next_back().unwrap_or("?"),
+                            dims,
+                            size_kb
+                        ),
+                    )
                 }
                 CompactMode::Hint => format!("<img:{:.0}K>", size_kb),
             }
@@ -521,7 +564,11 @@ fn format_value_compact(val: &Value, mode: CompactMode) -> String {
             CompactMode::Inline => {
                 let hex = hex::encode(data);
                 if hex.len() > 16 {
-                    color(mode, "36", &format!("<bytes:{}B {}...>", data.len(), &hex[..12]))
+                    color(
+                        mode,
+                        "36",
+                        &format!("<bytes:{}B {}...>", data.len(), &hex[..12]),
+                    )
                 } else {
                     color(mode, "36", &format!("<bytes:{}B {}>", data.len(), hex))
                 }
@@ -549,7 +596,7 @@ fn format_value_compact(val: &Value, mode: CompactMode) -> String {
         }
         Value::Future { id, state } => {
             use crate::ast::FutureState;
-            let guard = lock_or_recover(&state);
+            let guard = lock_or_recover(state);
             let status = match &*guard {
                 FutureState::Pending => "pending",
                 FutureState::Completed(_) => "completed",
@@ -704,13 +751,11 @@ mod tests {
             "very_long_column_name_two".to_string(),
             "very_long_column_name_three".to_string(),
         ];
-        let rows = vec![
-            vec![
-                Value::Literal("some_long_value_here".to_string()),
-                Value::Literal("another_long_value".to_string()),
-                Value::Literal("third_long_value".to_string()),
-            ],
-        ];
+        let rows = vec![vec![
+            Value::Literal("some_long_value_here".to_string()),
+            Value::Literal("another_long_value".to_string()),
+            Value::Literal("third_long_value".to_string()),
+        ]];
         // Set max_width to trigger scaling
         let result = format_table(&columns, &rows, 50);
         // Should still contain truncated content
@@ -724,9 +769,10 @@ mod tests {
     fn test_format_table_very_narrow_width() {
         // Test with very narrow max_width to force aggressive scaling
         let columns = vec!["col1".to_string(), "col2".to_string()];
-        let rows = vec![
-            vec![Value::Literal("value1".to_string()), Value::Literal("value2".to_string())],
-        ];
+        let rows = vec![vec![
+            Value::Literal("value1".to_string()),
+            Value::Literal("value2".to_string()),
+        ]];
         let result = format_table(&columns, &rows, 20);
         // Table should still render with truncation
         assert!(result.contains("┌"));
@@ -766,11 +812,7 @@ mod tests {
     #[test]
     fn test_format_list_small() {
         // Small list (<=10 items) shows all items with "..."
-        let items = vec![
-            Value::Number(1.0),
-            Value::Number(2.0),
-            Value::Number(3.0),
-        ];
+        let items = vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)];
         let result = format_list(&items, 80);
         assert!(result.contains("["));
         assert!(result.contains("]"));
@@ -841,8 +883,8 @@ mod tests {
 
     #[test]
     fn test_format_value_inline_number_float() {
-        let result = format_value_inline(&Value::Number(3.14159));
-        assert!(result.contains("3.14"));
+        let result = format_value_inline(&Value::Number(6.28125));
+        assert!(result.contains("6.28"));
     }
 
     #[test]
@@ -859,7 +901,11 @@ mod tests {
 
     #[test]
     fn test_format_value_inline_list() {
-        let list = Value::List(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+        let list = Value::List(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+        ]);
         let result = format_value_inline(&list);
         assert!(result.contains("[...3]"));
     }
@@ -952,8 +998,8 @@ mod tests {
 
     #[test]
     fn test_format_value_hint_number_float() {
-        let result = format_value_hint(&Value::Number(3.14159));
-        assert_eq!(result, "3.14");
+        let result = format_value_hint(&Value::Number(6.28125));
+        assert_eq!(result, "6.28");
     }
 
     #[test]

--- a/src/eval/aggregation.rs
+++ b/src/eval/aggregation.rs
@@ -1,6 +1,5 @@
 use super::{Evaluator, EvalError};
 use crate::ast::Value;
-use std::collections::HashMap;
 
 impl Evaluator {
     pub(crate) fn builtin_sum(&mut self) -> Result<(), EvalError> {
@@ -241,7 +240,7 @@ impl Evaluator {
                         format!("group-by: column '{}' not found", col)
                     ))?;
 
-                let mut groups: HashMap<String, Vec<Vec<Value>>> = HashMap::new();
+                let mut groups: indexmap::IndexMap<String, Vec<Vec<Value>>> = indexmap::IndexMap::new();
 
                 for row in rows {
                     let key = row.get(col_idx)
@@ -251,7 +250,7 @@ impl Evaluator {
                 }
 
                 // Convert groups to Record of Tables
-                let map: HashMap<String, Value> = groups.into_iter()
+                let map: indexmap::IndexMap<String, Value> = groups.into_iter()
                     .map(|(k, rows)| {
                         (k, Value::Table { columns: columns.clone(), rows })
                     })
@@ -405,7 +404,7 @@ impl Evaluator {
         let mut kept_rows = Vec::new();
         for row in rows {
             // Create a record for this row
-            let record: std::collections::HashMap<String, Value> = columns.iter()
+            let record: indexmap::IndexMap<String, Value> = columns.iter()
                 .zip(row.iter())
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();

--- a/src/eval/aggregation.rs
+++ b/src/eval/aggregation.rs
@@ -16,7 +16,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         };
 
@@ -40,7 +40,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         };
 
@@ -64,7 +64,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         };
 
@@ -91,7 +91,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         };
 
@@ -135,7 +135,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list),
+                got: list.type_name().to_string(),
             }),
         };
 
@@ -260,7 +260,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         }
 
@@ -364,7 +364,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list),
+                got: list.type_name().to_string(),
             }),
         };
 
@@ -397,7 +397,7 @@ impl Evaluator {
             Value::Table { columns, rows } => (columns, rows),
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         };
 
@@ -441,7 +441,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         };
 

--- a/src/eval/aggregation.rs
+++ b/src/eval/aggregation.rs
@@ -1,23 +1,28 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
     pub(crate) fn builtin_sum(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("sum requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("sum requires a list".into()))?;
 
         let total: f64 = match val {
-            Value::List(items) => {
-                items.iter().filter_map(|v| match v {
+            Value::List(items) => items
+                .iter()
+                .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
-                }).sum()
+                })
+                .sum(),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: val.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: val.type_name().to_string(),
-            }),
         };
 
         self.stack.push(Value::Number(total));
@@ -26,22 +31,29 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_avg(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("avg requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("avg requires a list".into()))?;
 
         let (total, count) = match val {
             Value::List(items) => {
-                let nums: Vec<f64> = items.iter().filter_map(|v| match v {
-                    Value::Number(n) => Some(*n),
-                    Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
-                    _ => None,
-                }).collect();
+                let nums: Vec<f64> = items
+                    .iter()
+                    .filter_map(|v| match v {
+                        Value::Number(n) => Some(*n),
+                        Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
+                        _ => None,
+                    })
+                    .collect();
                 (nums.iter().sum::<f64>(), nums.len())
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: val.type_name().to_string(),
+                })
+            }
         };
 
         let avg = if count > 0 { total / count as f64 } else { 0.0 };
@@ -51,21 +63,26 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_min(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("min requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("min requires a list".into()))?;
 
         let result = match val {
-            Value::List(items) => {
-                items.iter().filter_map(|v| match v {
+            Value::List(items) => items
+                .iter()
+                .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
-                }).fold(f64::INFINITY, f64::min)
+                })
+                .fold(f64::INFINITY, f64::min),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: val.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: val.type_name().to_string(),
-            }),
         };
 
         if result.is_infinite() {
@@ -78,21 +95,26 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_max(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("max requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("max requires a list".into()))?;
 
         let result = match val {
-            Value::List(items) => {
-                items.iter().filter_map(|v| match v {
+            Value::List(items) => items
+                .iter()
+                .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
-                }).fold(f64::NEG_INFINITY, f64::max)
+                })
+                .fold(f64::NEG_INFINITY, f64::max),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: val.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: val.type_name().to_string(),
-            }),
         };
 
         if result.is_infinite() {
@@ -105,8 +127,10 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_count(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("count requires a value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("count requires a value".into()))?;
 
         let n = match &val {
             Value::List(items) => items.len(),
@@ -126,17 +150,23 @@ impl Evaluator {
     /// The block receives (accumulator, current-item) and should return new accumulator
     pub(crate) fn builtin_reduce(&mut self) -> Result<(), EvalError> {
         let block = self.pop_block()?;
-        let init = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("reduce requires initial value".into()))?;
-        let list = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("reduce requires list".into()))?;
+        let init = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("reduce requires initial value".into()))?;
+        let list = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("reduce requires list".into()))?;
 
         let items = match list {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list.type_name().to_string(),
+                })
+            }
         };
 
         let mut acc = init;
@@ -149,8 +179,9 @@ impl Evaluator {
                 self.eval_expr(expr)?;
             }
             // Pop the result as new accumulator
-            acc = self.stack.pop().ok_or_else(||
-                EvalError::StackUnderflow("reduce block must return a value".into()))?;
+            acc = self.stack.pop().ok_or_else(|| {
+                EvalError::StackUnderflow("reduce block must return a value".into())
+            })?;
         }
 
         self.stack.push(acc);
@@ -171,8 +202,10 @@ impl Evaluator {
     pub(crate) fn builtin_bend(&mut self) -> Result<(), EvalError> {
         let step_block = self.pop_block()?;
         let pred_block = self.pop_block()?;
-        let seed = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("bend requires seed value".into()))?;
+        let seed = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("bend requires seed value".into()))?;
 
         let mut current = seed;
         let mut collected: Vec<Value> = Vec::new();
@@ -183,9 +216,10 @@ impl Evaluator {
 
         loop {
             if iterations >= max_iterations {
-                return Err(EvalError::ExecError(
-                    format!("bend: exceeded {} iterations (possible infinite loop)", max_iterations)
-                ));
+                return Err(EvalError::ExecError(format!(
+                    "bend: exceeded {} iterations (possible infinite loop)",
+                    max_iterations
+                )));
             }
             iterations += 1;
 
@@ -219,8 +253,9 @@ impl Evaluator {
             }
 
             // Pop the result as next seed
-            current = self.stack.pop().ok_or_else(||
-                EvalError::StackUnderflow("bend step block must return a value".into()))?;
+            current = self.stack.pop().ok_or_else(|| {
+                EvalError::StackUnderflow("bend step block must return a value".into())
+            })?;
         }
 
         self.stack.push(Value::List(collected));
@@ -230,38 +265,50 @@ impl Evaluator {
 
     pub(crate) fn builtin_group_by(&mut self) -> Result<(), EvalError> {
         let col = self.pop_string()?;
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("group-by requires a table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("group-by requires a table".into()))?;
 
         match table {
             Value::Table { columns, rows } => {
-                let col_idx = columns.iter().position(|c| c == &col)
-                    .ok_or_else(|| EvalError::ExecError(
-                        format!("group-by: column '{}' not found", col)
-                    ))?;
+                let col_idx = columns.iter().position(|c| c == &col).ok_or_else(|| {
+                    EvalError::ExecError(format!("group-by: column '{}' not found", col))
+                })?;
 
-                let mut groups: indexmap::IndexMap<String, Vec<Vec<Value>>> = indexmap::IndexMap::new();
+                let mut groups: indexmap::IndexMap<String, Vec<Vec<Value>>> =
+                    indexmap::IndexMap::new();
 
                 for row in rows {
-                    let key = row.get(col_idx)
+                    let key = row
+                        .get(col_idx)
                         .and_then(|v| v.as_arg())
                         .unwrap_or_default();
                     groups.entry(key).or_default().push(row);
                 }
 
                 // Convert groups to Record of Tables
-                let map: indexmap::IndexMap<String, Value> = groups.into_iter()
+                let map: indexmap::IndexMap<String, Value> = groups
+                    .into_iter()
                     .map(|(k, rows)| {
-                        (k, Value::Table { columns: columns.clone(), rows })
+                        (
+                            k,
+                            Value::Table {
+                                columns: columns.clone(),
+                                rows,
+                            },
+                        )
                     })
                     .collect();
 
                 self.stack.push(Value::Map(map));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -271,13 +318,16 @@ impl Evaluator {
     pub(crate) fn builtin_unique(&mut self) -> Result<(), EvalError> {
         use std::collections::HashSet;
 
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("unique requires a value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("unique requires a value".into()))?;
 
         match val {
             Value::List(items) => {
                 let mut seen = HashSet::new();
-                let unique: Vec<Value> = items.into_iter()
+                let unique: Vec<Value> = items
+                    .into_iter()
                     .filter(|v| {
                         let key = v.as_arg().unwrap_or_default();
                         seen.insert(key)
@@ -287,16 +337,21 @@ impl Evaluator {
             }
             Value::Table { columns, rows } => {
                 let mut seen = HashSet::new();
-                let unique: Vec<Vec<Value>> = rows.into_iter()
+                let unique: Vec<Vec<Value>> = rows
+                    .into_iter()
                     .filter(|row| {
-                        let key: String = row.iter()
+                        let key: String = row
+                            .iter()
                             .filter_map(|v| v.as_arg())
                             .collect::<Vec<_>>()
                             .join("\t");
                         seen.insert(key)
                     })
                     .collect();
-                self.stack.push(Value::Table { columns, rows: unique });
+                self.stack.push(Value::Table {
+                    columns,
+                    rows: unique,
+                });
             }
             _ => self.stack.push(val),
         }
@@ -306,8 +361,10 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_reverse(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("reverse requires a value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("reverse requires a value".into()))?;
 
         match val {
             Value::List(mut items) => {
@@ -332,8 +389,10 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_flatten(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("flatten requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("flatten requires a list".into()))?;
 
         match val {
             Value::List(items) => {
@@ -357,15 +416,19 @@ impl Evaluator {
     /// list #[predicate] reject -> filtered list (items where predicate is false)
     pub(crate) fn builtin_reject(&mut self) -> Result<(), EvalError> {
         let block = self.pop_block()?;
-        let list = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("reject requires list".into()))?;
+        let list = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("reject requires list".into()))?;
 
         let items = match list {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list.type_name().to_string(),
+                })
+            }
         };
 
         let mut kept = Vec::new();
@@ -390,21 +453,26 @@ impl Evaluator {
     /// table #[predicate] reject-where -> filtered table
     pub(crate) fn builtin_reject_where(&mut self) -> Result<(), EvalError> {
         let block = self.pop_block()?;
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("reject-where requires table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("reject-where requires table".into()))?;
 
         let (columns, rows) = match table {
             Value::Table { columns, rows } => (columns, rows),
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         };
 
         let mut kept_rows = Vec::new();
         for row in rows {
             // Create a record for this row
-            let record: indexmap::IndexMap<String, Value> = columns.iter()
+            let record: indexmap::IndexMap<String, Value> = columns
+                .iter()
                 .zip(row.iter())
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
@@ -426,7 +494,10 @@ impl Evaluator {
             }
         }
 
-        self.stack.push(Value::Table { columns, rows: kept_rows });
+        self.stack.push(Value::Table {
+            columns,
+            rows: kept_rows,
+        });
         self.last_exit_code = 0;
         Ok(())
     }
@@ -434,15 +505,19 @@ impl Evaluator {
     /// duplicates: Return only items that appear more than once (supplementary to unique)
     /// list duplicates -> list of duplicate items
     pub(crate) fn builtin_duplicates(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("duplicates requires list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("duplicates requires list".into()))?;
 
         let items = match val {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: val.type_name().to_string(),
+                })
+            }
         };
 
         // Count occurrences
@@ -454,7 +529,8 @@ impl Evaluator {
 
         // Keep only items that appear more than once
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let duplicates: Vec<Value> = items.into_iter()
+        let duplicates: Vec<Value> = items
+            .into_iter()
             .filter(|item| {
                 let key = item.as_arg().unwrap_or_default();
                 if counts.get(&key).copied().unwrap_or(0) > 1 && !seen.contains(&key) {

--- a/src/eval/async_ops.rs
+++ b/src/eval/async_ops.rs
@@ -47,7 +47,7 @@ impl Evaluator {
                 }
                 Err(e) => {
                     let mut guard = state_clone.lock().unwrap();
-                    *guard = FutureState::Failed(format!("{:?}", e));
+                    *guard = FutureState::Failed(e.to_string());
                 }
             }
         });
@@ -108,7 +108,7 @@ impl Evaluator {
             }
             _ => Err(EvalError::TypeError {
                 expected: "Future".into(),
-                got: format!("{:?}", future),
+                got: future.type_name().to_string(),
             }),
         }
     }
@@ -136,7 +136,7 @@ impl Evaluator {
             }
             _ => Err(EvalError::TypeError {
                 expected: "Future".into(),
-                got: format!("{:?}", future),
+                got: future.type_name().to_string(),
             }),
         }
     }
@@ -195,7 +195,7 @@ impl Evaluator {
             }
             _ => Err(EvalError::TypeError {
                 expected: "Future".into(),
-                got: format!("{:?}", future),
+                got: future.type_name().to_string(),
             }),
         }
     }
@@ -224,7 +224,7 @@ impl Evaluator {
             }
             _ => Err(EvalError::TypeError {
                 expected: "Future".into(),
-                got: format!("{:?}", future),
+                got: future.type_name().to_string(),
             }),
         }
     }
@@ -301,7 +301,7 @@ impl Evaluator {
             })?,
             _ => return Err(EvalError::TypeError {
                 expected: "integer".into(),
-                got: format!("{:?}", n_val),
+                got: n_val.type_name().to_string(),
             }),
         };
 
@@ -327,7 +327,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "list of blocks".into(),
-                got: format!("{:?}", blocks_val),
+                got: blocks_val.type_name().to_string(),
             }),
         };
 
@@ -361,7 +361,7 @@ impl Evaluator {
                         Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
                         Err(e) => Value::Error {
                             kind: "EvalError".into(),
-                            message: format!("{:?}", e),
+                            message: e.to_string(),
                             code: None,
                             source: None,
                             command: None,
@@ -404,7 +404,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list),
+                got: list.type_name().to_string(),
             }),
         };
 
@@ -440,7 +440,7 @@ impl Evaluator {
                         Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
                         Err(e) => Value::Error {
                             kind: "EvalError".into(),
-                            message: format!("{:?}", e),
+                            message: e.to_string(),
                             code: None,
                             source: None,
                             command: None,
@@ -489,7 +489,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "list of blocks".into(),
-                got: format!("{:?}", blocks_val),
+                got: blocks_val.type_name().to_string(),
             }),
         };
 
@@ -523,7 +523,7 @@ impl Evaluator {
                     Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
                     Err(e) => Value::Error {
                         kind: "EvalError".into(),
-                        message: format!("{:?}", e),
+                        message: e.to_string(),
                         code: None,
                         source: None,
                         command: None,
@@ -568,7 +568,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "list".into(),
-                got: format!("{:?}", list),
+                got: list.type_name().to_string(),
             }),
         };
 
@@ -650,7 +650,7 @@ impl Evaluator {
             })?,
             _ => return Err(EvalError::TypeError {
                 expected: "integer".into(),
-                got: format!("{:?}", n_val),
+                got: n_val.type_name().to_string(),
             }),
         };
 
@@ -755,7 +755,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "list of futures".into(),
-                got: format!("{:?}", list),
+                got: list.type_name().to_string(),
             }),
         };
 
@@ -821,7 +821,7 @@ impl Evaluator {
             Value::Future { id, state } => (id, state),
             _ => return Err(EvalError::TypeError {
                 expected: "Future".into(),
-                got: format!("{:?}", future),
+                got: future.type_name().to_string(),
             }),
         };
 
@@ -878,7 +878,7 @@ impl Evaluator {
                         }
                         Err(e) => {
                             let mut guard = new_state_clone.lock().unwrap();
-                            *guard = FutureState::Failed(format!("{:?}", e));
+                            *guard = FutureState::Failed(e.to_string());
                         }
                     }
                 }

--- a/src/eval/async_ops.rs
+++ b/src/eval/async_ops.rs
@@ -3,12 +3,12 @@
 //! Provides futures, parallel execution with limits, and delays.
 //! Note: `timeout` is in process.rs, `retry` is in combinators.rs
 
-use super::{Evaluator, EvalError};
-use crate::ast::{Expr, Value, FutureState};
+use super::{EvalError, Evaluator};
+use crate::ast::{Expr, FutureState, Value};
+use crate::util::lock_or_recover;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use crate::util::lock_or_recover;
 
 impl Evaluator {
     // === Core Async Operations ===
@@ -67,8 +67,10 @@ impl Evaluator {
     /// await: Future await -> result
     /// Block until future completes and return the result
     pub(crate) fn builtin_await(&mut self) -> Result<(), EvalError> {
-        let future = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("await requires a Future".into()))?;
+        let future = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("await requires a Future".into()))?;
 
         match future {
             Value::Future { id, state } => {
@@ -118,12 +120,14 @@ impl Evaluator {
 
     /// future-status: Future future-status -> "pending" | "completed" | "failed" | "cancelled"
     pub(crate) fn builtin_future_status(&mut self) -> Result<(), EvalError> {
-        let future = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("future-status requires a Future".into()))?;
+        let future = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("future-status requires a Future".into()))?;
 
         match &future {
             Value::Future { state, .. } => {
-                let guard = lock_or_recover(&state);
+                let guard = lock_or_recover(state);
                 let status = match &*guard {
                     FutureState::Pending => "pending",
                     FutureState::Completed(_) => "completed",
@@ -147,8 +151,10 @@ impl Evaluator {
     /// future-result: Future future-result -> {ok: value} | {err: message}
     /// Non-throwing result access
     pub(crate) fn builtin_future_result(&mut self) -> Result<(), EvalError> {
-        let future = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("future-result requires a Future".into()))?;
+        let future = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("future-result requires a Future".into()))?;
 
         match future {
             Value::Future { id, state } => {
@@ -206,8 +212,10 @@ impl Evaluator {
     /// future-cancel: Future future-cancel -> ()
     /// Cancel a running future
     pub(crate) fn builtin_future_cancel(&mut self) -> Result<(), EvalError> {
-        let future = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("future-cancel requires a Future".into()))?;
+        let future = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("future-cancel requires a Future".into()))?;
 
         match future {
             Value::Future { id: _, state } => {
@@ -255,7 +263,9 @@ impl Evaluator {
     /// Return a Future that resolves after the delay
     pub(crate) fn builtin_delay_async(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.is_empty() {
-            return Err(EvalError::ExecError("delay-async requires milliseconds".into()));
+            return Err(EvalError::ExecError(
+                "delay-async requires milliseconds".into(),
+            ));
         }
 
         let ms: u64 = args[0].parse().map_err(|_| EvalError::TypeError {
@@ -292,10 +302,12 @@ impl Evaluator {
     /// parallel-n: #[#[blocks]] N parallel-n -> [results]
     /// Run blocks in parallel with concurrency limit
     pub(crate) fn builtin_parallel_n(&mut self) -> Result<(), EvalError> {
-        let n_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("parallel-n requires concurrency limit".into()))?;
-        let blocks_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("parallel-n requires list of blocks".into()))?;
+        let n_val = self.stack.pop().ok_or_else(|| {
+            EvalError::StackUnderflow("parallel-n requires concurrency limit".into())
+        })?;
+        let blocks_val = self.stack.pop().ok_or_else(|| {
+            EvalError::StackUnderflow("parallel-n requires list of blocks".into())
+        })?;
 
         let limit: usize = match n_val {
             Value::Number(n) => n as usize,
@@ -303,36 +315,42 @@ impl Evaluator {
                 expected: "integer".into(),
                 got: s,
             })?,
-            _ => return Err(EvalError::TypeError {
-                expected: "integer".into(),
-                got: n_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "integer".into(),
+                    got: n_val.type_name().to_string(),
+                })
+            }
         };
 
         let blocks: Vec<Vec<Expr>> = match blocks_val {
-            Value::List(items) => {
-                items.into_iter().filter_map(|v| {
+            Value::List(items) => items
+                .into_iter()
+                .filter_map(|v| {
                     if let Value::Block(exprs) = v {
                         Some(exprs)
                     } else {
                         None
                     }
-                }).collect()
-            }
+                })
+                .collect(),
             // Also handle a block containing blocks (e.g., #[#[a] #[b] #[c]])
-            Value::Block(exprs) => {
-                exprs.into_iter().filter_map(|e| {
+            Value::Block(exprs) => exprs
+                .into_iter()
+                .filter_map(|e| {
                     if let Expr::Block(inner) = e {
                         Some(inner)
                     } else {
                         None
                     }
-                }).collect()
+                })
+                .collect(),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list of blocks".into(),
+                    got: blocks_val.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "list of blocks".into(),
-                got: blocks_val.type_name().to_string(),
-            }),
         };
 
         if blocks.is_empty() {
@@ -349,30 +367,33 @@ impl Evaluator {
         let mut results = Vec::new();
 
         for chunk in blocks.chunks(limit) {
-            let handles: Vec<_> = chunk.iter().map(|block| {
-                let block = block.clone();
-                let cwd = cwd.clone();
-                let definitions = definitions.clone();
-                let locals = locals.clone();
+            let handles: Vec<_> = chunk
+                .iter()
+                .map(|block| {
+                    let block = block.clone();
+                    let cwd = cwd.clone();
+                    let definitions = definitions.clone();
+                    let locals = locals.clone();
 
-                thread::spawn(move || {
-                    let mut eval = Evaluator::new();
-                    eval.cwd = cwd;
-                    eval.definitions = definitions;
-                    eval.local_values = locals;
+                    thread::spawn(move || {
+                        let mut eval = Evaluator::new();
+                        eval.cwd = cwd;
+                        eval.definitions = definitions;
+                        eval.local_values = locals;
 
-                    match eval.eval_block(&block) {
-                        Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
-                        Err(e) => Value::Error {
-                            kind: "EvalError".into(),
-                            message: e.to_string(),
-                            code: None,
-                            source: None,
-                            command: None,
-                        },
-                    }
+                        match eval.eval_block(&block) {
+                            Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
+                            Err(e) => Value::Error {
+                                kind: "EvalError".into(),
+                                message: e.to_string(),
+                                code: None,
+                                source: None,
+                                command: None,
+                            },
+                        }
+                    })
                 })
-            }).collect();
+                .collect();
 
             // Wait for this batch
             for handle in handles {
@@ -394,8 +415,10 @@ impl Evaluator {
     pub(crate) fn builtin_parallel_map(&mut self) -> Result<(), EvalError> {
         let limit = self.pop_number("parallel-map")? as usize;
         let block = self.pop_block()?;
-        let list = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("parallel-map requires a list".into()))?;
+        let list = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("parallel-map requires a list".into()))?;
 
         let items = match list {
             Value::List(items) => items,
@@ -403,13 +426,14 @@ impl Evaluator {
                 // Evaluate the block to produce a list of values
                 let saved_stack = std::mem::take(&mut self.stack);
                 self.eval_block(&exprs)?;
-                let items = std::mem::replace(&mut self.stack, saved_stack);
-                items
+                std::mem::replace(&mut self.stack, saved_stack)
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list.type_name().to_string(),
+                })
+            }
         };
 
         if items.is_empty() || limit == 0 {
@@ -425,33 +449,36 @@ impl Evaluator {
         let mut results = Vec::with_capacity(items.len());
 
         for chunk in items.chunks(limit) {
-            let handles: Vec<_> = chunk.iter().map(|item| {
-                let item = item.clone();
-                let block = block.clone();
-                let cwd = cwd.clone();
-                let definitions = definitions.clone();
-                let locals = locals.clone();
+            let handles: Vec<_> = chunk
+                .iter()
+                .map(|item| {
+                    let item = item.clone();
+                    let block = block.clone();
+                    let cwd = cwd.clone();
+                    let definitions = definitions.clone();
+                    let locals = locals.clone();
 
-                thread::spawn(move || {
-                    let mut eval = Evaluator::new();
-                    eval.cwd = cwd;
-                    eval.definitions = definitions;
-                    eval.local_values = locals;
+                    thread::spawn(move || {
+                        let mut eval = Evaluator::new();
+                        eval.cwd = cwd;
+                        eval.definitions = definitions;
+                        eval.local_values = locals;
 
-                    // Push the item onto the stack, then run the block
-                    eval.stack.push(item);
-                    match eval.eval_block(&block) {
-                        Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
-                        Err(e) => Value::Error {
-                            kind: "EvalError".into(),
-                            message: e.to_string(),
-                            code: None,
-                            source: None,
-                            command: None,
-                        },
-                    }
+                        // Push the item onto the stack, then run the block
+                        eval.stack.push(item);
+                        match eval.eval_block(&block) {
+                            Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
+                            Err(e) => Value::Error {
+                                kind: "EvalError".into(),
+                                message: e.to_string(),
+                                code: None,
+                                source: None,
+                                command: None,
+                            },
+                        }
+                    })
                 })
-            }).collect();
+                .collect();
 
             for handle in handles {
                 results.push(handle.join().unwrap_or(Value::Nil));
@@ -468,33 +495,39 @@ impl Evaluator {
     /// race: #[#[blocks]] race -> result
     /// Run blocks in parallel, return first to complete
     pub(crate) fn builtin_race(&mut self) -> Result<(), EvalError> {
-        let blocks_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("race requires list of blocks".into()))?;
+        let blocks_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("race requires list of blocks".into()))?;
 
         let blocks: Vec<Vec<Expr>> = match blocks_val {
-            Value::List(items) => {
-                items.into_iter().filter_map(|v| {
+            Value::List(items) => items
+                .into_iter()
+                .filter_map(|v| {
                     if let Value::Block(exprs) = v {
                         Some(exprs)
                     } else {
                         None
                     }
-                }).collect()
-            }
+                })
+                .collect(),
             // Also handle a block containing blocks (e.g., #[#[a] #[b] #[c]])
-            Value::Block(exprs) => {
-                exprs.into_iter().filter_map(|e| {
+            Value::Block(exprs) => exprs
+                .into_iter()
+                .filter_map(|e| {
                     if let Expr::Block(inner) = e {
                         Some(inner)
                     } else {
                         None
                     }
-                }).collect()
+                })
+                .collect(),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list of blocks".into(),
+                    got: blocks_val.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "list of blocks".into(),
-                got: blocks_val.type_name().to_string(),
-            }),
         };
 
         if blocks.is_empty() {
@@ -510,37 +543,40 @@ impl Evaluator {
         // Shared result - first to complete wins
         let result: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
 
-        let handles: Vec<_> = blocks.iter().map(|block| {
-            let block = block.clone();
-            let cwd = cwd.clone();
-            let definitions = definitions.clone();
-            let locals = locals.clone();
-            let result = Arc::clone(&result);
+        let handles: Vec<_> = blocks
+            .iter()
+            .map(|block| {
+                let block = block.clone();
+                let cwd = cwd.clone();
+                let definitions = definitions.clone();
+                let locals = locals.clone();
+                let result = Arc::clone(&result);
 
-            thread::spawn(move || {
-                let mut eval = Evaluator::new();
-                eval.cwd = cwd;
-                eval.definitions = definitions;
-                eval.local_values = locals;
+                thread::spawn(move || {
+                    let mut eval = Evaluator::new();
+                    eval.cwd = cwd;
+                    eval.definitions = definitions;
+                    eval.local_values = locals;
 
-                let value = match eval.eval_block(&block) {
-                    Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
-                    Err(e) => Value::Error {
-                        kind: "EvalError".into(),
-                        message: e.to_string(),
-                        code: None,
-                        source: None,
-                        command: None,
-                    },
-                };
+                    let value = match eval.eval_block(&block) {
+                        Ok(_) => eval.stack.pop().unwrap_or(Value::Nil),
+                        Err(e) => Value::Error {
+                            kind: "EvalError".into(),
+                            message: e.to_string(),
+                            code: None,
+                            source: None,
+                            command: None,
+                        },
+                    };
 
-                // Try to be the first to set result
-                let mut guard = lock_or_recover(&result);
-                if guard.is_none() {
-                    *guard = Some(value);
-                }
+                    // Try to be the first to set result
+                    let mut guard = lock_or_recover(&result);
+                    if guard.is_none() {
+                        *guard = Some(value);
+                    }
+                })
             })
-        }).collect();
+            .collect();
 
         // Wait for any result
         loop {
@@ -565,15 +601,18 @@ impl Evaluator {
     /// await-all: [futures] await-all -> [results]
     /// Await all futures in a list
     pub(crate) fn builtin_await_all(&mut self) -> Result<(), EvalError> {
-        let list = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("await-all requires list of futures".into()))?;
+        let list = self.stack.pop().ok_or_else(|| {
+            EvalError::StackUnderflow("await-all requires list of futures".into())
+        })?;
 
         let futures: Vec<Value> = match list {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "list".into(),
-                got: list.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list".into(),
+                    got: list.type_name().to_string(),
+                })
+            }
         };
 
         let mut results = Vec::new();
@@ -643,19 +682,25 @@ impl Evaluator {
     /// future-await-n: future1 future2 ... futureN N future-await-n -> result1 result2 ... resultN
     /// Await N futures from the stack, push results back in order
     pub(crate) fn builtin_future_await_n(&mut self) -> Result<(), EvalError> {
-        let n_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("future-await-n requires count".into()))?;
+        let n_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("future-await-n requires count".into()))?;
 
         let n: usize = match n_val {
             Value::Number(num) => num as usize,
-            Value::Literal(s) | Value::Output(s) => s.parse().map_err(|_| EvalError::TypeError {
-                expected: "integer".into(),
-                got: s,
-            })?,
-            _ => return Err(EvalError::TypeError {
-                expected: "integer".into(),
-                got: n_val.type_name().to_string(),
-            }),
+            Value::Literal(s) | Value::Output(s) => {
+                s.parse().map_err(|_| EvalError::TypeError {
+                    expected: "integer".into(),
+                    got: s,
+                })?
+            }
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "integer".into(),
+                    got: n_val.type_name().to_string(),
+                })
+            }
         };
 
         if n == 0 {
@@ -665,8 +710,9 @@ impl Evaluator {
         // Collect N futures from stack (in LIFO order)
         let mut futures = Vec::with_capacity(n);
         for _ in 0..n {
-            let val = self.stack.pop().ok_or_else(||
-                EvalError::StackUnderflow(format!("future-await-n requires {} futures", n)))?;
+            let val = self.stack.pop().ok_or_else(|| {
+                EvalError::StackUnderflow(format!("future-await-n requires {} futures", n))
+            })?;
             futures.push(val);
         }
 
@@ -744,23 +790,27 @@ impl Evaluator {
     /// future-race: [futures] future-race -> result
     /// Return result of first future to complete
     pub(crate) fn builtin_future_race(&mut self) -> Result<(), EvalError> {
-        let list = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("future-race requires list of futures".into()))?;
+        let list = self.stack.pop().ok_or_else(|| {
+            EvalError::StackUnderflow("future-race requires list of futures".into())
+        })?;
 
         let futures: Vec<(String, Arc<Mutex<FutureState>>)> = match list {
-            Value::List(items) => {
-                items.into_iter().filter_map(|v| {
+            Value::List(items) => items
+                .into_iter()
+                .filter_map(|v| {
                     if let Value::Future { id, state } = v {
                         Some((id, state))
                     } else {
                         None
                     }
-                }).collect()
+                })
+                .collect(),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list of futures".into(),
+                    got: list.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "list of futures".into(),
-                got: list.type_name().to_string(),
-            }),
         };
 
         if futures.is_empty() {
@@ -772,7 +822,7 @@ impl Evaluator {
         // Poll all futures until one completes
         loop {
             for (id, state) in &futures {
-                let guard = lock_or_recover(&state);
+                let guard = lock_or_recover(state);
                 match &*guard {
                     FutureState::Pending => continue,
                     FutureState::Completed(value) => {
@@ -782,7 +832,7 @@ impl Evaluator {
                         // Cancel others
                         for (other_id, other_state) in &futures {
                             if other_id != id {
-                                let mut g = lock_or_recover(&other_state);
+                                let mut g = lock_or_recover(other_state);
                                 if matches!(*g, FutureState::Pending) {
                                     *g = FutureState::Cancelled;
                                 }
@@ -837,15 +887,19 @@ impl Evaluator {
     /// Transform result without awaiting - returns new Future that applies block to result
     pub(crate) fn builtin_future_map(&mut self) -> Result<(), EvalError> {
         let transform_block = self.pop_block()?;
-        let future = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("future-map requires a Future".into()))?;
+        let future = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("future-map requires a Future".into()))?;
 
         let (orig_id, orig_state) = match future {
             Value::Future { id, state } => (id, state),
-            _ => return Err(EvalError::TypeError {
-                expected: "Future".into(),
-                got: future.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Future".into(),
+                    got: future.type_name().to_string(),
+                })
+            }
         };
 
         // Generate new future ID
@@ -923,7 +977,10 @@ impl Evaluator {
             std::mem::drop(orig_handle);
         }
 
-        self.stack.push(Value::Future { id: new_id, state: new_state });
+        self.stack.push(Value::Future {
+            id: new_id,
+            state: new_state,
+        });
         self.last_exit_code = 0;
         Ok(())
     }

--- a/src/eval/async_ops.rs
+++ b/src/eval/async_ops.rs
@@ -55,6 +55,8 @@ impl Evaluator {
 
         // Store handle for potential cancellation
         self.future_handles.insert(id.clone(), handle);
+        // Register in the futures registry so futures-list can enumerate it
+        self.futures.insert(id.clone(), Arc::clone(&state));
 
         // Push Future value onto stack
         self.stack.push(Value::Future { id, state });
@@ -279,6 +281,7 @@ impl Evaluator {
         });
 
         self.future_handles.insert(id.clone(), handle);
+        self.futures.insert(id.clone(), Arc::clone(&state));
         self.stack.push(Value::Future { id, state });
         self.last_exit_code = 0;
         Ok(())
@@ -800,13 +803,32 @@ impl Evaluator {
         }
     }
 
-    /// futures-list: futures-list -> [info...]
-    /// List all pending futures
+    /// futures-list: futures-list -> [{id status}...]
+    /// List every future spawned by this evaluator (async, delay-async,
+    /// future-map), in spawn order, with its current status.
+    ///
+    /// Lifecycle policy: futures stay registered for the lifetime of the
+    /// evaluator, including after await/future-cancel; terminal entries
+    /// report completed/failed/cancelled rather than being removed.
     pub(crate) fn builtin_futures_list(&mut self) -> Result<(), EvalError> {
-        // Note: We don't track all futures centrally in a queryable way currently.
-        // This would require additional state. For now, return empty list.
-        // TODO: Implement proper futures registry
-        self.stack.push(Value::List(vec![]));
+        let records: Vec<Value> = self
+            .futures
+            .iter()
+            .map(|(id, state)| {
+                let status = match &*lock_or_recover(state) {
+                    FutureState::Pending => "pending",
+                    FutureState::Completed(_) => "completed",
+                    FutureState::Failed(_) => "failed",
+                    FutureState::Cancelled => "cancelled",
+                };
+                let mut record = indexmap::IndexMap::new();
+                record.insert("id".to_string(), Value::Literal(id.clone()));
+                record.insert("status".to_string(), Value::Literal(status.to_string()));
+                Value::Map(record)
+            })
+            .collect();
+
+        self.stack.push(Value::List(records));
         self.last_exit_code = 0;
         Ok(())
     }
@@ -893,6 +915,7 @@ impl Evaluator {
 
         // Store handle and push new Future
         self.future_handles.insert(new_id.clone(), handle);
+        self.futures.insert(new_id.clone(), Arc::clone(&new_state));
 
         // Clean up original future handle if we have it
         if let Some(orig_handle) = self.future_handles.remove(&orig_id) {

--- a/src/eval/async_ops.rs
+++ b/src/eval/async_ops.rs
@@ -8,6 +8,7 @@ use crate::ast::{Expr, Value, FutureState};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+use crate::util::lock_or_recover;
 
 impl Evaluator {
     // === Core Async Operations ===
@@ -42,11 +43,11 @@ impl Evaluator {
                 Ok(_) => {
                     // Get result from stack (top value or Nil)
                     let result = eval.stack.pop().unwrap_or(Value::Nil);
-                    let mut guard = state_clone.lock().unwrap();
+                    let mut guard = lock_or_recover(&state_clone);
                     *guard = FutureState::Completed(Box::new(result));
                 }
                 Err(e) => {
-                    let mut guard = state_clone.lock().unwrap();
+                    let mut guard = lock_or_recover(&state_clone);
                     *guard = FutureState::Failed(e.to_string());
                 }
             }
@@ -71,7 +72,7 @@ impl Evaluator {
             Value::Future { id, state } => {
                 // Wait for completion by polling
                 loop {
-                    let guard = state.lock().unwrap();
+                    let guard = lock_or_recover(&state);
                     match &*guard {
                         FutureState::Pending => {
                             drop(guard);
@@ -120,7 +121,7 @@ impl Evaluator {
 
         match &future {
             Value::Future { state, .. } => {
-                let guard = state.lock().unwrap();
+                let guard = lock_or_recover(&state);
                 let status = match &*guard {
                     FutureState::Pending => "pending",
                     FutureState::Completed(_) => "completed",
@@ -151,7 +152,7 @@ impl Evaluator {
             Value::Future { id, state } => {
                 // Wait for completion
                 loop {
-                    let guard = state.lock().unwrap();
+                    let guard = lock_or_recover(&state);
                     match &*guard {
                         FutureState::Pending => {
                             drop(guard);
@@ -209,7 +210,7 @@ impl Evaluator {
         match future {
             Value::Future { id: _, state } => {
                 // Mark as cancelled
-                let mut guard = state.lock().unwrap();
+                let mut guard = lock_or_recover(&state);
                 if matches!(*guard, FutureState::Pending) {
                     *guard = FutureState::Cancelled;
                 }
@@ -271,7 +272,7 @@ impl Evaluator {
         // Spawn thread that sleeps then completes
         let handle = thread::spawn(move || {
             thread::sleep(Duration::from_millis(ms));
-            let mut guard = state_clone.lock().unwrap();
+            let mut guard = lock_or_recover(&state_clone);
             if matches!(*guard, FutureState::Pending) {
                 *guard = FutureState::Completed(Box::new(Value::Nil));
             }
@@ -531,7 +532,7 @@ impl Evaluator {
                 };
 
                 // Try to be the first to set result
-                let mut guard = result.lock().unwrap();
+                let mut guard = lock_or_recover(&result);
                 if guard.is_none() {
                     *guard = Some(value);
                 }
@@ -540,7 +541,7 @@ impl Evaluator {
 
         // Wait for any result
         loop {
-            let guard = result.lock().unwrap();
+            let guard = lock_or_recover(&result);
             if let Some(value) = guard.clone() {
                 drop(guard);
                 self.stack.push(value);
@@ -579,7 +580,7 @@ impl Evaluator {
                 Value::Future { id, state } => {
                     // Wait for this future
                     loop {
-                        let guard = state.lock().unwrap();
+                        let guard = lock_or_recover(&state);
                         match &*guard {
                             FutureState::Pending => {
                                 drop(guard);
@@ -676,7 +677,7 @@ impl Evaluator {
                 Value::Future { id, state } => {
                     // Wait for this future
                     let result = loop {
-                        let guard = state.lock().unwrap();
+                        let guard = lock_or_recover(&state);
                         match &*guard {
                             FutureState::Pending => {
                                 drop(guard);
@@ -768,7 +769,7 @@ impl Evaluator {
         // Poll all futures until one completes
         loop {
             for (id, state) in &futures {
-                let guard = state.lock().unwrap();
+                let guard = lock_or_recover(&state);
                 match &*guard {
                     FutureState::Pending => continue,
                     FutureState::Completed(value) => {
@@ -778,7 +779,7 @@ impl Evaluator {
                         // Cancel others
                         for (other_id, other_state) in &futures {
                             if other_id != id {
-                                let mut g = other_state.lock().unwrap();
+                                let mut g = lock_or_recover(&other_state);
                                 if matches!(*g, FutureState::Pending) {
                                     *g = FutureState::Cancelled;
                                 }
@@ -842,7 +843,7 @@ impl Evaluator {
         let handle = thread::spawn(move || {
             // Wait for original future
             let original_result = loop {
-                let guard = orig_state.lock().unwrap();
+                let guard = lock_or_recover(&orig_state);
                 match &*guard {
                     FutureState::Pending => {
                         drop(guard);
@@ -873,18 +874,18 @@ impl Evaluator {
                     match eval.eval_block(&transform_block) {
                         Ok(_) => {
                             let result = eval.stack.pop().unwrap_or(Value::Nil);
-                            let mut guard = new_state_clone.lock().unwrap();
+                            let mut guard = lock_or_recover(&new_state_clone);
                             *guard = FutureState::Completed(Box::new(result));
                         }
                         Err(e) => {
-                            let mut guard = new_state_clone.lock().unwrap();
+                            let mut guard = lock_or_recover(&new_state_clone);
                             *guard = FutureState::Failed(e.to_string());
                         }
                     }
                 }
                 Err(msg) => {
                     // Propagate failure
-                    let mut guard = new_state_clone.lock().unwrap();
+                    let mut guard = lock_or_recover(&new_state_clone);
                     *guard = FutureState::Failed(msg);
                 }
             }

--- a/src/eval/async_ops.rs
+++ b/src/eval/async_ops.rs
@@ -5,7 +5,6 @@
 
 use super::{Evaluator, EvalError};
 use crate::ast::{Expr, Value, FutureState};
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -159,7 +158,7 @@ impl Evaluator {
                             thread::sleep(Duration::from_millis(10));
                         }
                         FutureState::Completed(value) => {
-                            let mut result = HashMap::new();
+                            let mut result = indexmap::IndexMap::new();
                             result.insert("ok".to_string(), (**value).clone());
                             self.stack.push(Value::Map(result));
                             self.last_exit_code = 0;
@@ -170,7 +169,7 @@ impl Evaluator {
                             return Ok(());
                         }
                         FutureState::Failed(msg) => {
-                            let mut result = HashMap::new();
+                            let mut result = indexmap::IndexMap::new();
                             result.insert("err".to_string(), Value::Literal(msg.clone()));
                             self.stack.push(Value::Map(result));
                             self.last_exit_code = 1;
@@ -181,7 +180,7 @@ impl Evaluator {
                             return Ok(());
                         }
                         FutureState::Cancelled => {
-                            let mut result = HashMap::new();
+                            let mut result = indexmap::IndexMap::new();
                             result.insert("err".to_string(), Value::Literal("cancelled".into()));
                             self.stack.push(Value::Map(result));
                             self.last_exit_code = 1;

--- a/src/eval/bigint.rs
+++ b/src/eval/bigint.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use num_bigint::BigUint;
 
@@ -18,7 +18,9 @@ impl Evaluator {
             Value::Number(n) => {
                 if *n < 0.0 {
                     self.stack.push(value);
-                    return Err(EvalError::ExecError("to-bigint: negative numbers not supported".to_string()));
+                    return Err(EvalError::ExecError(
+                        "to-bigint: negative numbers not supported".to_string(),
+                    ));
                 }
                 BigUint::from(*n as u64)
             }
@@ -30,19 +32,19 @@ impl Evaluator {
                 let s = s.trim();
                 if s.starts_with("0x") || s.starts_with("0X") {
                     // Parse as hex
-                    BigUint::parse_bytes(s[2..].as_bytes(), 16).ok_or_else(|| {
-                        EvalError::ExecError(format!("Invalid hex: {}", s))
-                    })?
+                    BigUint::parse_bytes(&s.as_bytes()[2..], 16)
+                        .ok_or_else(|| EvalError::ExecError(format!("Invalid hex: {}", s)))?
                 } else {
                     // Parse as decimal
-                    BigUint::parse_bytes(s.as_bytes(), 10).ok_or_else(|| {
-                        EvalError::ExecError(format!("Invalid decimal: {}", s))
-                    })?
+                    BigUint::parse_bytes(s.as_bytes(), 10)
+                        .ok_or_else(|| EvalError::ExecError(format!("Invalid decimal: {}", s)))?
                 }
             }
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("to-bigint requires number, string, or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "to-bigint requires number, string, or Bytes".to_string(),
+                ));
             }
         };
 
@@ -65,7 +67,9 @@ impl Evaluator {
         let b = self.pop_bigint("big-sub")?;
         let a = self.pop_bigint("big-sub")?;
         if a < b {
-            return Err(EvalError::ExecError("big-sub: result would be negative".to_string()));
+            return Err(EvalError::ExecError(
+                "big-sub: result would be negative".to_string(),
+            ));
         }
         self.stack.push(Value::BigInt(a - b));
         self.last_exit_code = 0;
@@ -85,7 +89,9 @@ impl Evaluator {
     pub(crate) fn builtin_big_div(&mut self) -> Result<(), EvalError> {
         let b = self.pop_bigint("big-div")?;
         if b == BigUint::ZERO {
-            return Err(EvalError::ExecError("big-div: division by zero".to_string()));
+            return Err(EvalError::ExecError(
+                "big-div: division by zero".to_string(),
+            ));
         }
         let a = self.pop_bigint("big-div")?;
         self.stack.push(Value::BigInt(a / b));
@@ -97,7 +103,9 @@ impl Evaluator {
     pub(crate) fn builtin_big_mod(&mut self) -> Result<(), EvalError> {
         let b = self.pop_bigint("big-mod")?;
         if b == BigUint::ZERO {
-            return Err(EvalError::ExecError("big-mod: division by zero".to_string()));
+            return Err(EvalError::ExecError(
+                "big-mod: division by zero".to_string(),
+            ));
         }
         let a = self.pop_bigint("big-mod")?;
         self.stack.push(Value::BigInt(a % b));
@@ -163,12 +171,14 @@ impl Evaluator {
         })?;
         let shift = match &n {
             Value::Number(f) => *f as u64,
-            Value::Literal(s) | Value::Output(s) => {
-                s.trim().parse::<u64>().map_err(|_| {
-                    EvalError::ExecError(format!("big-shl: invalid shift amount: {}", s))
-                })?
+            Value::Literal(s) | Value::Output(s) => s.trim().parse::<u64>().map_err(|_| {
+                EvalError::ExecError(format!("big-shl: invalid shift amount: {}", s))
+            })?,
+            _ => {
+                return Err(EvalError::ExecError(
+                    "big-shl requires number shift amount".to_string(),
+                ))
             }
-            _ => return Err(EvalError::ExecError("big-shl requires number shift amount".to_string())),
         };
         let a = self.pop_bigint("big-shl")?;
         self.stack.push(Value::BigInt(a << shift));
@@ -183,12 +193,14 @@ impl Evaluator {
         })?;
         let shift = match &n {
             Value::Number(f) => *f as u64,
-            Value::Literal(s) | Value::Output(s) => {
-                s.trim().parse::<u64>().map_err(|_| {
-                    EvalError::ExecError(format!("big-shr: invalid shift amount: {}", s))
-                })?
+            Value::Literal(s) | Value::Output(s) => s.trim().parse::<u64>().map_err(|_| {
+                EvalError::ExecError(format!("big-shr: invalid shift amount: {}", s))
+            })?,
+            _ => {
+                return Err(EvalError::ExecError(
+                    "big-shr requires number shift amount".to_string(),
+                ))
             }
-            _ => return Err(EvalError::ExecError("big-shr requires number shift amount".to_string())),
         };
         let a = self.pop_bigint("big-shr")?;
         self.stack.push(Value::BigInt(a >> shift));
@@ -203,12 +215,15 @@ impl Evaluator {
         })?;
         let exp = match &n {
             Value::Number(f) => *f as u32,
-            Value::Literal(s) | Value::Output(s) => {
-                s.trim().parse::<u32>().map_err(|_| {
-                    EvalError::ExecError(format!("big-pow: invalid exponent: {}", s))
-                })?
+            Value::Literal(s) | Value::Output(s) => s
+                .trim()
+                .parse::<u32>()
+                .map_err(|_| EvalError::ExecError(format!("big-pow: invalid exponent: {}", s)))?,
+            _ => {
+                return Err(EvalError::ExecError(
+                    "big-pow requires number exponent".to_string(),
+                ))
             }
-            _ => return Err(EvalError::ExecError("big-pow requires number exponent".to_string())),
         };
         let a = self.pop_bigint("big-pow")?;
         self.stack.push(Value::BigInt(a.pow(exp)));

--- a/src/eval/combinators.rs
+++ b/src/eval/combinators.rs
@@ -61,7 +61,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list1),
+                got: list1.type_name().to_string(),
             }),
         };
 
@@ -69,7 +69,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list2),
+                got: list2.type_name().to_string(),
             }),
         };
 
@@ -96,7 +96,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list1),
+                got: list1.type_name().to_string(),
             }),
         };
 
@@ -104,7 +104,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", list2),
+                got: list2.type_name().to_string(),
             }),
         };
 
@@ -133,7 +133,7 @@ impl Evaluator {
             Value::Block(exprs) => exprs,
             _ => return Err(EvalError::TypeError {
                 expected: "Block".into(),
-                got: format!("{:?}", block),
+                got: block.type_name().to_string(),
             }),
         };
 
@@ -146,7 +146,7 @@ impl Evaluator {
                 })?,
             _ => return Err(EvalError::TypeError {
                 expected: "Number".into(),
-                got: format!("{:?}", count),
+                got: count.type_name().to_string(),
             }),
         };
 
@@ -210,7 +210,7 @@ impl Evaluator {
             Value::Block(exprs) => exprs,
             _ => return Err(EvalError::TypeError {
                 expected: "Block".into(),
-                got: format!("{:?}", block),
+                got: block.type_name().to_string(),
             }),
         };
 
@@ -223,7 +223,7 @@ impl Evaluator {
                 })?,
             _ => return Err(EvalError::TypeError {
                 expected: "Number".into(),
-                got: format!("{:?}", count),
+                got: count.type_name().to_string(),
             }),
         };
 
@@ -236,7 +236,7 @@ impl Evaluator {
                 })?,
             _ => return Err(EvalError::TypeError {
                 expected: "Number (milliseconds)".into(),
-                got: format!("{:?}", delay_ms),
+                got: delay_ms.type_name().to_string(),
             }),
         };
 
@@ -295,7 +295,7 @@ impl Evaluator {
                         Value::Block(exprs) => blocks.push(exprs),
                         _ => return Err(EvalError::TypeError {
                             expected: "Block".into(),
-                            got: format!("{:?}", item),
+                            got: item.type_name().to_string(),
                         }),
                     }
                 }
@@ -314,7 +314,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Block or List of Blocks".into(),
-                got: format!("{:?}", top),
+                got: top.type_name().to_string(),
             }),
         };
 

--- a/src/eval/combinators.rs
+++ b/src/eval/combinators.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::{Expr, Value};
 
 impl Evaluator {
@@ -18,8 +18,10 @@ impl Evaluator {
         }
 
         // Pop the input value
-        let input = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("fanout: no input value".into()))?;
+        let input = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("fanout: no input value".into()))?;
 
         // Run input through each block, collecting results
         let mut results: Vec<Value> = Vec::new();
@@ -52,30 +54,39 @@ impl Evaluator {
     /// zip: Pair two lists element-wise
     /// list1 list2 zip -> [[a1,b1], [a2,b2], ...]
     pub(crate) fn builtin_zip(&mut self) -> Result<(), EvalError> {
-        let list2 = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("zip: requires two lists".into()))?;
-        let list1 = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("zip: requires two lists".into()))?;
+        let list2 = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("zip: requires two lists".into()))?;
+        let list1 = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("zip: requires two lists".into()))?;
 
         let items1 = match list1 {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list1.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list1.type_name().to_string(),
+                })
+            }
         };
 
         let items2 = match list2 {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list2.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list2.type_name().to_string(),
+                })
+            }
         };
 
         // Zip together (stops at shorter list)
-        let zipped: Vec<Value> = items1.into_iter()
-            .zip(items2.into_iter())
+        let zipped: Vec<Value> = items1
+            .into_iter()
+            .zip(items2)
             .map(|(a, b)| Value::List(vec![a, b]))
             .collect();
 
@@ -87,25 +98,33 @@ impl Evaluator {
     /// cross: Cartesian product of two lists
     /// list1 list2 cross -> [[a1,b1], [a1,b2], [a2,b1], [a2,b2], ...]
     pub(crate) fn builtin_cross(&mut self) -> Result<(), EvalError> {
-        let list2 = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("cross: requires two lists".into()))?;
-        let list1 = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("cross: requires two lists".into()))?;
+        let list2 = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("cross: requires two lists".into()))?;
+        let list1 = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("cross: requires two lists".into()))?;
 
         let items1 = match list1 {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list1.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list1.type_name().to_string(),
+                })
+            }
         };
 
         let items2 = match list2 {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: list2.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: list2.type_name().to_string(),
+                })
+            }
         };
 
         // Cartesian product
@@ -124,30 +143,39 @@ impl Evaluator {
     /// retry: Retry a block N times until success
     /// N #[block] retry -> result (or error after N failures)
     pub(crate) fn builtin_retry(&mut self) -> Result<(), EvalError> {
-        let block = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("retry: requires a block".into()))?;
-        let count = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("retry: requires retry count".into()))?;
+        let block = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("retry: requires a block".into()))?;
+        let count = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("retry: requires retry count".into()))?;
 
         let block_exprs = match block {
             Value::Block(exprs) => exprs,
-            _ => return Err(EvalError::TypeError {
-                expected: "Block".into(),
-                got: block.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Block".into(),
+                    got: block.type_name().to_string(),
+                })
+            }
         };
 
         let max_tries = match count {
             Value::Number(n) => n as usize,
-            Value::Literal(s) | Value::Output(s) => s.parse::<usize>().map_err(|_|
-                EvalError::TypeError {
+            Value::Literal(s) | Value::Output(s) => {
+                s.parse::<usize>().map_err(|_| EvalError::TypeError {
                     expected: "Number".into(),
                     got: "String".into(),
-                })?,
-            _ => return Err(EvalError::TypeError {
-                expected: "Number".into(),
-                got: count.type_name().to_string(),
-            }),
+                })?
+            }
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Number".into(),
+                    got: count.type_name().to_string(),
+                })
+            }
         };
 
         if max_tries == 0 {
@@ -172,10 +200,10 @@ impl Evaluator {
                 }
                 Ok(()) => {
                     // Block completed but with non-zero exit code
-                    last_error = Some(EvalError::ExecError(
-                        format!("retry: attempt {}/{} failed with exit code {}",
-                                attempt, max_tries, self.last_exit_code)
-                    ));
+                    last_error = Some(EvalError::ExecError(format!(
+                        "retry: attempt {}/{} failed with exit code {}",
+                        attempt, max_tries, self.last_exit_code
+                    )));
                 }
                 Err(e) => {
                     last_error = Some(e);
@@ -190,8 +218,7 @@ impl Evaluator {
         }
 
         // All retries failed
-        Err(last_error.unwrap_or_else(||
-            EvalError::ExecError("retry: all attempts failed".into())))
+        Err(last_error.unwrap_or_else(|| EvalError::ExecError("retry: all attempts failed".into())))
     }
 
     /// retry-delay: Retry with configurable delay between attempts
@@ -199,49 +226,65 @@ impl Evaluator {
     /// Stack: #[block] count delay_ms (delay on top)
     pub(crate) fn builtin_retry_delay(&mut self) -> Result<(), EvalError> {
         // Pop in LIFO order: delay_ms, count, block
-        let delay_ms = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("retry-delay: requires delay in ms".into()))?;
-        let count = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("retry-delay: requires retry count".into()))?;
-        let block = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("retry-delay: requires a block".into()))?;
+        let delay_ms = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("retry-delay: requires delay in ms".into()))?;
+        let count = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("retry-delay: requires retry count".into()))?;
+        let block = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("retry-delay: requires a block".into()))?;
 
         let block_exprs = match block {
             Value::Block(exprs) => exprs,
-            _ => return Err(EvalError::TypeError {
-                expected: "Block".into(),
-                got: block.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Block".into(),
+                    got: block.type_name().to_string(),
+                })
+            }
         };
 
         let max_tries = match count {
             Value::Number(n) => n as usize,
-            Value::Literal(s) | Value::Output(s) => s.parse::<usize>().map_err(|_|
-                EvalError::TypeError {
+            Value::Literal(s) | Value::Output(s) => {
+                s.parse::<usize>().map_err(|_| EvalError::TypeError {
                     expected: "Number".into(),
                     got: "String".into(),
-                })?,
-            _ => return Err(EvalError::TypeError {
-                expected: "Number".into(),
-                got: count.type_name().to_string(),
-            }),
+                })?
+            }
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Number".into(),
+                    got: count.type_name().to_string(),
+                })
+            }
         };
 
         let delay: u64 = match delay_ms {
             Value::Number(n) => n as u64,
-            Value::Literal(s) | Value::Output(s) => s.parse::<u64>().map_err(|_|
-                EvalError::TypeError {
+            Value::Literal(s) | Value::Output(s) => {
+                s.parse::<u64>().map_err(|_| EvalError::TypeError {
                     expected: "Number (milliseconds)".into(),
                     got: "String".into(),
-                })?,
-            _ => return Err(EvalError::TypeError {
-                expected: "Number (milliseconds)".into(),
-                got: delay_ms.type_name().to_string(),
-            }),
+                })?
+            }
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Number (milliseconds)".into(),
+                    got: delay_ms.type_name().to_string(),
+                })
+            }
         };
 
         if max_tries == 0 {
-            return Err(EvalError::ExecError("retry-delay: count must be > 0".into()));
+            return Err(EvalError::ExecError(
+                "retry-delay: count must be > 0".into(),
+            ));
         }
 
         let mut last_error: Option<EvalError> = None;
@@ -259,10 +302,10 @@ impl Evaluator {
                     return Ok(());
                 }
                 Ok(()) => {
-                    last_error = Some(EvalError::ExecError(
-                        format!("retry-delay: attempt {}/{} failed with exit code {}",
-                                attempt, max_tries, self.last_exit_code)
-                    ));
+                    last_error = Some(EvalError::ExecError(format!(
+                        "retry-delay: attempt {}/{} failed with exit code {}",
+                        attempt, max_tries, self.last_exit_code
+                    )));
                 }
                 Err(e) => {
                     last_error = Some(e);
@@ -274,8 +317,8 @@ impl Evaluator {
             }
         }
 
-        Err(last_error.unwrap_or_else(||
-            EvalError::ExecError("retry-delay: all attempts failed".into())))
+        Err(last_error
+            .unwrap_or_else(|| EvalError::ExecError("retry-delay: all attempts failed".into())))
     }
 
     /// compose: Combine multiple blocks into a single pipeline block
@@ -283,8 +326,10 @@ impl Evaluator {
     /// Or from a list: list-of-blocks compose -> single-block
     pub(crate) fn builtin_compose(&mut self) -> Result<(), EvalError> {
         // Check if top of stack is a list of blocks or individual blocks
-        let top = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("compose: requires blocks".into()))?;
+        let top = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("compose: requires blocks".into()))?;
 
         let blocks: Vec<Vec<Expr>> = match top {
             // If it's a list, extract blocks from it
@@ -293,10 +338,12 @@ impl Evaluator {
                 for item in items {
                     match item {
                         Value::Block(exprs) => blocks.push(exprs),
-                        _ => return Err(EvalError::TypeError {
-                            expected: "Block".into(),
-                            got: item.type_name().to_string(),
-                        }),
+                        _ => {
+                            return Err(EvalError::TypeError {
+                                expected: "Block".into(),
+                                got: item.type_name().to_string(),
+                            })
+                        }
                     }
                 }
                 blocks
@@ -312,10 +359,12 @@ impl Evaluator {
                 blocks.reverse(); // Restore original order
                 blocks
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Block or List of Blocks".into(),
-                got: top.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Block or List of Blocks".into(),
+                    got: top.type_name().to_string(),
+                })
+            }
         };
 
         if blocks.is_empty() {

--- a/src/eval/command.rs
+++ b/src/eval/command.rs
@@ -84,11 +84,19 @@ impl Evaluator {
         std::io::stdout().is_terminal() && std::io::stdin().is_terminal()
     }
 
-    /// Try to execute a builtin command
+    /// Try to execute a string-argument (shell-style) builtin command.
+    ///
+    /// Dispatch ownership (issue #32): for a literal word, `eval_expr`
+    /// (src/eval/mod.rs) tries `try_structured_builtin` FIRST; only if that
+    /// returns `Ok(false)` does the word reach `execute_command` -> here.
+    /// Therefore this table must only contain names NOT handled by
+    /// `try_structured_builtin` (they would be dead copies). The single
+    /// deliberate overlap is `len`: `try_structured_builtin` handles
+    /// `Value::Bytes` and falls through to the string version here.
     pub(crate) fn try_builtin(&mut self, cmd: &str, args: &[String]) -> Option<Result<(), EvalError>> {
         match cmd {
             // Borderlines: both formats (POSIX compat + dot-convention)
-            "cd" | ".cd" => Some(self.builtin_cd(args)),
+            // Note: cd/.cd is owned by try_structured_builtin (builtin_cd_native)
             "pwd" | ".pwd" => Some(self.builtin_pwd()),
             "echo" | ".echo" => Some(self.builtin_echo(args)),
             "true" | ".true" => Some(self.builtin_true()),
@@ -135,75 +143,9 @@ impl Evaluator {
             "format" => Some(self.builtin_format(args)),
             // Path operations (native implementation for performance)
             "reext" => Some(self.builtin_reext(args)),
-            // Type predicates
-            "number?" => Some(self.builtin_number_predicate()),
-            "string?" => Some(self.builtin_string_predicate()),
-            "array?" => Some(self.builtin_array_predicate()),
-            "function?" => Some(self.builtin_function_predicate()),
-            // Logical operators
-            "not" => Some(self.builtin_not()),
-            "xor" => Some(self.builtin_xor()),
-            "nand" => Some(self.builtin_nand()),
-            "nor" => Some(self.builtin_nor()),
-            // Phase 0: Type introspection
-            "typeof" => Some(self.builtin_typeof()),
-            // Phase 1: Record operations
-            "record" => Some(self.builtin_record()),
-            "get" => Some(self.builtin_get()),
-            "set" => Some(self.builtin_set()),
-            "del" => Some(self.builtin_del()),
-            "has?" => Some(self.builtin_has()),
-            "keys" => Some(self.builtin_keys()),
-            "values" => Some(self.builtin_values()),
-            "merge" => Some(self.builtin_merge()),
-            // Phase 2: Table operations
-            "table" => Some(self.builtin_table()),
-            "where" => Some(self.builtin_where()),
-            "sort-by" => Some(self.builtin_sort_by()),
-            "select" => Some(self.builtin_select()),
-            "first" => Some(self.builtin_first()),
-            "last" => Some(self.builtin_last()),
-            "nth" => Some(self.builtin_nth()),
-            // Phase 3: Error handling
-            "try" => Some(self.builtin_try()),
-            "error?" => Some(self.builtin_error_predicate()),
-            "throw" => Some(self.builtin_throw()),
-            // Phase 4: Serialization bridge
-            // into-X = serialize (structured -> text), from-X = parse (text -> structured)
-            "into-json" | "to-json" => Some(self.builtin_to_json()),
-            "from-json" => Some(self.builtin_into_json()),
-            "into-csv" | "to-csv" => Some(self.builtin_to_csv()),
-            "from-csv" => Some(self.builtin_into_csv()),
-            "into-lines" | "from-lines" => Some(self.builtin_into_lines()),
-            "to-lines" => Some(self.builtin_to_lines()),
-            "into-kv" | "to-kv" => Some(self.builtin_to_kv()),
-            "from-kv" => Some(self.builtin_into_kv()),
-            "into-tsv" | "to-tsv" => Some(self.builtin_to_tsv()),
-            "from-tsv" => Some(self.builtin_into_tsv()),
-            "to-delimited" => Some(self.builtin_to_delimited()),
-            // File operations
-            "save" => Some(self.builtin_save()),
-            // Additional aggregations
-            "reduce" => Some(self.builtin_reduce()),
-            "fold" => Some(self.builtin_fold()),
-            "bend" => Some(self.builtin_bend()),
-            // Additional list/table operations
-            "reject" => Some(self.builtin_reject()),
-            "reject-where" => Some(self.builtin_reject_where()),
-            "duplicates" => Some(self.builtin_duplicates()),
-            // Vector operations (for embeddings)
-            "dot-product" => Some(self.builtin_dot_product()),
-            "magnitude" => Some(self.builtin_magnitude()),
-            "normalize" => Some(self.builtin_normalize()),
-            "cosine-similarity" => Some(self.builtin_cosine_similarity()),
-            "euclidean-distance" => Some(self.builtin_euclidean_distance()),
-            // Phase 10: Combinators
-            "fanout" => Some(self.builtin_fanout()),
-            "zip" => Some(self.builtin_zip()),
-            "cross" => Some(self.builtin_cross()),
-            "retry" => Some(self.builtin_retry()),
-            "retry-delay" => Some(self.builtin_retry_delay()),
-            "compose" => Some(self.builtin_compose()),
+            // NOTE (issue #32): stack-native builtins (typeof, record, table,
+            // aggregations, serialization, vectors, combinators, etc.) are
+            // owned by try_structured_builtin and intentionally absent here.
             // Plugin management builtins (meta commands)
             #[cfg(feature = "plugins")]
             ".plugin-load" => Some(self.builtin_plugin_load(args)),
@@ -230,6 +172,13 @@ impl Evaluator {
 
     /// Try to handle structured data builtins directly (without stringifying args)
     /// Returns true if handled, false if should fall through to execute_command
+    ///
+    /// Dispatch ownership (issue #32): this table runs FIRST for literal
+    /// words (see src/eval/mod.rs eval_expr) and owns every stack-native
+    /// builtin. Names handled here must NOT also appear in `try_builtin`
+    /// (they would be unreachable dead copies), with one deliberate
+    /// exception: `len` returns Ok(false) for non-Bytes values so the
+    /// string-argument `len` in `try_builtin` can handle them.
     pub(crate) fn try_structured_builtin(&mut self, cmd: &str) -> Result<bool, EvalError> {
         match cmd {
             // Local variable (stack-native to preserve structured values)

--- a/src/eval/command.rs
+++ b/src/eval/command.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use std::process::{Command, Stdio};
 
@@ -45,7 +45,11 @@ impl Evaluator {
 
     /// Execute a native command using std::process::Command
     /// Uses capture_mode to decide whether to capture output or run interactively
-    pub(crate) fn execute_native(&mut self, cmd: &str, args: Vec<String>) -> Result<(String, i32), EvalError> {
+    pub(crate) fn execute_native(
+        &mut self,
+        cmd: &str,
+        args: Vec<String>,
+    ) -> Result<(String, i32), EvalError> {
         // Only run interactively if:
         // 1. capture_mode is false (nothing will consume the output)
         // 2. stdout is a TTY (we're in an interactive context)
@@ -93,7 +97,11 @@ impl Evaluator {
     /// `try_structured_builtin` (they would be dead copies). The single
     /// deliberate overlap is `len`: `try_structured_builtin` handles
     /// `Value::Bytes` and falls through to the string version here.
-    pub(crate) fn try_builtin(&mut self, cmd: &str, args: &[String]) -> Option<Result<(), EvalError>> {
+    pub(crate) fn try_builtin(
+        &mut self,
+        cmd: &str,
+        args: &[String],
+    ) -> Option<Result<(), EvalError>> {
         match cmd {
             // Borderlines: both formats (POSIX compat + dot-convention)
             // Note: cd/.cd is owned by try_structured_builtin (builtin_cd_native)
@@ -182,143 +190,482 @@ impl Evaluator {
     pub(crate) fn try_structured_builtin(&mut self, cmd: &str) -> Result<bool, EvalError> {
         match cmd {
             // Local variable (stack-native to preserve structured values)
-            "local" | ".local" => { self.builtin_local_stack()?; Ok(true) }
+            "local" | ".local" => {
+                self.builtin_local_stack()?;
+                Ok(true)
+            }
             // Phase 0
-            "typeof" => { self.builtin_typeof()?; Ok(true) }
+            "typeof" => {
+                self.builtin_typeof()?;
+                Ok(true)
+            }
             // Phase 1: Record ops
-            "record" => { self.builtin_record()?; Ok(true) }
-            "get" => { self.builtin_get()?; Ok(true) }
-            "set" => { self.builtin_set()?; Ok(true) }
-            "del" => { self.builtin_del()?; Ok(true) }
-            "has?" => { self.builtin_has()?; Ok(true) }
-            "keys" => { self.builtin_keys()?; Ok(true) }
-            "values" => { self.builtin_values()?; Ok(true) }
-            "merge" => { self.builtin_merge()?; Ok(true) }
+            "record" => {
+                self.builtin_record()?;
+                Ok(true)
+            }
+            "get" => {
+                self.builtin_get()?;
+                Ok(true)
+            }
+            "set" => {
+                self.builtin_set()?;
+                Ok(true)
+            }
+            "del" => {
+                self.builtin_del()?;
+                Ok(true)
+            }
+            "has?" => {
+                self.builtin_has()?;
+                Ok(true)
+            }
+            "keys" => {
+                self.builtin_keys()?;
+                Ok(true)
+            }
+            "values" => {
+                self.builtin_values()?;
+                Ok(true)
+            }
+            "merge" => {
+                self.builtin_merge()?;
+                Ok(true)
+            }
             // Phase 2: Table ops
-            "table" => { self.builtin_table()?; Ok(true) }
-            "where" => { self.builtin_where()?; Ok(true) }
-            "sort-by" => { self.builtin_sort_by()?; Ok(true) }
-            "select" => { self.builtin_select()?; Ok(true) }
-            "first" => { self.builtin_first()?; Ok(true) }
-            "last" => { self.builtin_last()?; Ok(true) }
-            "nth" => { self.builtin_nth()?; Ok(true) }
+            "table" => {
+                self.builtin_table()?;
+                Ok(true)
+            }
+            "where" => {
+                self.builtin_where()?;
+                Ok(true)
+            }
+            "sort-by" => {
+                self.builtin_sort_by()?;
+                Ok(true)
+            }
+            "select" => {
+                self.builtin_select()?;
+                Ok(true)
+            }
+            "first" => {
+                self.builtin_first()?;
+                Ok(true)
+            }
+            "last" => {
+                self.builtin_last()?;
+                Ok(true)
+            }
+            "nth" => {
+                self.builtin_nth()?;
+                Ok(true)
+            }
             // Type predicates
-            "number?" => { self.builtin_number_predicate()?; Ok(true) }
-            "string?" => { self.builtin_string_predicate()?; Ok(true) }
-            "array?" => { self.builtin_array_predicate()?; Ok(true) }
-            "function?" => { self.builtin_function_predicate()?; Ok(true) }
+            "number?" => {
+                self.builtin_number_predicate()?;
+                Ok(true)
+            }
+            "string?" => {
+                self.builtin_string_predicate()?;
+                Ok(true)
+            }
+            "array?" => {
+                self.builtin_array_predicate()?;
+                Ok(true)
+            }
+            "function?" => {
+                self.builtin_function_predicate()?;
+                Ok(true)
+            }
             // Logical operators
-            "not" => { self.builtin_not()?; Ok(true) }
-            "xor" => { self.builtin_xor()?; Ok(true) }
-            "nand" => { self.builtin_nand()?; Ok(true) }
-            "nor" => { self.builtin_nor()?; Ok(true) }
+            "not" => {
+                self.builtin_not()?;
+                Ok(true)
+            }
+            "xor" => {
+                self.builtin_xor()?;
+                Ok(true)
+            }
+            "nand" => {
+                self.builtin_nand()?;
+                Ok(true)
+            }
+            "nor" => {
+                self.builtin_nor()?;
+                Ok(true)
+            }
             // Phase 3: Error handling
-            "try" => { self.builtin_try()?; Ok(true) }
-            "error?" => { self.builtin_error_predicate()?; Ok(true) }
-            "nil?" => { self.builtin_nil_predicate()?; Ok(true) }
-            "throw" => { self.builtin_throw()?; Ok(true) }
+            "try" => {
+                self.builtin_try()?;
+                Ok(true)
+            }
+            "error?" => {
+                self.builtin_error_predicate()?;
+                Ok(true)
+            }
+            "nil?" => {
+                self.builtin_nil_predicate()?;
+                Ok(true)
+            }
+            "throw" => {
+                self.builtin_throw()?;
+                Ok(true)
+            }
             // Phase 4: Serialization
             // into-X = serialize (structured -> text), from-X = parse (text -> structured)
-            "into-json" | "to-json" => { self.builtin_to_json()?; Ok(true) }
-            "from-json" => { self.builtin_into_json()?; Ok(true) }
-            "into-csv" | "to-csv" => { self.builtin_to_csv()?; Ok(true) }
-            "from-csv" => { self.builtin_into_csv()?; Ok(true) }
-            "into-lines" | "from-lines" => { self.builtin_into_lines()?; Ok(true) }
-            "to-lines" => { self.builtin_to_lines()?; Ok(true) }
-            "into-kv" | "to-kv" => { self.builtin_to_kv()?; Ok(true) }
-            "from-kv" => { self.builtin_into_kv()?; Ok(true) }
-            "into-tsv" | "to-tsv" => { self.builtin_to_tsv()?; Ok(true) }
-            "from-tsv" => { self.builtin_into_tsv()?; Ok(true) }
-            "to-delimited" => { self.builtin_to_delimited()?; Ok(true) }
+            "into-json" | "to-json" => {
+                self.builtin_to_json()?;
+                Ok(true)
+            }
+            "from-json" => {
+                self.builtin_into_json()?;
+                Ok(true)
+            }
+            "into-csv" | "to-csv" => {
+                self.builtin_to_csv()?;
+                Ok(true)
+            }
+            "from-csv" => {
+                self.builtin_into_csv()?;
+                Ok(true)
+            }
+            "into-lines" | "from-lines" => {
+                self.builtin_into_lines()?;
+                Ok(true)
+            }
+            "to-lines" => {
+                self.builtin_to_lines()?;
+                Ok(true)
+            }
+            "into-kv" | "to-kv" => {
+                self.builtin_to_kv()?;
+                Ok(true)
+            }
+            "from-kv" => {
+                self.builtin_into_kv()?;
+                Ok(true)
+            }
+            "into-tsv" | "to-tsv" => {
+                self.builtin_to_tsv()?;
+                Ok(true)
+            }
+            "from-tsv" => {
+                self.builtin_into_tsv()?;
+                Ok(true)
+            }
+            "to-delimited" => {
+                self.builtin_to_delimited()?;
+                Ok(true)
+            }
             // Phase 5: Stack utilities
-            "tap" => { self.builtin_tap()?; Ok(true) }
-            "dip" => { self.builtin_dip()?; Ok(true) }
-            "dig" | "pick" => { self.stack_dig()?; Ok(true) }
-            "bury" | "roll" => { self.stack_bury()?; Ok(true) }
+            "tap" => {
+                self.builtin_tap()?;
+                Ok(true)
+            }
+            "dip" => {
+                self.builtin_dip()?;
+                Ok(true)
+            }
+            "dig" | "pick" => {
+                self.stack_dig()?;
+                Ok(true)
+            }
+            "bury" | "roll" => {
+                self.stack_bury()?;
+                Ok(true)
+            }
             // Phase 6: Aggregations
-            "sum" => { self.builtin_sum()?; Ok(true) }
-            "avg" => { self.builtin_avg()?; Ok(true) }
-            "min" => { self.builtin_min()?; Ok(true) }
-            "max" => { self.builtin_max()?; Ok(true) }
-            "count" => { self.builtin_count()?; Ok(true) }
-            "reduce" => { self.builtin_reduce()?; Ok(true) }
-            "fold" => { self.builtin_fold()?; Ok(true) }
-            "bend" => { self.builtin_bend()?; Ok(true) }
+            "sum" => {
+                self.builtin_sum()?;
+                Ok(true)
+            }
+            "avg" => {
+                self.builtin_avg()?;
+                Ok(true)
+            }
+            "min" => {
+                self.builtin_min()?;
+                Ok(true)
+            }
+            "max" => {
+                self.builtin_max()?;
+                Ok(true)
+            }
+            "count" => {
+                self.builtin_count()?;
+                Ok(true)
+            }
+            "reduce" => {
+                self.builtin_reduce()?;
+                Ok(true)
+            }
+            "fold" => {
+                self.builtin_fold()?;
+                Ok(true)
+            }
+            "bend" => {
+                self.builtin_bend()?;
+                Ok(true)
+            }
             // Phase 6.5: Statistical functions
-            "product" => { self.builtin_product()?; Ok(true) }
-            "median" => { self.builtin_median()?; Ok(true) }
-            "mode" => { self.builtin_mode()?; Ok(true) }
-            "modes" => { self.builtin_modes()?; Ok(true) }
-            "variance" => { self.builtin_variance()?; Ok(true) }
-            "sample-variance" => { self.builtin_sample_variance()?; Ok(true) }
-            "stdev" => { self.builtin_stdev()?; Ok(true) }
-            "sample-stdev" => { self.builtin_sample_stdev()?; Ok(true) }
-            "percentile" => { self.builtin_percentile()?; Ok(true) }
-            "five-num" => { self.builtin_five_num()?; Ok(true) }
+            "product" => {
+                self.builtin_product()?;
+                Ok(true)
+            }
+            "median" => {
+                self.builtin_median()?;
+                Ok(true)
+            }
+            "mode" => {
+                self.builtin_mode()?;
+                Ok(true)
+            }
+            "modes" => {
+                self.builtin_modes()?;
+                Ok(true)
+            }
+            "variance" => {
+                self.builtin_variance()?;
+                Ok(true)
+            }
+            "sample-variance" => {
+                self.builtin_sample_variance()?;
+                Ok(true)
+            }
+            "stdev" => {
+                self.builtin_stdev()?;
+                Ok(true)
+            }
+            "sample-stdev" => {
+                self.builtin_sample_stdev()?;
+                Ok(true)
+            }
+            "percentile" => {
+                self.builtin_percentile()?;
+                Ok(true)
+            }
+            "five-num" => {
+                self.builtin_five_num()?;
+                Ok(true)
+            }
             // Phase 8: Extended table ops
-            "group-by" => { self.builtin_group_by()?; Ok(true) }
-            "unique" => { self.builtin_unique()?; Ok(true) }
-            "reverse" => { self.builtin_reverse()?; Ok(true) }
-            "flatten" => { self.builtin_flatten()?; Ok(true) }
-            "reject" => { self.builtin_reject()?; Ok(true) }
-            "reject-where" => { self.builtin_reject_where()?; Ok(true) }
-            "duplicates" => { self.builtin_duplicates()?; Ok(true) }
+            "group-by" => {
+                self.builtin_group_by()?;
+                Ok(true)
+            }
+            "unique" => {
+                self.builtin_unique()?;
+                Ok(true)
+            }
+            "reverse" => {
+                self.builtin_reverse()?;
+                Ok(true)
+            }
+            "flatten" => {
+                self.builtin_flatten()?;
+                Ok(true)
+            }
+            "reject" => {
+                self.builtin_reject()?;
+                Ok(true)
+            }
+            "reject-where" => {
+                self.builtin_reject_where()?;
+                Ok(true)
+            }
+            "duplicates" => {
+                self.builtin_duplicates()?;
+                Ok(true)
+            }
             // Extended spread operations
-            "fields" => { self.builtin_fields()?; Ok(true) }
-            "fields-keys" => { self.builtin_fields_keys()?; Ok(true) }
-            "spread-head" => { self.builtin_spread_head()?; Ok(true) }
-            "spread-tail" => { self.builtin_spread_tail()?; Ok(true) }
-            "spread-n" => { self.builtin_spread_n()?; Ok(true) }
-            "spread-to" => { self.builtin_spread_to()?; Ok(true) }
+            "fields" => {
+                self.builtin_fields()?;
+                Ok(true)
+            }
+            "fields-keys" => {
+                self.builtin_fields_keys()?;
+                Ok(true)
+            }
+            "spread-head" => {
+                self.builtin_spread_head()?;
+                Ok(true)
+            }
+            "spread-tail" => {
+                self.builtin_spread_tail()?;
+                Ok(true)
+            }
+            "spread-n" => {
+                self.builtin_spread_n()?;
+                Ok(true)
+            }
+            "spread-to" => {
+                self.builtin_spread_to()?;
+                Ok(true)
+            }
             // Phase 9: Vector operations
-            "dot-product" => { self.builtin_dot_product()?; Ok(true) }
-            "magnitude" => { self.builtin_magnitude()?; Ok(true) }
-            "normalize" => { self.builtin_normalize()?; Ok(true) }
-            "cosine-similarity" => { self.builtin_cosine_similarity()?; Ok(true) }
-            "euclidean-distance" => { self.builtin_euclidean_distance()?; Ok(true) }
+            "dot-product" => {
+                self.builtin_dot_product()?;
+                Ok(true)
+            }
+            "magnitude" => {
+                self.builtin_magnitude()?;
+                Ok(true)
+            }
+            "normalize" => {
+                self.builtin_normalize()?;
+                Ok(true)
+            }
+            "cosine-similarity" => {
+                self.builtin_cosine_similarity()?;
+                Ok(true)
+            }
+            "euclidean-distance" => {
+                self.builtin_euclidean_distance()?;
+                Ok(true)
+            }
             // Phase 10: Combinators
-            "fanout" => { self.builtin_fanout()?; Ok(true) }
-            "zip" => { self.builtin_zip()?; Ok(true) }
-            "cross" => { self.builtin_cross()?; Ok(true) }
-            "retry" => { self.builtin_retry()?; Ok(true) }
-            "compose" => { self.builtin_compose()?; Ok(true) }
+            "fanout" => {
+                self.builtin_fanout()?;
+                Ok(true)
+            }
+            "zip" => {
+                self.builtin_zip()?;
+                Ok(true)
+            }
+            "cross" => {
+                self.builtin_cross()?;
+                Ok(true)
+            }
+            "retry" => {
+                self.builtin_retry()?;
+                Ok(true)
+            }
+            "compose" => {
+                self.builtin_compose()?;
+                Ok(true)
+            }
             // Phase 11: Additional parsers (from-X aliases for parsing)
-            "from-delimited" | "into-delimited" => { self.builtin_into_delimited()?; Ok(true) }
+            "from-delimited" | "into-delimited" => {
+                self.builtin_into_delimited()?;
+                Ok(true)
+            }
             // Structured builtins
-            "ls-table" => { self.builtin_ls_table()?; Ok(true) }
-            "open" => { self.builtin_open()?; Ok(true) }
-            "save" => { self.builtin_save()?; Ok(true) }
+            "ls-table" => {
+                self.builtin_ls_table()?;
+                Ok(true)
+            }
+            "open" => {
+                self.builtin_open()?;
+                Ok(true)
+            }
+            "save" => {
+                self.builtin_save()?;
+                Ok(true)
+            }
             // Media / Image operations
-            "image-load" => { self.builtin_image_load_stack()?; Ok(true) }
-            "image-show" => { self.builtin_image_show()?; Ok(true) }
-            "image-info" => { self.builtin_image_info()?; Ok(true) }
-            "to-base64" => { self.builtin_to_base64()?; Ok(true) }
-            "from-base64" => { self.builtin_from_base64()?; Ok(true) }
+            "image-load" => {
+                self.builtin_image_load_stack()?;
+                Ok(true)
+            }
+            "image-show" => {
+                self.builtin_image_show()?;
+                Ok(true)
+            }
+            "image-info" => {
+                self.builtin_image_info()?;
+                Ok(true)
+            }
+            "to-base64" => {
+                self.builtin_to_base64()?;
+                Ok(true)
+            }
+            "from-base64" => {
+                self.builtin_from_base64()?;
+                Ok(true)
+            }
             // Link operations (OSC 8)
-            "link" => { self.builtin_link()?; Ok(true) }
-            "link-info" => { self.builtin_link_info()?; Ok(true) }
+            "link" => {
+                self.builtin_link()?;
+                Ok(true)
+            }
+            "link-info" => {
+                self.builtin_link_info()?;
+                Ok(true)
+            }
             // Clipboard operations (OSC 52)
-            ".copy" => { self.builtin_clip_copy()?; Ok(true) }
-            ".cut" => { self.builtin_clip_cut()?; Ok(true) }
-            ".paste" => { self.builtin_clip_paste()?; Ok(true) }
+            ".copy" => {
+                self.builtin_clip_copy()?;
+                Ok(true)
+            }
+            ".cut" => {
+                self.builtin_clip_cut()?;
+                Ok(true)
+            }
+            ".paste" => {
+                self.builtin_clip_paste()?;
+                Ok(true)
+            }
             // Encoding operations
-            "to-hex" => { self.builtin_to_hex()?; Ok(true) }
-            "from-hex" => { self.builtin_from_hex()?; Ok(true) }
-            "as-bytes" => { self.builtin_as_bytes()?; Ok(true) }
-            "to-bytes" => { self.builtin_to_bytes_list()?; Ok(true) }
-            "to-string" => { self.builtin_bytes_to_string()?; Ok(true) }
-            "read-bytes" => { self.builtin_read_bytes()?; Ok(true) }
+            "to-hex" => {
+                self.builtin_to_hex()?;
+                Ok(true)
+            }
+            "from-hex" => {
+                self.builtin_from_hex()?;
+                Ok(true)
+            }
+            "as-bytes" => {
+                self.builtin_as_bytes()?;
+                Ok(true)
+            }
+            "to-bytes" => {
+                self.builtin_to_bytes_list()?;
+                Ok(true)
+            }
+            "to-string" => {
+                self.builtin_bytes_to_string()?;
+                Ok(true)
+            }
+            "read-bytes" => {
+                self.builtin_read_bytes()?;
+                Ok(true)
+            }
             // Hash functions (SHA-2)
-            "sha256" => { self.builtin_sha256()?; Ok(true) }
-            "sha384" => { self.builtin_sha384()?; Ok(true) }
-            "sha512" => { self.builtin_sha512()?; Ok(true) }
+            "sha256" => {
+                self.builtin_sha256()?;
+                Ok(true)
+            }
+            "sha384" => {
+                self.builtin_sha384()?;
+                Ok(true)
+            }
+            "sha512" => {
+                self.builtin_sha512()?;
+                Ok(true)
+            }
             // Hash functions (SHA-3)
-            "sha3-256" => { self.builtin_sha3_256()?; Ok(true) }
-            "sha3-384" => { self.builtin_sha3_384()?; Ok(true) }
-            "sha3-512" => { self.builtin_sha3_512()?; Ok(true) }
+            "sha3-256" => {
+                self.builtin_sha3_256()?;
+                Ok(true)
+            }
+            "sha3-384" => {
+                self.builtin_sha3_384()?;
+                Ok(true)
+            }
+            "sha3-512" => {
+                self.builtin_sha3_512()?;
+                Ok(true)
+            }
             // File hash functions
-            "sha256-file" => { self.builtin_sha256_file()?; Ok(true) }
-            "sha3-256-file" => { self.builtin_sha3_256_file()?; Ok(true) }
+            "sha256-file" => {
+                self.builtin_sha256_file()?;
+                Ok(true)
+            }
+            "sha3-256-file" => {
+                self.builtin_sha3_256_file()?;
+                Ok(true)
+            }
             // Bytes len (try first, fallback to string len)
             "len" => {
                 // Try Bytes len first
@@ -330,104 +677,363 @@ impl Evaluator {
                 }
             }
             // BigInt operations
-            "to-bigint" => { self.builtin_to_bigint()?; Ok(true) }
-            "big-add" => { self.builtin_big_add()?; Ok(true) }
-            "big-sub" => { self.builtin_big_sub()?; Ok(true) }
-            "big-mul" => { self.builtin_big_mul()?; Ok(true) }
-            "big-div" => { self.builtin_big_div()?; Ok(true) }
-            "big-mod" => { self.builtin_big_mod()?; Ok(true) }
-            "big-xor" => { self.builtin_big_xor()?; Ok(true) }
-            "big-and" => { self.builtin_big_and()?; Ok(true) }
-            "big-or" => { self.builtin_big_or()?; Ok(true) }
-            "big-eq?" => { self.builtin_big_eq()?; Ok(true) }
-            "big-lt?" => { self.builtin_big_lt()?; Ok(true) }
-            "big-gt?" => { self.builtin_big_gt()?; Ok(true) }
-            "big-shl" => { self.builtin_big_shl()?; Ok(true) }
-            "big-shr" => { self.builtin_big_shr()?; Ok(true) }
-            "big-pow" => { self.builtin_big_pow()?; Ok(true) }
+            "to-bigint" => {
+                self.builtin_to_bigint()?;
+                Ok(true)
+            }
+            "big-add" => {
+                self.builtin_big_add()?;
+                Ok(true)
+            }
+            "big-sub" => {
+                self.builtin_big_sub()?;
+                Ok(true)
+            }
+            "big-mul" => {
+                self.builtin_big_mul()?;
+                Ok(true)
+            }
+            "big-div" => {
+                self.builtin_big_div()?;
+                Ok(true)
+            }
+            "big-mod" => {
+                self.builtin_big_mod()?;
+                Ok(true)
+            }
+            "big-xor" => {
+                self.builtin_big_xor()?;
+                Ok(true)
+            }
+            "big-and" => {
+                self.builtin_big_and()?;
+                Ok(true)
+            }
+            "big-or" => {
+                self.builtin_big_or()?;
+                Ok(true)
+            }
+            "big-eq?" => {
+                self.builtin_big_eq()?;
+                Ok(true)
+            }
+            "big-lt?" => {
+                self.builtin_big_lt()?;
+                Ok(true)
+            }
+            "big-gt?" => {
+                self.builtin_big_gt()?;
+                Ok(true)
+            }
+            "big-shl" => {
+                self.builtin_big_shl()?;
+                Ok(true)
+            }
+            "big-shr" => {
+                self.builtin_big_shr()?;
+                Ok(true)
+            }
+            "big-pow" => {
+                self.builtin_big_pow()?;
+                Ok(true)
+            }
             // Predicates (stack-native to avoid greedy arg collection)
-            "eq?" => { self.builtin_eq_stack()?; Ok(true) }
-            "ne?" => { self.builtin_ne_stack()?; Ok(true) }
-            "=?" => { self.builtin_num_eq_stack()?; Ok(true) }
-            "!=?" => { self.builtin_num_ne_stack()?; Ok(true) }
-            "lt?" => { self.builtin_lt_stack()?; Ok(true) }
-            "gt?" => { self.builtin_gt_stack()?; Ok(true) }
-            "le?" => { self.builtin_le_stack()?; Ok(true) }
-            "ge?" => { self.builtin_ge_stack()?; Ok(true) }
+            "eq?" => {
+                self.builtin_eq_stack()?;
+                Ok(true)
+            }
+            "ne?" => {
+                self.builtin_ne_stack()?;
+                Ok(true)
+            }
+            "=?" => {
+                self.builtin_num_eq_stack()?;
+                Ok(true)
+            }
+            "!=?" => {
+                self.builtin_num_ne_stack()?;
+                Ok(true)
+            }
+            "lt?" => {
+                self.builtin_lt_stack()?;
+                Ok(true)
+            }
+            "gt?" => {
+                self.builtin_gt_stack()?;
+                Ok(true)
+            }
+            "le?" => {
+                self.builtin_le_stack()?;
+                Ok(true)
+            }
+            "ge?" => {
+                self.builtin_ge_stack()?;
+                Ok(true)
+            }
             // Arithmetic primitives (stack-native to avoid greedy arg collection)
-            "plus" | "+" => { self.builtin_plus_stack()?; Ok(true) }
-            "minus" | "-" => { self.builtin_minus_stack()?; Ok(true) }
-            "mul" | "*" => { self.builtin_mul_stack()?; Ok(true) }
-            "div" | "/" => { self.builtin_div_stack()?; Ok(true) }
-            "mod" | "%" => { self.builtin_mod_stack()?; Ok(true) }
+            "plus" | "+" => {
+                self.builtin_plus_stack()?;
+                Ok(true)
+            }
+            "minus" | "-" => {
+                self.builtin_minus_stack()?;
+                Ok(true)
+            }
+            "mul" | "*" => {
+                self.builtin_mul_stack()?;
+                Ok(true)
+            }
+            "div" | "/" => {
+                self.builtin_div_stack()?;
+                Ok(true)
+            }
+            "mod" | "%" => {
+                self.builtin_mod_stack()?;
+                Ok(true)
+            }
             // Math primitives (for stats support)
-            "pow" | "**" => { self.builtin_pow()?; Ok(true) }
+            "pow" | "**" => {
+                self.builtin_pow()?;
+                Ok(true)
+            }
             // Increment / Decrement
-            "++" => { self.builtin_increment()?; Ok(true) }
-            "--" => { self.builtin_decrement()?; Ok(true) }
-            "sqrt" => { self.builtin_sqrt()?; Ok(true) }
-            "floor" => { self.builtin_floor()?; Ok(true) }
-            "ceil" => { self.builtin_ceil()?; Ok(true) }
-            "round" => { self.builtin_round()?; Ok(true) }
-            "idiv" => { self.builtin_idiv()?; Ok(true) }
-            "sort-nums" => { self.builtin_sort_nums()?; Ok(true) }
-            "log-base" => { self.builtin_log_base()?; Ok(true) }
+            "++" => {
+                self.builtin_increment()?;
+                Ok(true)
+            }
+            "--" => {
+                self.builtin_decrement()?;
+                Ok(true)
+            }
+            "sqrt" => {
+                self.builtin_sqrt()?;
+                Ok(true)
+            }
+            "floor" => {
+                self.builtin_floor()?;
+                Ok(true)
+            }
+            "ceil" => {
+                self.builtin_ceil()?;
+                Ok(true)
+            }
+            "round" => {
+                self.builtin_round()?;
+                Ok(true)
+            }
+            "idiv" => {
+                self.builtin_idiv()?;
+                Ok(true)
+            }
+            "sort-nums" => {
+                self.builtin_sort_nums()?;
+                Ok(true)
+            }
+            "log-base" => {
+                self.builtin_log_base()?;
+                Ok(true)
+            }
             // Async / concurrent operations
-            "async" => { self.builtin_async()?; Ok(true) }
-            "await" => { self.builtin_await()?; Ok(true) }
-            "future-status" => { self.builtin_future_status()?; Ok(true) }
-            "future-result" => { self.builtin_future_result()?; Ok(true) }
-            "future-cancel" => { self.builtin_future_cancel()?; Ok(true) }
-            "parallel-n" => { self.builtin_parallel_n()?; Ok(true) }
-            "parallel-map" => { self.builtin_parallel_map()?; Ok(true) }
-            "race" => { self.builtin_race()?; Ok(true) }
-            "await-all" => { self.builtin_await_all()?; Ok(true) }
-            "future-race" => { self.builtin_future_race()?; Ok(true) }
-            "future-await-n" => { self.builtin_future_await_n()?; Ok(true) }
-            "futures-list" => { self.builtin_futures_list()?; Ok(true) }
-            "future-map" => { self.builtin_future_map()?; Ok(true) }
-            "retry-delay" => { self.builtin_retry_delay()?; Ok(true) }
+            "async" => {
+                self.builtin_async()?;
+                Ok(true)
+            }
+            "await" => {
+                self.builtin_await()?;
+                Ok(true)
+            }
+            "future-status" => {
+                self.builtin_future_status()?;
+                Ok(true)
+            }
+            "future-result" => {
+                self.builtin_future_result()?;
+                Ok(true)
+            }
+            "future-cancel" => {
+                self.builtin_future_cancel()?;
+                Ok(true)
+            }
+            "parallel-n" => {
+                self.builtin_parallel_n()?;
+                Ok(true)
+            }
+            "parallel-map" => {
+                self.builtin_parallel_map()?;
+                Ok(true)
+            }
+            "race" => {
+                self.builtin_race()?;
+                Ok(true)
+            }
+            "await-all" => {
+                self.builtin_await_all()?;
+                Ok(true)
+            }
+            "future-race" => {
+                self.builtin_future_race()?;
+                Ok(true)
+            }
+            "future-await-n" => {
+                self.builtin_future_await_n()?;
+                Ok(true)
+            }
+            "futures-list" => {
+                self.builtin_futures_list()?;
+                Ok(true)
+            }
+            "future-map" => {
+                self.builtin_future_map()?;
+                Ok(true)
+            }
+            "retry-delay" => {
+                self.builtin_retry_delay()?;
+                Ok(true)
+            }
             // HTTP client operations
-            "fetch" => { self.builtin_fetch()?; Ok(true) }
-            "fetch-status" => { self.builtin_fetch_status()?; Ok(true) }
-            "fetch-headers" => { self.builtin_fetch_headers()?; Ok(true) }
+            "fetch" => {
+                self.builtin_fetch()?;
+                Ok(true)
+            }
+            "fetch-status" => {
+                self.builtin_fetch_status()?;
+                Ok(true)
+            }
+            "fetch-headers" => {
+                self.builtin_fetch_headers()?;
+                Ok(true)
+            }
             // Macro-generated builtins (proof of concept)
-            "abs" => { self.builtin_abs()?; Ok(true) }
-            "negate" => { self.builtin_negate()?; Ok(true) }
-            "max-of" => { self.builtin_max_of()?; Ok(true) }
-            "min-of" => { self.builtin_min_of()?; Ok(true) }
+            "abs" => {
+                self.builtin_abs()?;
+                Ok(true)
+            }
+            "negate" => {
+                self.builtin_negate()?;
+                Ok(true)
+            }
+            "max-of" => {
+                self.builtin_max_of()?;
+                Ok(true)
+            }
+            "min-of" => {
+                self.builtin_min_of()?;
+                Ok(true)
+            }
             // Unicode operator aliases
-            "Σ" => { self.builtin_sum()?; Ok(true) }
-            "Π" => { self.builtin_product()?; Ok(true) }
-            "÷" => { self.builtin_div_stack()?; Ok(true) }
-            "⋅" => { self.builtin_mul_stack()?; Ok(true) }
-            "√" => { self.builtin_sqrt()?; Ok(true) }
-            "∅" => { self.stack.push(Value::Nil); self.last_exit_code = 0; Ok(true) }
-            "≠" => { self.builtin_ne_stack()?; Ok(true) }
-            "≤" => { self.builtin_le_stack()?; Ok(true) }
-            "≥" => { self.builtin_ge_stack()?; Ok(true) }
-            "μ" => { self.builtin_avg()?; Ok(true) }
+            "Σ" => {
+                self.builtin_sum()?;
+                Ok(true)
+            }
+            "Π" => {
+                self.builtin_product()?;
+                Ok(true)
+            }
+            "÷" => {
+                self.builtin_div_stack()?;
+                Ok(true)
+            }
+            "⋅" => {
+                self.builtin_mul_stack()?;
+                Ok(true)
+            }
+            "√" => {
+                self.builtin_sqrt()?;
+                Ok(true)
+            }
+            "∅" => {
+                self.stack.push(Value::Nil);
+                self.last_exit_code = 0;
+                Ok(true)
+            }
+            "≠" => {
+                self.builtin_ne_stack()?;
+                Ok(true)
+            }
+            "≤" => {
+                self.builtin_le_stack()?;
+                Ok(true)
+            }
+            "≥" => {
+                self.builtin_ge_stack()?;
+                Ok(true)
+            }
+            "μ" => {
+                self.builtin_avg()?;
+                Ok(true)
+            }
             // Watch mode
             #[cfg(feature = "plugins")]
-            "watch" => { self.builtin_watch()?; Ok(true) }
+            "watch" => {
+                self.builtin_watch()?;
+                Ok(true)
+            }
             // Stack-native shell operations (override existing where applicable)
-            "cd" | ".cd" => { self.builtin_cd_native()?; Ok(true) }
-            "touch" => { self.builtin_touch()?; Ok(true) }
-            "mkdir" => { self.builtin_mkdir_native()?; Ok(true) }
-            "mkdir-p" => { self.builtin_mkdir_p()?; Ok(true) }
-            "mktemp" => { self.builtin_mktemp()?; Ok(true) }
-            "mktemp-d" => { self.builtin_mktemp_d()?; Ok(true) }
-            "cp" => { self.builtin_cp()?; Ok(true) }
-            "mv" => { self.builtin_mv()?; Ok(true) }
-            "rm" => { self.builtin_rm()?; Ok(true) }
-            "rm-r" => { self.builtin_rm_r()?; Ok(true) }
-            "ln" => { self.builtin_ln()?; Ok(true) }
-            "realpath" => { self.builtin_realpath()?; Ok(true) }
-            "which" => { self.builtin_which_native()?; Ok(true) }
+            "cd" | ".cd" => {
+                self.builtin_cd_native()?;
+                Ok(true)
+            }
+            "touch" => {
+                self.builtin_touch()?;
+                Ok(true)
+            }
+            "mkdir" => {
+                self.builtin_mkdir_native()?;
+                Ok(true)
+            }
+            "mkdir-p" => {
+                self.builtin_mkdir_p()?;
+                Ok(true)
+            }
+            "mktemp" => {
+                self.builtin_mktemp()?;
+                Ok(true)
+            }
+            "mktemp-d" => {
+                self.builtin_mktemp_d()?;
+                Ok(true)
+            }
+            "cp" => {
+                self.builtin_cp()?;
+                Ok(true)
+            }
+            "mv" => {
+                self.builtin_mv()?;
+                Ok(true)
+            }
+            "rm" => {
+                self.builtin_rm()?;
+                Ok(true)
+            }
+            "rm-r" => {
+                self.builtin_rm_r()?;
+                Ok(true)
+            }
+            "ln" => {
+                self.builtin_ln()?;
+                Ok(true)
+            }
+            "realpath" => {
+                self.builtin_realpath()?;
+                Ok(true)
+            }
+            "which" => {
+                self.builtin_which_native()?;
+                Ok(true)
+            }
             // Note: dirname/basename handled by parser as Expr::Dirname/Basename
-            "extname" => { self.builtin_extname()?; Ok(true) }
-            "glob" => { self.builtin_glob()?; Ok(true) }
-            "ls" => { self.builtin_ls_native()?; Ok(true) }
+            "extname" => {
+                self.builtin_extname()?;
+                Ok(true)
+            }
+            "glob" => {
+                self.builtin_glob()?;
+                Ok(true)
+            }
+            "ls" => {
+                self.builtin_ls_native()?;
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
@@ -438,7 +1044,11 @@ impl Evaluator {
         #[cfg(feature = "plugins")]
         {
             // First, check if this command is provided by a plugin
-            let has_cmd = self.plugin_host.as_ref().map(|h| h.has_command(cmd)).unwrap_or(false);
+            let has_cmd = self
+                .plugin_host
+                .as_ref()
+                .map(|h| h.has_command(cmd))
+                .unwrap_or(false);
 
             if !has_cmd {
                 // Check for hot reloads even if this isn't a plugin command

--- a/src/eval/control.rs
+++ b/src/eval/control.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -141,7 +141,9 @@ impl Evaluator {
                     Err(EvalError::BreakLoop) => {
                         // Clean up marker before breaking
                         while let Some(v) = self.stack.pop() {
-                            if v.is_marker() { break; }
+                            if v.is_marker() {
+                                break;
+                            }
                         }
                         break 'outer;
                     }

--- a/src/eval/encoding.rs
+++ b/src/eval/encoding.rs
@@ -1,10 +1,10 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
     /// Convert Bytes/Media/string to base64 string: data to-base64 -> "base64..."
     pub(crate) fn builtin_to_base64(&mut self) -> Result<(), EvalError> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
 
         let value = self.stack.pop().ok_or_else(|| {
             EvalError::ExecError("to-base64 requires a value on stack".to_string())
@@ -33,7 +33,9 @@ impl Evaluator {
             }
             other => {
                 self.stack.push(other);
-                return Err(EvalError::ExecError("to-base64 requires Bytes, Media, or string".to_string()));
+                return Err(EvalError::ExecError(
+                    "to-base64 requires Bytes, Media, or string".to_string(),
+                ));
             }
         }
 
@@ -42,7 +44,7 @@ impl Evaluator {
 
     /// Convert base64 string to Bytes: "base64..." from-base64 -> Bytes
     pub(crate) fn builtin_from_base64(&mut self) -> Result<(), EvalError> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
 
         let b64_str = self.stack.pop().ok_or_else(|| {
             EvalError::ExecError("from-base64 requires base64 string on stack".to_string())
@@ -52,9 +54,9 @@ impl Evaluator {
             EvalError::ExecError("from-base64 requires base64 string".to_string())
         })?;
 
-        let data = STANDARD.decode(&b64).map_err(|e| {
-            EvalError::ExecError(format!("Invalid base64: {}", e))
-        })?;
+        let data = STANDARD
+            .decode(&b64)
+            .map_err(|e| EvalError::ExecError(format!("Invalid base64: {}", e)))?;
 
         self.stack.push(Value::Bytes(data));
         self.last_exit_code = 0;
@@ -63,9 +65,10 @@ impl Evaluator {
 
     /// Convert Bytes/BigInt to hex string: bytes to-hex -> "abcd..."
     pub(crate) fn builtin_to_hex(&mut self) -> Result<(), EvalError> {
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("to-hex requires a value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("to-hex requires a value on stack".to_string()))?;
 
         match value {
             Value::Bytes(data) => {
@@ -91,7 +94,9 @@ impl Evaluator {
             }
             other => {
                 self.stack.push(other);
-                return Err(EvalError::ExecError("to-hex requires Bytes, BigInt, or string".to_string()));
+                return Err(EvalError::ExecError(
+                    "to-hex requires Bytes, BigInt, or string".to_string(),
+                ));
             }
         }
 
@@ -104,13 +109,12 @@ impl Evaluator {
             EvalError::ExecError("from-hex requires hex string on stack".to_string())
         })?;
 
-        let hex = hex_str.as_arg().ok_or_else(|| {
-            EvalError::ExecError("from-hex requires hex string".to_string())
-        })?;
+        let hex = hex_str
+            .as_arg()
+            .ok_or_else(|| EvalError::ExecError("from-hex requires hex string".to_string()))?;
 
-        let data = hex::decode(&hex).map_err(|e| {
-            EvalError::ExecError(format!("Invalid hex: {}", e))
-        })?;
+        let data =
+            hex::decode(&hex).map_err(|e| EvalError::ExecError(format!("Invalid hex: {}", e)))?;
 
         self.stack.push(Value::Bytes(data));
         self.last_exit_code = 0;
@@ -155,9 +159,7 @@ impl Evaluator {
 
         match value {
             Value::Bytes(data) => {
-                let list: Vec<Value> = data.iter()
-                    .map(|&b| Value::Number(b as f64))
-                    .collect();
+                let list: Vec<Value> = data.iter().map(|&b| Value::Number(b as f64)).collect();
                 self.stack.push(Value::List(list));
                 self.last_exit_code = 0;
             }
@@ -169,7 +171,9 @@ impl Evaluator {
             }
             other => {
                 self.stack.push(other);
-                return Err(EvalError::ExecError("to-bytes requires Bytes or BigInt".to_string()));
+                return Err(EvalError::ExecError(
+                    "to-bytes requires Bytes or BigInt".to_string(),
+                ));
             }
         }
 
@@ -178,15 +182,15 @@ impl Evaluator {
 
     /// Convert Bytes to UTF-8 string: bytes to-string -> "hello"
     pub(crate) fn builtin_bytes_to_string(&mut self) -> Result<(), EvalError> {
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("to-string requires Bytes on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("to-string requires Bytes on stack".to_string()))?;
 
         match value {
             Value::Bytes(data) => {
-                let s = String::from_utf8(data).map_err(|e| {
-                    EvalError::ExecError(format!("Invalid UTF-8: {}", e))
-                })?;
+                let s = String::from_utf8(data)
+                    .map_err(|e| EvalError::ExecError(format!("Invalid UTF-8: {}", e)))?;
                 self.stack.push(Value::Literal(s));
                 self.last_exit_code = 0;
             }
@@ -197,7 +201,9 @@ impl Evaluator {
                     self.last_exit_code = 0;
                 } else {
                     self.stack.push(other);
-                    return Err(EvalError::ExecError("to-string requires convertible value".to_string()));
+                    return Err(EvalError::ExecError(
+                        "to-string requires convertible value".to_string(),
+                    ));
                 }
             }
         }
@@ -207,9 +213,10 @@ impl Evaluator {
 
     /// Get length of Bytes: bytes len -> number
     pub(crate) fn builtin_bytes_len(&mut self) -> Result<(), EvalError> {
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("len requires value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("len requires value on stack".to_string()))?;
 
         match value {
             Value::Bytes(data) => {
@@ -220,7 +227,9 @@ impl Evaluator {
             other => {
                 // Put it back and let regular len handle it
                 self.stack.push(other);
-                Err(EvalError::ExecError("Not bytes - fallback to string len".to_string()))
+                Err(EvalError::ExecError(
+                    "Not bytes - fallback to string len".to_string(),
+                ))
             }
         }
     }
@@ -231,11 +240,12 @@ impl Evaluator {
 
     /// SHA-256 hash: "hello" sha256 -> Bytes
     pub(crate) fn builtin_sha256(&mut self) -> Result<(), EvalError> {
-        use sha2::{Sha256, Digest};
+        use sha2::{Digest, Sha256};
 
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("sha256 requires a value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("sha256 requires a value on stack".to_string()))?;
 
         let data = match &value {
             Value::Literal(s) => s.as_bytes().to_vec(),
@@ -243,7 +253,9 @@ impl Evaluator {
             Value::Bytes(b) => b.clone(),
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("sha256 requires string or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "sha256 requires string or Bytes".to_string(),
+                ));
             }
         };
 
@@ -258,11 +270,12 @@ impl Evaluator {
 
     /// SHA-384 hash: "hello" sha384 -> Bytes
     pub(crate) fn builtin_sha384(&mut self) -> Result<(), EvalError> {
-        use sha2::{Sha384, Digest};
+        use sha2::{Digest, Sha384};
 
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("sha384 requires a value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("sha384 requires a value on stack".to_string()))?;
 
         let data = match &value {
             Value::Literal(s) => s.as_bytes().to_vec(),
@@ -270,7 +283,9 @@ impl Evaluator {
             Value::Bytes(b) => b.clone(),
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("sha384 requires string or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "sha384 requires string or Bytes".to_string(),
+                ));
             }
         };
 
@@ -285,11 +300,12 @@ impl Evaluator {
 
     /// SHA-512 hash: "hello" sha512 -> Bytes
     pub(crate) fn builtin_sha512(&mut self) -> Result<(), EvalError> {
-        use sha2::{Sha512, Digest};
+        use sha2::{Digest, Sha512};
 
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("sha512 requires a value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("sha512 requires a value on stack".to_string()))?;
 
         let data = match &value {
             Value::Literal(s) => s.as_bytes().to_vec(),
@@ -297,7 +313,9 @@ impl Evaluator {
             Value::Bytes(b) => b.clone(),
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("sha512 requires string or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "sha512 requires string or Bytes".to_string(),
+                ));
             }
         };
 
@@ -312,7 +330,7 @@ impl Evaluator {
 
     /// SHA3-256 hash: "hello" sha3-256 -> Bytes
     pub(crate) fn builtin_sha3_256(&mut self) -> Result<(), EvalError> {
-        use sha3::{Sha3_256, Digest};
+        use sha3::{Digest, Sha3_256};
 
         let value = self.stack.pop().ok_or_else(|| {
             EvalError::ExecError("sha3-256 requires a value on stack".to_string())
@@ -324,7 +342,9 @@ impl Evaluator {
             Value::Bytes(b) => b.clone(),
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("sha3-256 requires string or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "sha3-256 requires string or Bytes".to_string(),
+                ));
             }
         };
 
@@ -339,7 +359,7 @@ impl Evaluator {
 
     /// SHA3-384 hash: "hello" sha3-384 -> Bytes
     pub(crate) fn builtin_sha3_384(&mut self) -> Result<(), EvalError> {
-        use sha3::{Sha3_384, Digest};
+        use sha3::{Digest, Sha3_384};
 
         let value = self.stack.pop().ok_or_else(|| {
             EvalError::ExecError("sha3-384 requires a value on stack".to_string())
@@ -351,7 +371,9 @@ impl Evaluator {
             Value::Bytes(b) => b.clone(),
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("sha3-384 requires string or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "sha3-384 requires string or Bytes".to_string(),
+                ));
             }
         };
 
@@ -366,7 +388,7 @@ impl Evaluator {
 
     /// SHA3-512 hash: "hello" sha3-512 -> Bytes
     pub(crate) fn builtin_sha3_512(&mut self) -> Result<(), EvalError> {
-        use sha3::{Sha3_512, Digest};
+        use sha3::{Digest, Sha3_512};
 
         let value = self.stack.pop().ok_or_else(|| {
             EvalError::ExecError("sha3-512 requires a value on stack".to_string())
@@ -378,7 +400,9 @@ impl Evaluator {
             Value::Bytes(b) => b.clone(),
             _ => {
                 self.stack.push(value);
-                return Err(EvalError::ExecError("sha3-512 requires string or Bytes".to_string()));
+                return Err(EvalError::ExecError(
+                    "sha3-512 requires string or Bytes".to_string(),
+                ));
             }
         };
 
@@ -393,28 +417,29 @@ impl Evaluator {
 
     /// SHA-256 hash of file: "path" sha256-file -> Bytes
     pub(crate) fn builtin_sha256_file(&mut self) -> Result<(), EvalError> {
-        use sha2::{Sha256, Digest};
+        use sha2::{Digest, Sha256};
         use std::io::Read;
 
         let value = self.stack.pop().ok_or_else(|| {
             EvalError::ExecError("sha256-file requires path on stack".to_string())
         })?;
 
-        let path = value.as_arg().ok_or_else(|| {
-            EvalError::ExecError("sha256-file requires path string".to_string())
-        })?;
+        let path = value
+            .as_arg()
+            .ok_or_else(|| EvalError::ExecError("sha256-file requires path string".to_string()))?;
 
-        let mut file = std::fs::File::open(&path).map_err(|e| {
-            EvalError::ExecError(format!("sha256-file: {}: {}", path, e))
-        })?;
+        let mut file = std::fs::File::open(&path)
+            .map_err(|e| EvalError::ExecError(format!("sha256-file: {}: {}", path, e)))?;
 
         let mut hasher = Sha256::new();
         let mut buffer = [0u8; 8192];
         loop {
-            let n = file.read(&mut buffer).map_err(|e| {
-                EvalError::ExecError(format!("sha256-file read error: {}", e))
-            })?;
-            if n == 0 { break; }
+            let n = file
+                .read(&mut buffer)
+                .map_err(|e| EvalError::ExecError(format!("sha256-file read error: {}", e)))?;
+            if n == 0 {
+                break;
+            }
             hasher.update(&buffer[..n]);
         }
 
@@ -432,14 +457,12 @@ impl Evaluator {
         let n = self.pop_number("read-bytes")? as usize;
         let path = self.pop_string()?;
 
-        let mut file = std::fs::File::open(&path).map_err(|e| {
-            EvalError::ExecError(format!("read-bytes: {}: {}", path, e))
-        })?;
+        let mut file = std::fs::File::open(&path)
+            .map_err(|e| EvalError::ExecError(format!("read-bytes: {}: {}", path, e)))?;
 
         let mut buf = vec![0u8; n];
-        file.read_exact(&mut buf).map_err(|e| {
-            EvalError::ExecError(format!("read-bytes: {}: {}", path, e))
-        })?;
+        file.read_exact(&mut buf)
+            .map_err(|e| EvalError::ExecError(format!("read-bytes: {}: {}", path, e)))?;
 
         self.stack.push(Value::Bytes(buf));
         self.last_exit_code = 0;
@@ -448,7 +471,7 @@ impl Evaluator {
 
     /// SHA3-256 hash of file: "path" sha3-256-file -> Bytes
     pub(crate) fn builtin_sha3_256_file(&mut self) -> Result<(), EvalError> {
-        use sha3::{Sha3_256, Digest};
+        use sha3::{Digest, Sha3_256};
         use std::io::Read;
 
         let value = self.stack.pop().ok_or_else(|| {
@@ -459,17 +482,18 @@ impl Evaluator {
             EvalError::ExecError("sha3-256-file requires path string".to_string())
         })?;
 
-        let mut file = std::fs::File::open(&path).map_err(|e| {
-            EvalError::ExecError(format!("sha3-256-file: {}: {}", path, e))
-        })?;
+        let mut file = std::fs::File::open(&path)
+            .map_err(|e| EvalError::ExecError(format!("sha3-256-file: {}: {}", path, e)))?;
 
         let mut hasher = Sha3_256::new();
         let mut buffer = [0u8; 8192];
         loop {
-            let n = file.read(&mut buffer).map_err(|e| {
-                EvalError::ExecError(format!("sha3-256-file read error: {}", e))
-            })?;
-            if n == 0 { break; }
+            let n = file
+                .read(&mut buffer)
+                .map_err(|e| EvalError::ExecError(format!("sha3-256-file read error: {}", e)))?;
+            if n == 0 {
+                break;
+            }
             hasher.update(&buffer[..n]);
         }
 

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -2,7 +2,7 @@ use super::{Evaluator, EvalError};
 use crate::ast::{Expr, Value};
 use glob::glob;
 use num_bigint::BigUint;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 impl Evaluator {
     /// Expand tilde (~) to home directory
@@ -307,7 +307,7 @@ impl Evaluator {
                     map.insert(key.to_string(), value);
                 } else {
                     // Need to recurse
-                    let current = map.get(key).cloned().unwrap_or_else(|| Value::Map(HashMap::new()));
+                    let current = map.get(key).cloned().unwrap_or_else(|| Value::Map(IndexMap::new()));
                     let new_val = self.deep_set_recursive(current, remaining, value)?;
                     map.insert(key.to_string(), new_val);
                 }
@@ -315,7 +315,7 @@ impl Evaluator {
             }
             Value::Nil => {
                 // Create nested structure
-                let mut map = HashMap::new();
+                let mut map = IndexMap::new();
                 if remaining.is_empty() {
                     map.insert(key.to_string(), value);
                 } else {

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -136,7 +136,7 @@ impl Evaluator {
             Value::Block(exprs) => Ok(exprs),
             other => Err(EvalError::TypeError {
                 expected: "block".into(),
-                got: format!("{:?}", other),
+                got: other.type_name().to_string(),
             }),
         }
     }
@@ -145,7 +145,7 @@ impl Evaluator {
         let value = self.pop_value_or_err()?;
         value.as_arg().ok_or_else(|| EvalError::TypeError {
             expected: "string".into(),
-            got: format!("{:?}", value),
+            got: value.type_name().to_string(),
         })
     }
 
@@ -200,14 +200,14 @@ impl Evaluator {
                         }
                         _ => Err(EvalError::TypeError {
                             expected: "Number".into(),
-                            got: format!("{:?}", v),
+                            got: v.type_name().to_string(),
                         }),
                     })
                     .collect()
             }
             _ => Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         }
     }
@@ -326,7 +326,7 @@ impl Evaluator {
             }
             _ => Err(EvalError::TypeError {
                 expected: "Record".into(),
-                got: format!("{:?}", target),
+                got: target.type_name().to_string(),
             }),
         }
     }

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -1,8 +1,8 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::{Expr, Value};
 use glob::glob;
-use num_bigint::BigUint;
 use indexmap::IndexMap;
+use num_bigint::BigUint;
 
 impl Evaluator {
     /// Expand tilde (~) to home directory
@@ -38,7 +38,11 @@ impl Evaluator {
                     if let Some(val) = self.lookup_var_as_string(&var_name) {
                         result.push_str(&val);
                     }
-                } else if chars.peek().map(|c| c.is_ascii_alphabetic() || *c == '_').unwrap_or(false) {
+                } else if chars
+                    .peek()
+                    .map(|c| c.is_ascii_alphabetic() || *c == '_')
+                    .unwrap_or(false)
+                {
                     // $VAR syntax - collect alphanumeric and underscore
                     let mut var_name = String::new();
                     while let Some(&ch) = chars.peek() {
@@ -151,9 +155,10 @@ impl Evaluator {
 
     /// Helper to pop a number from stack (handles Literal/Output too)
     pub(crate) fn pop_number(&mut self, op: &str) -> Result<f64, EvalError> {
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError(format!("{} requires a number on stack", op))
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError(format!("{} requires a number on stack", op)))?;
         match &value {
             Value::Number(n) => Ok(*n),
             Value::Literal(s) | Value::Output(s) => {
@@ -169,9 +174,10 @@ impl Evaluator {
 
     /// Helper to pop a BigInt from stack
     pub(crate) fn pop_bigint(&mut self, op: &str) -> Result<BigUint, EvalError> {
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError(format!("{} requires BigInt on stack", op))
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError(format!("{} requires BigInt on stack", op)))?;
         match value {
             Value::BigInt(n) => Ok(n),
             other => {
@@ -183,28 +189,28 @@ impl Evaluator {
 
     /// Helper: Pop a numeric list from the stack
     pub(crate) fn pop_number_list(&mut self) -> Result<Vec<f64>, EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("vector operation requires list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("vector operation requires list".into()))?;
 
         match val {
-            Value::List(items) => {
-                items.iter()
-                    .map(|v| match v {
-                        Value::Number(n) => Ok(*n),
-                        Value::Literal(s) | Value::Output(s) => {
-                            s.trim().parse::<f64>().map_err(|_|
-                                EvalError::TypeError {
-                                    expected: "Number".into(),
-                                    got: format!("'{}'", s),
-                                })
-                        }
-                        _ => Err(EvalError::TypeError {
+            Value::List(items) => items
+                .iter()
+                .map(|v| match v {
+                    Value::Number(n) => Ok(*n),
+                    Value::Literal(s) | Value::Output(s) => {
+                        s.trim().parse::<f64>().map_err(|_| EvalError::TypeError {
                             expected: "Number".into(),
-                            got: v.type_name().to_string(),
-                        }),
-                    })
-                    .collect()
-            }
+                            got: format!("'{}'", s),
+                        })
+                    }
+                    _ => Err(EvalError::TypeError {
+                        expected: "Number".into(),
+                        got: v.type_name().to_string(),
+                    }),
+                })
+                .collect(),
             _ => Err(EvalError::TypeError {
                 expected: "List".into(),
                 got: val.type_name().to_string(),
@@ -213,7 +219,10 @@ impl Evaluator {
     }
 
     /// Convert a block to command + args
-    pub(crate) fn block_to_cmd_args(&self, exprs: &[Expr]) -> Result<(String, Vec<String>), EvalError> {
+    pub(crate) fn block_to_cmd_args(
+        &self,
+        exprs: &[Expr],
+    ) -> Result<(String, Vec<String>), EvalError> {
         let mut parts: Vec<String> = Vec::new();
 
         for expr in exprs {
@@ -260,9 +269,7 @@ impl Evaluator {
 
         for part in parts {
             current = match current {
-                Value::Map(map) => {
-                    map.get(part).cloned().unwrap_or(Value::Nil)
-                }
+                Value::Map(map) => map.get(part).cloned().unwrap_or(Value::Nil),
                 Value::List(items) => {
                     if let Ok(idx) = part.parse::<usize>() {
                         items.get(idx).cloned().unwrap_or(Value::Nil)
@@ -283,7 +290,12 @@ impl Evaluator {
     }
 
     /// Deep set a value at a dot-path (e.g., "server.port")
-    pub(crate) fn deep_set(&self, target: Value, path: &str, value: Value) -> Result<Value, EvalError> {
+    pub(crate) fn deep_set(
+        &self,
+        target: Value,
+        path: &str,
+        value: Value,
+    ) -> Result<Value, EvalError> {
         let parts: Vec<&str> = path.split('.').collect();
         if parts.is_empty() {
             return Ok(target);
@@ -292,7 +304,12 @@ impl Evaluator {
         self.deep_set_recursive(target, &parts, value)
     }
 
-    pub(crate) fn deep_set_recursive(&self, target: Value, path: &[&str], value: Value) -> Result<Value, EvalError> {
+    pub(crate) fn deep_set_recursive(
+        &self,
+        target: Value,
+        path: &[&str],
+        value: Value,
+    ) -> Result<Value, EvalError> {
         if path.is_empty() {
             return Ok(value);
         }
@@ -307,7 +324,10 @@ impl Evaluator {
                     map.insert(key.to_string(), value);
                 } else {
                     // Need to recurse
-                    let current = map.get(key).cloned().unwrap_or_else(|| Value::Map(IndexMap::new()));
+                    let current = map
+                        .get(key)
+                        .cloned()
+                        .unwrap_or_else(|| Value::Map(IndexMap::new()));
                     let new_val = self.deep_set_recursive(current, remaining, value)?;
                     map.insert(key.to_string(), new_val);
                 }

--- a/src/eval/http.rs
+++ b/src/eval/http.rs
@@ -5,7 +5,7 @@
 //! - fetch-status: Return status code as number
 //! - fetch-headers: Return response headers as Map
 
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use std::collections::HashMap;
 
@@ -53,11 +53,9 @@ impl Evaluator {
             }
             1 => {
                 // Just URL
-                url = args[0].as_arg().ok_or_else(|| {
-                    EvalError::TypeError {
-                        expected: "URL string".into(),
-                        got: args[0].type_name().to_string(),
-                    }
+                url = args[0].as_arg().ok_or_else(|| EvalError::TypeError {
+                    expected: "URL string".into(),
+                    got: args[0].type_name().to_string(),
                 })?;
             }
             2 => {
@@ -127,14 +125,16 @@ impl Evaluator {
     pub(crate) fn builtin_fetch_status(&mut self) -> Result<(), EvalError> {
         // Pop URL and optional method
         let mut method = "GET".to_string();
-        let url_val = self.stack.pop().ok_or_else(|| {
-            EvalError::StackUnderflow("fetch-status requires URL".into())
-        })?;
+        let url_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("fetch-status requires URL".into()))?;
 
         // Check if there's a method on top
         let url = if is_http_method(&url_val.as_arg().unwrap_or_default()) {
             method = url_val.as_arg().unwrap_or_default().to_uppercase();
-            self.stack.pop()
+            self.stack
+                .pop()
                 .ok_or_else(|| EvalError::StackUnderflow("fetch-status requires URL".into()))?
                 .as_arg()
                 .ok_or_else(|| EvalError::TypeError {
@@ -159,13 +159,15 @@ impl Evaluator {
     pub(crate) fn builtin_fetch_headers(&mut self) -> Result<(), EvalError> {
         // Pop URL and optional method
         let mut method = "GET".to_string();
-        let url_val = self.stack.pop().ok_or_else(|| {
-            EvalError::StackUnderflow("fetch-headers requires URL".into())
-        })?;
+        let url_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("fetch-headers requires URL".into()))?;
 
         let url = if is_http_method(&url_val.as_arg().unwrap_or_default()) {
             method = url_val.as_arg().unwrap_or_default().to_uppercase();
-            self.stack.pop()
+            self.stack
+                .pop()
                 .ok_or_else(|| EvalError::StackUnderflow("fetch-headers requires URL".into()))?
                 .as_arg()
                 .ok_or_else(|| EvalError::TypeError {
@@ -182,7 +184,8 @@ impl Evaluator {
         let response = self.do_http_request(&method, &url, None, None)?;
 
         // Convert headers to Map
-        let headers_map: indexmap::IndexMap<String, Value> = response.headers
+        let headers_map: indexmap::IndexMap<String, Value> = response
+            .headers
             .into_iter()
             .map(|(k, v)| (k, Value::Literal(v)))
             .collect();
@@ -273,9 +276,7 @@ impl Evaluator {
                     body,
                 })
             }
-            Err(e) => {
-                Err(EvalError::ExecError(format!("HTTP request failed: {}", e)))
-            }
+            Err(e) => Err(EvalError::ExecError(format!("HTTP request failed: {}", e))),
         }
     }
 }
@@ -314,9 +315,7 @@ fn json_to_value(json: serde_json::Value) -> Value {
             }
         }
         serde_json::Value::String(s) => Value::Literal(s),
-        serde_json::Value::Array(arr) => {
-            Value::List(arr.into_iter().map(json_to_value).collect())
-        }
+        serde_json::Value::Array(arr) => Value::List(arr.into_iter().map(json_to_value).collect()),
         serde_json::Value::Object(obj) => {
             let map: indexmap::IndexMap<String, Value> = obj
                 .into_iter()

--- a/src/eval/http.rs
+++ b/src/eval/http.rs
@@ -56,7 +56,7 @@ impl Evaluator {
                 url = args[0].as_arg().ok_or_else(|| {
                     EvalError::TypeError {
                         expected: "URL string".into(),
-                        got: format!("{:?}", args[0]),
+                        got: args[0].type_name().to_string(),
                     }
                 })?;
             }
@@ -144,7 +144,7 @@ impl Evaluator {
         } else {
             url_val.as_arg().ok_or_else(|| EvalError::TypeError {
                 expected: "URL string".into(),
-                got: format!("{:?}", url_val),
+                got: url_val.type_name().to_string(),
             })?
         };
 
@@ -175,7 +175,7 @@ impl Evaluator {
         } else {
             url_val.as_arg().ok_or_else(|| EvalError::TypeError {
                 expected: "URL string".into(),
-                got: format!("{:?}", url_val),
+                got: url_val.type_name().to_string(),
             })?
         };
 

--- a/src/eval/http.rs
+++ b/src/eval/http.rs
@@ -182,7 +182,7 @@ impl Evaluator {
         let response = self.do_http_request(&method, &url, None, None)?;
 
         // Convert headers to Map
-        let headers_map: HashMap<String, Value> = response.headers
+        let headers_map: indexmap::IndexMap<String, Value> = response.headers
             .into_iter()
             .map(|(k, v)| (k, Value::Literal(v)))
             .collect();
@@ -318,7 +318,7 @@ fn json_to_value(json: serde_json::Value) -> Value {
             Value::List(arr.into_iter().map(json_to_value).collect())
         }
         serde_json::Value::Object(obj) => {
-            let map: HashMap<String, Value> = obj
+            let map: indexmap::IndexMap<String, Value> = obj
                 .into_iter()
                 .map(|(k, v)| (k, json_to_value(v)))
                 .collect();

--- a/src/eval/image.rs
+++ b/src/eval/image.rs
@@ -111,7 +111,7 @@ impl Evaluator {
 
         match media {
             Value::Media { mime_type, data, width, height, alt, source } => {
-                let mut map = std::collections::HashMap::new();
+                let mut map = indexmap::IndexMap::new();
                 map.insert("mime_type".to_string(), Value::Literal(mime_type.clone()));
                 map.insert("size".to_string(), Value::Number(data.len() as f64));
                 if let Some(w) = width {

--- a/src/eval/image.rs
+++ b/src/eval/image.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -8,16 +8,15 @@ impl Evaluator {
             EvalError::ExecError("image-load requires a file path on stack".to_string())
         })?;
 
-        let path = path_val.as_arg().ok_or_else(|| {
-            EvalError::ExecError("image-load requires a string path".to_string())
-        })?;
+        let path = path_val
+            .as_arg()
+            .ok_or_else(|| EvalError::ExecError("image-load requires a string path".to_string()))?;
 
         self.load_image_from_path(&path)
     }
 
     /// Common image loading logic
     pub(crate) fn load_image_from_path(&mut self, path: &str) -> Result<(), EvalError> {
-
         // Expand tilde if present
         let expanded_path = if path.starts_with('~') {
             if let Ok(home) = std::env::var("HOME") {
@@ -35,7 +34,12 @@ impl Evaluator {
         })?;
 
         // Detect MIME type from extension
-        let mime_type = match expanded_path.rsplit('.').next().map(|s| s.to_lowercase()).as_deref() {
+        let mime_type = match expanded_path
+            .rsplit('.')
+            .next()
+            .map(|s| s.to_lowercase())
+            .as_deref()
+        {
             Some("png") => "image/png",
             Some("jpg") | Some("jpeg") => "image/jpeg",
             Some("gif") => "image/gif",
@@ -96,7 +100,9 @@ impl Evaluator {
             }
             _ => {
                 self.stack.push(media);
-                return Err(EvalError::ExecError("image-show requires a Media value".to_string()));
+                return Err(EvalError::ExecError(
+                    "image-show requires a Media value".to_string(),
+                ));
             }
         }
 
@@ -110,7 +116,14 @@ impl Evaluator {
         })?;
 
         match media {
-            Value::Media { mime_type, data, width, height, alt, source } => {
+            Value::Media {
+                mime_type,
+                data,
+                width,
+                height,
+                alt,
+                source,
+            } => {
                 let mut map = indexmap::IndexMap::new();
                 map.insert("mime_type".to_string(), Value::Literal(mime_type.clone()));
                 map.insert("size".to_string(), Value::Number(data.len() as f64));
@@ -131,7 +144,9 @@ impl Evaluator {
             }
             other => {
                 self.stack.push(other);
-                return Err(EvalError::ExecError("image-info requires a Media value".to_string()));
+                return Err(EvalError::ExecError(
+                    "image-info requires a Media value".to_string(),
+                ));
             }
         }
 

--- a/src/eval/list.rs
+++ b/src/eval/list.rs
@@ -283,7 +283,7 @@ impl Evaluator {
             self.local_values.push(std::collections::HashMap::new());
         }
         if let Some(scope) = self.local_values.last_mut() {
-            for (name, val) in names.into_iter().zip(values.into_iter()) {
+            for (name, val) in names.into_iter().zip(values) {
                 scope.insert(name, val);
             }
         }

--- a/src/eval/list.rs
+++ b/src/eval/list.rs
@@ -53,7 +53,7 @@ impl Evaluator {
                 .collect(),
             _ => return Err(EvalError::TypeError {
                 expected: "list of keys".into(),
-                got: format!("{:?}", keys_val),
+                got: keys_val.type_name().to_string(),
             }),
         };
 
@@ -61,7 +61,7 @@ impl Evaluator {
             Value::Map(m) => m,
             _ => return Err(EvalError::TypeError {
                 expected: "record".into(),
-                got: format!("{:?}", record_val),
+                got: record_val.type_name().to_string(),
             }),
         };
 
@@ -85,7 +85,7 @@ impl Evaluator {
             Value::Map(m) => m,
             _ => return Err(EvalError::TypeError {
                 expected: "record".into(),
-                got: format!("{:?}", record_val),
+                got: record_val.type_name().to_string(),
             }),
         };
 
@@ -112,7 +112,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "list".into(),
-                got: format!("{:?}", list_val),
+                got: list_val.type_name().to_string(),
             }),
         };
 
@@ -140,7 +140,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "list".into(),
-                got: format!("{:?}", list_val),
+                got: list_val.type_name().to_string(),
             }),
         };
 
@@ -174,7 +174,7 @@ impl Evaluator {
             })?,
             _ => return Err(EvalError::TypeError {
                 expected: "integer".into(),
-                got: format!("{:?}", n_val),
+                got: n_val.type_name().to_string(),
             }),
         };
 
@@ -182,7 +182,7 @@ impl Evaluator {
             Value::List(items) => items,
             _ => return Err(EvalError::TypeError {
                 expected: "list".into(),
-                got: format!("{:?}", list_val),
+                got: list_val.type_name().to_string(),
             }),
         };
 
@@ -214,7 +214,7 @@ impl Evaluator {
                 .collect(),
             _ => return Err(EvalError::TypeError {
                 expected: "list of names".into(),
-                got: format!("{:?}", names_val),
+                got: names_val.type_name().to_string(),
             }),
         };
 
@@ -229,7 +229,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "list or record".into(),
-                got: format!("{:?}", value),
+                got: value.type_name().to_string(),
             }),
         };
 

--- a/src/eval/list.rs
+++ b/src/eval/list.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -42,27 +42,33 @@ impl Evaluator {
     /// fields: {record} ["key1" "key2"] fields -> val1 val2
     /// Extract specific fields from a record (no marker)
     pub(crate) fn builtin_fields(&mut self) -> Result<(), EvalError> {
-        let keys_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("fields requires list of keys".into()))?;
-        let record_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("fields requires a record".into()))?;
+        let keys_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("fields requires list of keys".into()))?;
+        let record_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("fields requires a record".into()))?;
 
         let keys: Vec<String> = match keys_val {
-            Value::List(items) => items.into_iter()
-                .filter_map(|v| v.as_arg())
-                .collect(),
-            _ => return Err(EvalError::TypeError {
-                expected: "list of keys".into(),
-                got: keys_val.type_name().to_string(),
-            }),
+            Value::List(items) => items.into_iter().filter_map(|v| v.as_arg()).collect(),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list of keys".into(),
+                    got: keys_val.type_name().to_string(),
+                })
+            }
         };
 
         let map = match record_val {
             Value::Map(m) => m,
-            _ => return Err(EvalError::TypeError {
-                expected: "record".into(),
-                got: record_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "record".into(),
+                    got: record_val.type_name().to_string(),
+                })
+            }
         };
 
         // Push values for each key (Nil if missing)
@@ -78,15 +84,19 @@ impl Evaluator {
     /// fields-keys: {record} fields-keys -> marker k1 v1 k2 v2 ...
     /// Extract key-value pairs from a record
     pub(crate) fn builtin_fields_keys(&mut self) -> Result<(), EvalError> {
-        let record_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("fields-keys requires a record".into()))?;
+        let record_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("fields-keys requires a record".into()))?;
 
         let map = match record_val {
             Value::Map(m) => m,
-            _ => return Err(EvalError::TypeError {
-                expected: "record".into(),
-                got: record_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "record".into(),
+                    got: record_val.type_name().to_string(),
+                })
+            }
         };
 
         // Push marker
@@ -105,15 +115,19 @@ impl Evaluator {
     /// spread-head: [list] spread-head -> head [tail]
     /// Split first element from rest
     pub(crate) fn builtin_spread_head(&mut self) -> Result<(), EvalError> {
-        let list_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("spread-head requires a list".into()))?;
+        let list_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("spread-head requires a list".into()))?;
 
         let items = match list_val {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "list".into(),
-                got: list_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list".into(),
+                    got: list_val.type_name().to_string(),
+                })
+            }
         };
 
         if items.is_empty() {
@@ -133,15 +147,19 @@ impl Evaluator {
     /// spread-tail: [list] spread-tail -> [init] last
     /// Split last element from init
     pub(crate) fn builtin_spread_tail(&mut self) -> Result<(), EvalError> {
-        let list_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("spread-tail requires a list".into()))?;
+        let list_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("spread-tail requires a list".into()))?;
 
         let items = match list_val {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "list".into(),
-                got: list_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list".into(),
+                    got: list_val.type_name().to_string(),
+                })
+            }
         };
 
         if items.is_empty() {
@@ -161,35 +179,45 @@ impl Evaluator {
     /// spread-n: [list] N spread-n -> item1 item2 ... itemN [rest]
     /// Take first N elements, leave rest as list
     pub(crate) fn builtin_spread_n(&mut self) -> Result<(), EvalError> {
-        let n_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("spread-n requires count".into()))?;
-        let list_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("spread-n requires a list".into()))?;
+        let n_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("spread-n requires count".into()))?;
+        let list_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("spread-n requires a list".into()))?;
 
         let n: usize = match n_val {
             Value::Number(num) => num as usize,
-            Value::Literal(s) | Value::Output(s) => s.parse().map_err(|_| EvalError::TypeError {
-                expected: "integer".into(),
-                got: s,
-            })?,
-            _ => return Err(EvalError::TypeError {
-                expected: "integer".into(),
-                got: n_val.type_name().to_string(),
-            }),
+            Value::Literal(s) | Value::Output(s) => {
+                s.parse().map_err(|_| EvalError::TypeError {
+                    expected: "integer".into(),
+                    got: s,
+                })?
+            }
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "integer".into(),
+                    got: n_val.type_name().to_string(),
+                })
+            }
         };
 
         let items = match list_val {
             Value::List(items) => items,
-            _ => return Err(EvalError::TypeError {
-                expected: "list".into(),
-                got: list_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list".into(),
+                    got: list_val.type_name().to_string(),
+                })
+            }
         };
 
         // Take up to N items
         let take_count = n.min(items.len());
-        for i in 0..take_count {
-            self.stack.push(items[i].clone());
+        for item in items.iter().take(take_count) {
+            self.stack.push(item.clone());
         }
 
         // Push rest as list
@@ -203,19 +231,23 @@ impl Evaluator {
     /// spread-to: value ["name1" "name2" ...] spread-to -> (binds to locals)
     /// Bind values to named locals
     pub(crate) fn builtin_spread_to(&mut self) -> Result<(), EvalError> {
-        let names_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("spread-to requires list of names".into()))?;
-        let value = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("spread-to requires a value".into()))?;
+        let names_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("spread-to requires list of names".into()))?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("spread-to requires a value".into()))?;
 
         let names: Vec<String> = match names_val {
-            Value::List(items) => items.into_iter()
-                .filter_map(|v| v.as_arg())
-                .collect(),
-            _ => return Err(EvalError::TypeError {
-                expected: "list of names".into(),
-                got: names_val.type_name().to_string(),
-            }),
+            Value::List(items) => items.into_iter().filter_map(|v| v.as_arg()).collect(),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list of names".into(),
+                    got: names_val.type_name().to_string(),
+                })
+            }
         };
 
         // Get values to bind
@@ -223,21 +255,25 @@ impl Evaluator {
             Value::List(items) => items,
             Value::Map(map) => {
                 // For records, extract values in order of names
-                names.iter()
+                names
+                    .iter()
                     .map(|name| map.get(name).cloned().unwrap_or(Value::Nil))
                     .collect()
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "list or record".into(),
-                got: value.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "list or record".into(),
+                    got: value.type_name().to_string(),
+                })
+            }
         };
 
         // Check length match for lists
         if values.len() < names.len() {
             return Err(EvalError::ExecError(format!(
                 "spread-to: {} names but only {} values",
-                names.len(), values.len()
+                names.len(),
+                values.len()
             )));
         }
 

--- a/src/eval/list.rs
+++ b/src/eval/list.rs
@@ -20,7 +20,7 @@ impl Evaluator {
                 }
             }
             Value::Map(map) => {
-                // Spread map values onto stack (order undefined per spec)
+                // Spread map values onto stack (insertion order)
                 for (_key, val) in map {
                     self.stack.push(val);
                 }
@@ -92,7 +92,7 @@ impl Evaluator {
         // Push marker
         self.stack.push(Value::Marker);
 
-        // Push key-value pairs (order undefined)
+        // Push key-value pairs (insertion order)
         for (key, val) in map {
             self.stack.push(Value::Literal(key));
             self.stack.push(val);

--- a/src/eval/local.rs
+++ b/src/eval/local.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -17,16 +17,21 @@ impl Evaluator {
         let name = self.pop_string()?;
 
         // Pop the value (preserve its type)
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::StackUnderflow("local requires a value".into())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("local requires a value".into()))?;
 
         // Check if this is a structured value that needs special storage
         let is_structured = matches!(
             &value,
-            Value::List(_) | Value::Table { .. } | Value::Map(_) |
-            Value::Media { .. } | Value::Bytes(_) | Value::BigInt(_) |
-            Value::Block(_)
+            Value::List(_)
+                | Value::Table { .. }
+                | Value::Map(_)
+                | Value::Media { .. }
+                | Value::Bytes(_)
+                | Value::BigInt(_)
+                | Value::Block(_)
         );
 
         if is_structured {
@@ -36,10 +41,9 @@ impl Evaluator {
             }
             // Also save env var state for cleanup (even if we don't use it)
             let current_scope = self.local_scopes.last_mut().unwrap();
-            if !current_scope.contains_key(&name) {
-                let old_value = std::env::var(&name).ok();
-                current_scope.insert(name, old_value);
-            }
+            current_scope
+                .entry(name)
+                .or_insert_with_key(|name| std::env::var(name).ok());
         } else {
             // Primitive value - use env vars for shell compatibility
             let string_value = match &value {

--- a/src/eval/macro_builtins.rs
+++ b/src/eval/macro_builtins.rs
@@ -1,6 +1,6 @@
 //! Builtins generated via the stack_builtin! macro (proof of concept)
 
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {

--- a/src/eval/macros.rs
+++ b/src/eval/macros.rs
@@ -51,7 +51,7 @@ macro_rules! stack_builtin {
                 }).collect(),
                 _ => return Err(EvalError::TypeError {
                     expected: "List".into(),
-                    got: format!("{:?}", val),
+                    got: val.type_name().to_string(),
                 }),
             };
             let result: f64 = $body;
@@ -74,7 +74,7 @@ macro_rules! stack_builtin {
                 }).collect(),
                 _ => return Err(EvalError::TypeError {
                     expected: "List".into(),
-                    got: format!("{:?}", val),
+                    got: val.type_name().to_string(),
                 }),
             };
             let result: Value = $body;

--- a/src/eval/macros.rs
+++ b/src/eval/macros.rs
@@ -13,7 +13,6 @@
 /// Supported push types:
 ///   Number -> push Value::Number(result)
 ///   Value  -> push result directly (must be a Value)
-
 macro_rules! stack_builtin {
     // Two Number params -> Number result
     ($name:ident, $op:expr, ($a:ident : Number, $b:ident : Number) -> Number, $body:expr) => {
@@ -41,18 +40,25 @@ macro_rules! stack_builtin {
     // NumberList param -> Number result
     ($name:ident, $op:expr, ($list:ident : NumberList) -> Number, $body:expr) => {
         pub(crate) fn $name(&mut self) -> Result<(), EvalError> {
-            let val = self.stack.pop().ok_or_else(||
-                EvalError::StackUnderflow(format!("{} requires a list", $op)))?;
+            let val = self
+                .stack
+                .pop()
+                .ok_or_else(|| EvalError::StackUnderflow(format!("{} requires a list", $op)))?;
             let $list: Vec<f64> = match val {
-                Value::List(items) => items.iter().filter_map(|v| match v {
-                    Value::Number(n) => Some(*n),
-                    Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
-                    _ => None,
-                }).collect(),
-                _ => return Err(EvalError::TypeError {
-                    expected: "List".into(),
-                    got: val.type_name().to_string(),
-                }),
+                Value::List(items) => items
+                    .iter()
+                    .filter_map(|v| match v {
+                        Value::Number(n) => Some(*n),
+                        Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => {
+                    return Err(EvalError::TypeError {
+                        expected: "List".into(),
+                        got: val.type_name().to_string(),
+                    })
+                }
             };
             let result: f64 = $body;
             self.stack.push(Value::Number(result));
@@ -64,18 +70,25 @@ macro_rules! stack_builtin {
     // NumberList param -> Value result (for functions that return lists etc.)
     ($name:ident, $op:expr, ($list:ident : NumberList) -> Value, $body:expr) => {
         pub(crate) fn $name(&mut self) -> Result<(), EvalError> {
-            let val = self.stack.pop().ok_or_else(||
-                EvalError::StackUnderflow(format!("{} requires a list", $op)))?;
+            let val = self
+                .stack
+                .pop()
+                .ok_or_else(|| EvalError::StackUnderflow(format!("{} requires a list", $op)))?;
             let $list: Vec<f64> = match val {
-                Value::List(items) => items.iter().filter_map(|v| match v {
-                    Value::Number(n) => Some(*n),
-                    Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
-                    _ => None,
-                }).collect(),
-                _ => return Err(EvalError::TypeError {
-                    expected: "List".into(),
-                    got: val.type_name().to_string(),
-                }),
+                Value::List(items) => items
+                    .iter()
+                    .filter_map(|v| match v {
+                        Value::Number(n) => Some(*n),
+                        Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => {
+                    return Err(EvalError::TypeError {
+                        expected: "List".into(),
+                        got: val.type_name().to_string(),
+                    })
+                }
             };
             let result: Value = $body;
             self.stack.push(result);

--- a/src/eval/math.rs
+++ b/src/eval/math.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use std::path::Path;
 
@@ -233,22 +233,30 @@ impl Evaluator {
                 items.sort_by(|a, b| {
                     let a_num = match a {
                         Value::Number(n) => *n,
-                        Value::Literal(s) | Value::Output(s) => s.trim().parse().unwrap_or(f64::NAN),
+                        Value::Literal(s) | Value::Output(s) => {
+                            s.trim().parse().unwrap_or(f64::NAN)
+                        }
                         _ => f64::NAN,
                     };
                     let b_num = match b {
                         Value::Number(n) => *n,
-                        Value::Literal(s) | Value::Output(s) => s.trim().parse().unwrap_or(f64::NAN),
+                        Value::Literal(s) | Value::Output(s) => {
+                            s.trim().parse().unwrap_or(f64::NAN)
+                        }
                         _ => f64::NAN,
                     };
-                    a_num.partial_cmp(&b_num).unwrap_or(std::cmp::Ordering::Equal)
+                    a_num
+                        .partial_cmp(&b_num)
+                        .unwrap_or(std::cmp::Ordering::Equal)
                 });
                 self.stack.push(Value::List(items));
                 self.last_exit_code = 0;
             }
             other => {
                 self.stack.push(other);
-                return Err(EvalError::ExecError("sort-nums requires a list".to_string()));
+                return Err(EvalError::ExecError(
+                    "sort-nums requires a list".to_string(),
+                ));
             }
         }
 
@@ -261,14 +269,16 @@ impl Evaluator {
         let base = self.pop_number("log-base")?;
         let value = self.pop_number("log-base")?;
         if base <= 0.0 || base == 1.0 {
-            return Err(EvalError::ExecError(
-                format!("log-base: base must be positive and not 1, got {}", base)
-            ));
+            return Err(EvalError::ExecError(format!(
+                "log-base: base must be positive and not 1, got {}",
+                base
+            )));
         }
         if value <= 0.0 {
-            return Err(EvalError::ExecError(
-                format!("log-base: value must be positive, got {}", value)
-            ));
+            return Err(EvalError::ExecError(format!(
+                "log-base: value must be positive, got {}",
+                value
+            )));
         }
         let result = value.ln() / base.ln();
         self.stack.push(Value::Number(result));
@@ -281,9 +291,9 @@ impl Evaluator {
     // ========================================
 
     pub(crate) fn builtin_file_predicate(&mut self, args: &[String]) -> Result<(), EvalError> {
-        let path = args.first().ok_or_else(|| {
-            EvalError::ExecError("file?: path required".into())
-        })?;
+        let path = args
+            .first()
+            .ok_or_else(|| EvalError::ExecError("file?: path required".into()))?;
         let result = Path::new(path).is_file();
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
@@ -293,9 +303,9 @@ impl Evaluator {
     /// Check if path is a directory
     /// Usage: "path" dir?
     pub(crate) fn builtin_dir_predicate(&mut self, args: &[String]) -> Result<(), EvalError> {
-        let path = args.first().ok_or_else(|| {
-            EvalError::ExecError("dir?: path required".into())
-        })?;
+        let path = args
+            .first()
+            .ok_or_else(|| EvalError::ExecError("dir?: path required".into()))?;
         let result = Path::new(path).is_dir();
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
@@ -305,9 +315,9 @@ impl Evaluator {
     /// Check if path exists (file or directory)
     /// Usage: "path" exists?
     pub(crate) fn builtin_exists_predicate(&mut self, args: &[String]) -> Result<(), EvalError> {
-        let path = args.first().ok_or_else(|| {
-            EvalError::ExecError("exists?: path required".into())
-        })?;
+        let path = args
+            .first()
+            .ok_or_else(|| EvalError::ExecError("exists?: path required".into()))?;
         self.restore_excess_args(args, 1);
         let result = Path::new(path).exists();
         self.stack.push(Value::Bool(result));
@@ -333,7 +343,9 @@ impl Evaluator {
     /// Usage: "string" "substr" contains?
     pub(crate) fn builtin_contains_predicate(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 2 {
-            return Err(EvalError::ExecError("contains?: string and substring required".into()));
+            return Err(EvalError::ExecError(
+                "contains?: string and substring required".into(),
+            ));
         }
         self.restore_excess_args(args, 2);
         // Args in LIFO: [needle, haystack] for "haystack needle contains?"
@@ -349,7 +361,9 @@ impl Evaluator {
     /// Usage: "string" "prefix" starts?
     pub(crate) fn builtin_starts_predicate(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 2 {
-            return Err(EvalError::ExecError("starts?: string and prefix required".into()));
+            return Err(EvalError::ExecError(
+                "starts?: string and prefix required".into(),
+            ));
         }
         self.restore_excess_args(args, 2);
         // Args in LIFO: [prefix, string] for "string prefix starts?"
@@ -365,7 +379,9 @@ impl Evaluator {
     /// Usage: "string" "suffix" ends?
     pub(crate) fn builtin_ends_predicate(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 2 {
-            return Err(EvalError::ExecError("ends?: string and suffix required".into()));
+            return Err(EvalError::ExecError(
+                "ends?: string and suffix required".into(),
+            ));
         }
         self.restore_excess_args(args, 2);
         // Args in LIFO: [suffix, string] for "string suffix ends?"

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -58,6 +58,7 @@ mod tests;
 
 use crate::ast::{Expr, Program, Value};
 use crate::resolver::ExecutableResolver;
+use crate::util::lock_or_recover;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Child;
@@ -435,7 +436,7 @@ impl Evaluator {
                     }
                     Value::Future { id, state } => {
                         use crate::ast::FutureState;
-                        let guard = state.lock().unwrap();
+                        let guard = lock_or_recover(&state);
                         let status = match &*guard {
                             FutureState::Pending => "pending",
                             FutureState::Completed(_) => "completed",
@@ -626,7 +627,7 @@ impl Evaluator {
             Value::Error { kind, .. } => format!("error:{}", kind),
             Value::Future { id, state } => {
                 use crate::ast::FutureState;
-                let guard = state.lock().unwrap();
+                let guard = lock_or_recover(&state);
                 let status = match &*guard {
                     FutureState::Pending => "pending",
                     FutureState::Completed(_) => "completed",

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -104,7 +104,8 @@ pub(crate) struct Job {
     pub(crate) pid: u32,
     pub(crate) pgid: u32,  // Process group ID for signal delivery
     pub(crate) command: String,
-    #[allow(dead_code)]
+    /// Handle to the spawned child; used by the reaper (`reap_jobs`),
+    /// `wait`, and `.fg` (issue #30)
     pub(crate) child: Option<Child>,
     pub(crate) status: JobStatus,
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -182,6 +182,10 @@ pub struct Evaluator {
     pub(crate) future_counter: u32,
     /// Handles to background threads for futures (for cleanup)
     pub(crate) future_handles: HashMap<String, std::thread::JoinHandle<()>>,
+    /// Registry of every spawned future's shared state, keyed by id (issue #29).
+    /// Entries are kept for the lifetime of the evaluator (terminal states
+    /// included) so `futures-list` can enumerate them; see docs/async.md.
+    pub(crate) futures: indexmap::IndexMap<String, std::sync::Arc<std::sync::Mutex<crate::ast::FutureState>>>,
     /// Plugin host for WASM plugin support
     #[cfg(feature = "plugins")]
     pub(crate) plugin_host: Option<PluginHost>,
@@ -260,6 +264,7 @@ impl Evaluator {
             snapshot_counter: 0,
             future_counter: 0,
             future_handles: HashMap::new(),
+            futures: indexmap::IndexMap::new(),
             #[cfg(feature = "plugins")]
             plugin_host,
             #[cfg(feature = "plugins")]

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -24,37 +24,37 @@
 
 #[macro_use]
 mod macros;
-mod macro_builtins;
-mod helpers;
-mod stack;
-mod path;
-mod string;
-mod list;
-mod control;
-mod process;
-mod command;
-mod shell;
-mod structured;
-mod serialization;
 mod aggregation;
-mod stats;
-mod math;
-mod vector;
-mod combinators;
-mod encoding;
-mod bigint;
-mod terminal;
-mod image;
-mod modules;
-mod local;
-mod plugin;
-mod snapshot;
 mod async_ops;
+mod bigint;
+mod combinators;
+mod command;
+mod control;
+mod encoding;
+mod helpers;
 mod http;
+mod image;
+mod list;
+mod local;
+mod macro_builtins;
+mod math;
+mod modules;
+mod path;
+mod plugin;
+mod process;
+mod serialization;
+mod shell;
+mod shell_native;
+mod snapshot;
+mod stack;
+mod stats;
+mod string;
+mod structured;
+mod terminal;
+mod tests;
+mod vector;
 #[cfg(feature = "plugins")]
 mod watch;
-mod shell_native;
-mod tests;
 
 use crate::ast::{Expr, Program, Value};
 use crate::resolver::ExecutableResolver;
@@ -102,7 +102,7 @@ pub struct EvalResult {
 pub(crate) struct Job {
     pub(crate) id: usize,
     pub(crate) pid: u32,
-    pub(crate) pgid: u32,  // Process group ID for signal delivery
+    pub(crate) pgid: u32, // Process group ID for signal delivery
     pub(crate) command: String,
     /// Handle to the spawned child; used by the reaper (`reap_jobs`),
     /// `wait`, and `.fg` (issue #30)
@@ -186,7 +186,8 @@ pub struct Evaluator {
     /// Registry of every spawned future's shared state, keyed by id (issue #29).
     /// Entries are kept for the lifetime of the evaluator (terminal states
     /// included) so `futures-list` can enumerate them; see docs/async.md.
-    pub(crate) futures: indexmap::IndexMap<String, std::sync::Arc<std::sync::Mutex<crate::ast::FutureState>>>,
+    pub(crate) futures:
+        indexmap::IndexMap<String, std::sync::Arc<std::sync::Mutex<crate::ast::FutureState>>>,
     /// Plugin host for WASM plugin support
     #[cfg(feature = "plugins")]
     pub(crate) plugin_host: Option<PluginHost>,
@@ -402,7 +403,10 @@ impl Evaluator {
         let expr_str = self.expr_to_string(expr);
 
         // Format stack (show all items, max 10)
-        let stack_items: Vec<String> = self.stack.iter().enumerate()
+        let stack_items: Vec<String> = self
+            .stack
+            .iter()
+            .enumerate()
             .map(|(i, v)| {
                 let val_str = match v {
                     Value::Literal(s) => {
@@ -430,7 +434,9 @@ impl Evaluator {
                     Value::Marker => "|marker|".to_string(),
                     Value::Error { message, .. } => format!("Error:{}", message),
                     Value::Media { data, .. } => format!("<media:{}B>", data.len()),
-                    Value::Link { url, .. } => format!("<link:{}>", if url.len() > 20 { &url[..20] } else { url }),
+                    Value::Link { url, .. } => {
+                        format!("<link:{}>", if url.len() > 20 { &url[..20] } else { url })
+                    }
                     Value::Bytes(data) => format!("<bytes:{}B>", data.len()),
                     Value::BigInt(n) => {
                         let s = n.to_string();
@@ -442,7 +448,7 @@ impl Evaluator {
                     }
                     Value::Future { id, state } => {
                         use crate::ast::FutureState;
-                        let guard = lock_or_recover(&state);
+                        let guard = lock_or_recover(state);
                         let status = match &*guard {
                             FutureState::Pending => "pending",
                             FutureState::Completed(_) => "completed",
@@ -595,7 +601,8 @@ impl Evaluator {
                 format!("record:{{{}{}}}", fields.join(", "), suffix)
             }
             Value::List(items) => {
-                let preview: Vec<String> = items.iter()
+                let preview: Vec<String> = items
+                    .iter()
                     .take(3)
                     .map(|v| self.format_value_inline(v))
                     .collect();
@@ -605,12 +612,15 @@ impl Evaluator {
             Value::Table { columns, rows } => {
                 format!("table[{}x{}]", columns.len(), rows.len())
             }
-            Value::Media { mime_type, width, height, .. } => {
-                match (width, height) {
-                    (Some(w), Some(h)) => format!("{}[{}x{}]", mime_type, w, h),
-                    _ => mime_type.clone(),
-                }
-            }
+            Value::Media {
+                mime_type,
+                width,
+                height,
+                ..
+            } => match (width, height) {
+                (Some(w), Some(h)) => format!("{}[{}x{}]", mime_type, w, h),
+                _ => mime_type.clone(),
+            },
             Value::Block(_) => "block:[...]".to_string(),
             Value::BigInt(n) => {
                 let s = n.to_string();
@@ -633,7 +643,7 @@ impl Evaluator {
             Value::Error { kind, .. } => format!("error:{}", kind),
             Value::Future { id, state } => {
                 use crate::ast::FutureState;
-                let guard = lock_or_recover(&state);
+                let guard = lock_or_recover(state);
                 let status = match &*guard {
                     FutureState::Pending => "pending",
                     FutureState::Completed(_) => "completed",
@@ -807,7 +817,11 @@ impl Evaluator {
         };
 
         // Format stack (show top 5 items)
-        let stack_items: Vec<String> = self.stack.iter().rev().take(5)
+        let stack_items: Vec<String> = self
+            .stack
+            .iter()
+            .rev()
+            .take(5)
             .map(|v| match v {
                 Value::Literal(s) => format!("\"{}\"", s),
                 Value::Number(n) => format!("{}", n),
@@ -881,7 +895,9 @@ impl Evaluator {
                 Expr::Map | Expr::Filter => true,
 
                 // Control flow consumes blocks/values
-                Expr::If | Expr::ElseIf | Expr::Else | Expr::Times | Expr::While | Expr::Until => true,
+                Expr::If | Expr::ElseIf | Expr::Else | Expr::Times | Expr::While | Expr::Until => {
+                    true
+                }
 
                 // Parallel execution
                 Expr::Parallel | Expr::Fork => true,

--- a/src/eval/modules.rs
+++ b/src/eval/modules.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Expr;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -22,7 +22,9 @@ impl Evaluator {
         let resolved_path = self.resolve_module_path(&path_str)?;
 
         // Get canonical path for tracking
-        let canonical = resolved_path.canonicalize().unwrap_or_else(|_| resolved_path.clone());
+        let canonical = resolved_path
+            .canonicalize()
+            .unwrap_or_else(|_| resolved_path.clone());
 
         // Skip if already loaded
         if self.loaded_modules.contains(&canonical) {
@@ -70,13 +72,14 @@ impl Evaluator {
         }
 
         // Find definitions that were added or changed during module execution
-        let module_defs: Vec<String> = self.definitions
+        let module_defs: Vec<String> = self
+            .definitions
             .iter()
             .filter(|(name, body)| {
                 // Include if: new name OR same name but different body
                 match before_defs.get(*name) {
-                    None => true,  // New definition
-                    Some(old_body) => old_body != *body,  // Changed definition
+                    None => true,                        // New definition
+                    Some(old_body) => old_body != *body, // Changed definition
                 }
             })
             .map(|(name, _)| name.clone())
@@ -115,13 +118,16 @@ impl Evaluator {
             if path.exists() {
                 return Ok(path);
             }
-            return Err(EvalError::ExecError(format!("import: module not found: {}", path_str)));
+            return Err(EvalError::ExecError(format!(
+                "import: module not found: {}",
+                path_str
+            )));
         }
 
         // Build search paths
         let mut search_paths = vec![
-            self.cwd.clone(),                           // Current directory
-            self.cwd.join("lib"),                       // ./lib/
+            self.cwd.clone(),     // Current directory
+            self.cwd.join("lib"), // ./lib/
         ];
 
         // Add ~/.hsab/lib/
@@ -146,6 +152,9 @@ impl Evaluator {
             }
         }
 
-        Err(EvalError::ExecError(format!("import: module not found: {}", path_str)))
+        Err(EvalError::ExecError(format!(
+            "import: module not found: {}",
+            path_str
+        )))
     }
 }

--- a/src/eval/path.rs
+++ b/src/eval/path.rs
@@ -1,6 +1,6 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 impl Evaluator {
     /// Resolve a path to its canonical absolute form
@@ -29,13 +29,14 @@ impl Evaluator {
             }
         };
 
-        self.stack.push(Value::Literal(resolved.to_string_lossy().to_string()));
+        self.stack
+            .push(Value::Literal(resolved.to_string_lossy().to_string()));
         Ok(())
     }
 
     /// Lexical path normalization (no filesystem access)
     /// Handles . and .. components without requiring path to exist
-    fn normalize_path(path: &PathBuf) -> PathBuf {
+    fn normalize_path(path: &Path) -> PathBuf {
         use std::path::Component;
         let mut components = Vec::new();
 
@@ -77,7 +78,8 @@ impl Evaluator {
     pub(crate) fn path_suffix(&mut self) -> Result<(), EvalError> {
         let suffix = self.pop_string()?;
         let base = self.pop_string()?;
-        self.stack.push(Value::Literal(format!("{}{}", base, suffix)));
+        self.stack
+            .push(Value::Literal(format!("{}{}", base, suffix)));
         Ok(())
     }
 
@@ -85,9 +87,9 @@ impl Evaluator {
     pub(crate) fn path_dirname(&mut self) -> Result<(), EvalError> {
         let path = self.pop_string()?;
         let result = match path.rfind('/') {
-            Some(0) => "/".to_string(),        // Root: /file -> /
+            Some(0) => "/".to_string(), // Root: /file -> /
             Some(idx) => path[..idx].to_string(),
-            None => ".".to_string(),            // No slash: file -> .
+            None => ".".to_string(), // No slash: file -> .
         };
         self.stack.push(Value::Literal(result));
         Ok(())
@@ -115,7 +117,9 @@ impl Evaluator {
     /// "file.txt" ".md" reext -> "file.md"
     pub(crate) fn builtin_reext(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 2 {
-            return Err(EvalError::ExecError("reext: path and new extension required".into()));
+            return Err(EvalError::ExecError(
+                "reext: path and new extension required".into(),
+            ));
         }
         self.restore_excess_args(args, 2);
         // Args in LIFO: [newext, path] for "path newext reext"

--- a/src/eval/plugin.rs
+++ b/src/eval/plugin.rs
@@ -1,6 +1,6 @@
-use super::Evaluator;
 #[cfg(feature = "plugins")]
 use super::EvalError;
+use super::Evaluator;
 
 impl Evaluator {
     /// Load a plugin: "path/to/plugin" plugin-load
@@ -14,12 +14,13 @@ impl Evaluator {
         let plugin_path = std::path::Path::new(&path);
 
         if let Some(ref mut host) = self.plugin_host {
-            host.load_plugin(plugin_path).map_err(|e| {
-                EvalError::ExecError(format!("Failed to load plugin: {}", e))
-            })?;
+            host.load_plugin(plugin_path)
+                .map_err(|e| EvalError::ExecError(format!("Failed to load plugin: {}", e)))?;
             self.last_exit_code = 0;
         } else {
-            return Err(EvalError::ExecError("Plugin system not initialized".to_string()));
+            return Err(EvalError::ExecError(
+                "Plugin system not initialized".to_string(),
+            ));
         }
 
         Ok(())
@@ -33,12 +34,13 @@ impl Evaluator {
         })?;
 
         if let Some(ref mut host) = self.plugin_host {
-            host.unload_plugin(name).map_err(|e| {
-                EvalError::ExecError(format!("Failed to unload plugin: {}", e))
-            })?;
+            host.unload_plugin(name)
+                .map_err(|e| EvalError::ExecError(format!("Failed to unload plugin: {}", e)))?;
             self.last_exit_code = 0;
         } else {
-            return Err(EvalError::ExecError("Plugin system not initialized".to_string()));
+            return Err(EvalError::ExecError(
+                "Plugin system not initialized".to_string(),
+            ));
         }
 
         Ok(())
@@ -52,13 +54,14 @@ impl Evaluator {
         })?;
 
         if let Some(ref mut host) = self.plugin_host {
-            host.reload_plugin(name).map_err(|e| {
-                EvalError::ExecError(format!("Failed to reload plugin: {}", e))
-            })?;
+            host.reload_plugin(name)
+                .map_err(|e| EvalError::ExecError(format!("Failed to reload plugin: {}", e)))?;
             println!("Plugin reloaded: {}", name);
             self.last_exit_code = 0;
         } else {
-            return Err(EvalError::ExecError("Plugin system not initialized".to_string()));
+            return Err(EvalError::ExecError(
+                "Plugin system not initialized".to_string(),
+            ));
         }
 
         Ok(())
@@ -109,7 +112,9 @@ impl Evaluator {
                 self.last_exit_code = 1;
             }
         } else {
-            return Err(EvalError::ExecError("Plugin system not initialized".to_string()));
+            return Err(EvalError::ExecError(
+                "Plugin system not initialized".to_string(),
+            ));
         }
 
         Ok(())

--- a/src/eval/process.rs
+++ b/src/eval/process.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError, Job, JobStatus};
+use super::{EvalError, Evaluator, Job, JobStatus};
 use crate::ast::{Expr, Value};
 use std::fs::File;
 use std::io::Write;
@@ -114,7 +114,10 @@ impl Evaluator {
         for file in &files {
             let mut f = match mode {
                 ">" => File::create(file)?,
-                ">>" => std::fs::OpenOptions::new().append(true).create(true).open(file)?,
+                ">>" => std::fs::OpenOptions::new()
+                    .append(true)
+                    .create(true)
+                    .open(file)?,
                 _ => continue,
             };
             f.write_all(output.as_bytes())?;
@@ -124,7 +127,11 @@ impl Evaluator {
     }
 
     /// Execute stdin redirect: [cmd] [file] <
-    pub(crate) fn execute_stdin_redirect(&mut self, cmd: &[Expr], input_file: &str) -> Result<(), EvalError> {
+    pub(crate) fn execute_stdin_redirect(
+        &mut self,
+        cmd: &[Expr],
+        input_file: &str,
+    ) -> Result<(), EvalError> {
         let (cmd_name, args) = self.block_to_cmd_args(cmd)?;
 
         // Open the input file
@@ -294,7 +301,7 @@ impl Evaluator {
         self.jobs.push(Job {
             id: job_id,
             pid,
-            pgid: pid,  // Process group ID same as PID for background jobs
+            pgid: pid, // Process group ID same as PID for background jobs
             command: cmd_str.clone(),
             child: Some(child),
             status: JobStatus::Running,
@@ -427,7 +434,7 @@ impl Evaluator {
             self.jobs.push(Job {
                 id: job_id,
                 pid,
-                pgid: pid,  // Process group ID same as PID for background jobs
+                pgid: pid, // Process group ID same as PID for background jobs
                 command: cmd_str,
                 child: Some(child),
                 status: JobStatus::Running,
@@ -490,7 +497,10 @@ impl Evaluator {
             let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
             if result != 0 {
                 let err = std::io::Error::last_os_error();
-                return Err(EvalError::ExecError(format!("fifo: mkfifo failed: {}", err)));
+                return Err(EvalError::ExecError(format!(
+                    "fifo: mkfifo failed: {}",
+                    err
+                )));
             }
 
             // Spawn command in background, redirecting stdout to the fifo
@@ -499,11 +509,7 @@ impl Evaluator {
             let cwd = self.cwd.clone();
             std::thread::spawn(move || {
                 // Run the command first to get output
-                if let Ok(output) = Command::new(&cmd)
-                    .args(&args)
-                    .current_dir(&cwd)
-                    .output()
-                {
+                if let Ok(output) = Command::new(&cmd).args(&args).current_dir(&cwd).output() {
                     // Now open fifo and write (this blocks until a reader opens)
                     if let Ok(mut fifo) = std::fs::OpenOptions::new()
                         .write(true)

--- a/src/eval/serialization.rs
+++ b/src/eval/serialization.rs
@@ -1,7 +1,7 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
-use serde_json::Value as JsonValue;
 use indexmap::IndexMap;
+use serde_json::Value as JsonValue;
 use std::path::PathBuf;
 
 impl Evaluator {
@@ -24,10 +24,14 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_into_json(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("into-json requires string".into()))?;
-        let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("into-json requires string".into()))?;
+        let text = val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: val.type_name().to_string(),
+        })?;
 
         let json: serde_json::Value = serde_json::from_str(&text)
             .map_err(|e| EvalError::ExecError(format!("into-json: {}", e)))?;
@@ -38,18 +42,21 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_into_csv(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("into-csv requires string".into()))?;
-        let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("into-csv requires string".into()))?;
+        let text = val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: val.type_name().to_string(),
+        })?;
 
         let mut lines = text.lines();
-        let header = lines.next().ok_or_else(||
-            EvalError::ExecError("into-csv: empty input".into()))?;
+        let header = lines
+            .next()
+            .ok_or_else(|| EvalError::ExecError("into-csv: empty input".into()))?;
 
-        let columns: Vec<String> = header.split(',')
-            .map(|s| s.trim().to_string())
-            .collect();
+        let columns: Vec<String> = header.split(',').map(|s| s.trim().to_string()).collect();
 
         let rows: Vec<Vec<Value>> = lines
             .filter(|line| !line.trim().is_empty())
@@ -74,12 +81,17 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_into_lines(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("into-lines requires string".into()))?;
-        let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("into-lines requires string".into()))?;
+        let text = val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: val.type_name().to_string(),
+        })?;
 
-        let lines: Vec<Value> = text.lines()
+        let lines: Vec<Value> = text
+            .lines()
             .map(|s| Value::Literal(s.to_string()))
             .collect();
 
@@ -89,10 +101,14 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_into_kv(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("into-kv requires string".into()))?;
-        let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("into-kv requires string".into()))?;
+        let text = val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: val.type_name().to_string(),
+        })?;
 
         let mut map = IndexMap::new();
         for line in text.lines() {
@@ -119,18 +135,27 @@ impl Evaluator {
         self.parse_delimited_text(&text, &delim)
     }
 
-    pub(crate) fn parse_delimited_text(&mut self, text: &str, delim: &str) -> Result<(), EvalError> {
+    pub(crate) fn parse_delimited_text(
+        &mut self,
+        text: &str,
+        delim: &str,
+    ) -> Result<(), EvalError> {
         let lines: Vec<&str> = text.lines().collect();
         if lines.is_empty() {
-            self.stack.push(Value::Table { columns: vec![], rows: vec![] });
+            self.stack.push(Value::Table {
+                columns: vec![],
+                rows: vec![],
+            });
             return Ok(());
         }
 
-        let columns: Vec<String> = lines[0].split(delim)
+        let columns: Vec<String> = lines[0]
+            .split(delim)
             .map(|s| s.trim().to_string())
             .collect();
 
-        let rows: Vec<Vec<Value>> = lines[1..].iter()
+        let rows: Vec<Vec<Value>> = lines[1..]
+            .iter()
             .filter(|l| !l.trim().is_empty())
             .map(|line| {
                 line.split(delim)
@@ -145,8 +170,10 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_to_json(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-json requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-json requires value".into()))?;
 
         let json = crate::ast::value_to_json(&val);
         let text = serde_json::to_string(&json)
@@ -158,24 +185,27 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_to_csv(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-csv requires table".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-csv requires table".into()))?;
 
         match val {
             Value::Table { columns, rows } => {
                 let mut lines = vec![columns.join(",")];
                 for row in rows {
-                    let line: Vec<String> = row.iter()
-                        .map(|v| v.as_arg().unwrap_or_default())
-                        .collect();
+                    let line: Vec<String> =
+                        row.iter().map(|v| v.as_arg().unwrap_or_default()).collect();
                     lines.push(line.join(","));
                 }
                 self.stack.push(Value::Output(lines.join("\n")));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: val.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -183,20 +213,22 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_to_lines(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-lines requires list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-lines requires list".into()))?;
 
         match val {
             Value::List(items) => {
-                let lines: Vec<String> = items.iter()
-                    .filter_map(|v| v.as_arg())
-                    .collect();
+                let lines: Vec<String> = items.iter().filter_map(|v| v.as_arg()).collect();
                 self.stack.push(Value::Output(lines.join("\n")));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List".into(),
-                got: val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List".into(),
+                    got: val.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -204,12 +236,15 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_to_kv(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-kv requires record".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-kv requires record".into()))?;
 
         match val {
             Value::Map(map) => {
-                let mut pairs: Vec<_> = map.iter()
+                let mut pairs: Vec<_> = map
+                    .iter()
                     .map(|(k, v)| {
                         let val_str = v.as_arg().unwrap_or_default();
                         format!("{}={}", k, val_str)
@@ -218,10 +253,12 @@ impl Evaluator {
                 pairs.sort(); // Consistent ordering
                 self.stack.push(Value::Output(pairs.join("\n")));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Record".into(),
-                got: val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Record".into(),
+                    got: val.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -230,24 +267,27 @@ impl Evaluator {
 
     /// to-tsv: Convert table to TSV string format
     pub(crate) fn builtin_to_tsv(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-tsv requires table".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-tsv requires table".into()))?;
 
         match val {
             Value::Table { columns, rows } => {
                 let mut lines = vec![columns.join("\t")];
                 for row in rows {
-                    let line: Vec<String> = row.iter()
-                        .map(|v| v.as_arg().unwrap_or_default())
-                        .collect();
+                    let line: Vec<String> =
+                        row.iter().map(|v| v.as_arg().unwrap_or_default()).collect();
                     lines.push(line.join("\t"));
                 }
                 self.stack.push(Value::Output(lines.join("\n")));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: val.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -257,10 +297,14 @@ impl Evaluator {
     /// to-delimited: Convert table to custom-delimited string format
     /// table delimiter to-delimited -> delimited string
     pub(crate) fn builtin_to_delimited(&mut self) -> Result<(), EvalError> {
-        let delim_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-delimited requires delimiter".into()))?;
-        let table_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("to-delimited requires table".into()))?;
+        let delim_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-delimited requires delimiter".into()))?;
+        let table_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("to-delimited requires table".into()))?;
 
         let delim = delim_val.as_arg().unwrap_or_else(|| ",".to_string());
 
@@ -268,17 +312,18 @@ impl Evaluator {
             Value::Table { columns, rows } => {
                 let mut lines = vec![columns.join(&delim)];
                 for row in rows {
-                    let line: Vec<String> = row.iter()
-                        .map(|v| v.as_arg().unwrap_or_default())
-                        .collect();
+                    let line: Vec<String> =
+                        row.iter().map(|v| v.as_arg().unwrap_or_default()).collect();
                     lines.push(line.join(&delim));
                 }
                 self.stack.push(Value::Output(lines.join("\n")));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: table_val.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: table_val.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -290,18 +335,26 @@ impl Evaluator {
     pub(crate) fn builtin_open(&mut self) -> Result<(), EvalError> {
         use std::fs;
 
-        let path_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("open requires file path".into()))?;
-        let path_str = path_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: path_val.type_name().to_string() })?;
+        let path_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("open requires file path".into()))?;
+        let path_str = path_val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: path_val.type_name().to_string(),
+        })?;
         let path = PathBuf::from(self.expand_tilde(&path_str));
 
         let content = fs::read_to_string(&path).map_err(|e| {
-            EvalError::IoError(std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))
+            EvalError::IoError(std::io::Error::new(
+                e.kind(),
+                format!("{}: {}", path.display(), e),
+            ))
         })?;
 
         // Determine format based on extension
-        let ext = path.extension()
+        let ext = path
+            .extension()
             .and_then(|s| s.to_str())
             .map(|s| s.to_lowercase())
             .unwrap_or_default();
@@ -338,17 +391,24 @@ impl Evaluator {
     pub(crate) fn builtin_save(&mut self) -> Result<(), EvalError> {
         use std::fs;
 
-        let path_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("save requires file path".into()))?;
-        let data_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("save requires data".into()))?;
+        let path_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("save requires file path".into()))?;
+        let data_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("save requires data".into()))?;
 
-        let path_str = path_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: path_val.type_name().to_string() })?;
+        let path_str = path_val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: path_val.type_name().to_string(),
+        })?;
         let path = PathBuf::from(self.expand_tilde(&path_str));
 
         // Determine format based on extension
-        let ext = path.extension()
+        let ext = path
+            .extension()
             .and_then(|s| s.to_str())
             .map(|s| s.to_lowercase())
             .unwrap_or_default();
@@ -366,9 +426,8 @@ impl Evaluator {
                     Value::Table { columns, rows } => {
                         let mut lines = vec![columns.join(",")];
                         for row in rows {
-                            let line: Vec<String> = row.iter()
-                                .map(|v| v.as_arg().unwrap_or_default())
-                                .collect();
+                            let line: Vec<String> =
+                                row.iter().map(|v| v.as_arg().unwrap_or_default()).collect();
                             lines.push(line.join(","));
                         }
                         lines.join("\n")
@@ -382,9 +441,8 @@ impl Evaluator {
                     Value::Table { columns, rows } => {
                         let mut lines = vec![columns.join("\t")];
                         for row in rows {
-                            let line: Vec<String> = row.iter()
-                                .map(|v| v.as_arg().unwrap_or_default())
-                                .collect();
+                            let line: Vec<String> =
+                                row.iter().map(|v| v.as_arg().unwrap_or_default()).collect();
                             lines.push(line.join("\t"));
                         }
                         lines.join("\n")
@@ -399,7 +457,10 @@ impl Evaluator {
         };
 
         fs::write(&path, content).map_err(|e| {
-            EvalError::IoError(std::io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))
+            EvalError::IoError(std::io::Error::new(
+                e.kind(),
+                format!("{}: {}", path.display(), e),
+            ))
         })?;
 
         self.last_exit_code = 0;

--- a/src/eval/serialization.rs
+++ b/src/eval/serialization.rs
@@ -1,7 +1,7 @@
 use super::{Evaluator, EvalError};
 use crate::ast::Value;
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::path::PathBuf;
 
 impl Evaluator {
@@ -94,7 +94,7 @@ impl Evaluator {
         let text = val.as_arg().ok_or_else(||
             EvalError::TypeError { expected: "String".into(), got: format!("{:?}", val) })?;
 
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         for line in text.lines() {
             if let Some(eq_pos) = line.find('=') {
                 let key = line[..eq_pos].trim().to_string();

--- a/src/eval/serialization.rs
+++ b/src/eval/serialization.rs
@@ -27,7 +27,7 @@ impl Evaluator {
         let val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("into-json requires string".into()))?;
         let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", val) })?;
+            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
 
         let json: serde_json::Value = serde_json::from_str(&text)
             .map_err(|e| EvalError::ExecError(format!("into-json: {}", e)))?;
@@ -41,7 +41,7 @@ impl Evaluator {
         let val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("into-csv requires string".into()))?;
         let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", val) })?;
+            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
 
         let mut lines = text.lines();
         let header = lines.next().ok_or_else(||
@@ -77,7 +77,7 @@ impl Evaluator {
         let val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("into-lines requires string".into()))?;
         let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", val) })?;
+            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
 
         let lines: Vec<Value> = text.lines()
             .map(|s| Value::Literal(s.to_string()))
@@ -92,7 +92,7 @@ impl Evaluator {
         let val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("into-kv requires string".into()))?;
         let text = val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", val) })?;
+            EvalError::TypeError { expected: "String".into(), got: val.type_name().to_string() })?;
 
         let mut map = IndexMap::new();
         for line in text.lines() {
@@ -174,7 +174,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         }
 
@@ -195,7 +195,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         }
 
@@ -220,7 +220,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Record".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         }
 
@@ -246,7 +246,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", val),
+                got: val.type_name().to_string(),
             }),
         }
 
@@ -277,7 +277,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", table_val),
+                got: table_val.type_name().to_string(),
             }),
         }
 
@@ -293,7 +293,7 @@ impl Evaluator {
         let path_val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("open requires file path".into()))?;
         let path_str = path_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", path_val) })?;
+            EvalError::TypeError { expected: "String".into(), got: path_val.type_name().to_string() })?;
         let path = PathBuf::from(self.expand_tilde(&path_str));
 
         let content = fs::read_to_string(&path).map_err(|e| {
@@ -344,7 +344,7 @@ impl Evaluator {
             EvalError::StackUnderflow("save requires data".into()))?;
 
         let path_str = path_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", path_val) })?;
+            EvalError::TypeError { expected: "String".into(), got: path_val.type_name().to_string() })?;
         let path = PathBuf::from(self.expand_tilde(&path_str));
 
         // Determine format based on extension

--- a/src/eval/shell.rs
+++ b/src/eval/shell.rs
@@ -149,12 +149,33 @@ impl Evaluator {
     }
 
     pub(crate) fn update_job_statuses(&mut self) {
+        let _ = self.reap_jobs();
+    }
+
+    /// Reap finished background jobs without blocking (issue #30).
+    ///
+    /// Called from the REPL loop when SIGCHLD was flagged, and from
+    /// `.jobs`. Uses `Child::try_wait()` (waitpid WNOHANG on the tracked
+    /// pid) per job instead of a global `waitpid(-1, WNOHANG)` loop so we
+    /// never steal exit statuses from children owned by other code
+    /// (e.g. `Command::output()` running concurrently in future threads).
+    ///
+    /// Returns bash-style notification lines for jobs that just finished.
+    pub fn reap_jobs(&mut self) -> Vec<String> {
+        let mut notices = Vec::new();
         for job in &mut self.jobs {
             if job.status == JobStatus::Running {
                 if let Some(ref mut child) = job.child {
                     match child.try_wait() {
                         Ok(Some(status)) => {
-                            job.status = JobStatus::Done(status.code().unwrap_or(-1));
+                            let code = status.code().unwrap_or(-1);
+                            job.status = JobStatus::Done(code);
+                            let label = if code == 0 {
+                                "Done".to_string()
+                            } else {
+                                format!("Exit {}", code)
+                            };
+                            notices.push(format!("[{}] {}\t{}", job.id, label, job.command));
                         }
                         Ok(None) => {}
                         Err(_) => {
@@ -164,6 +185,7 @@ impl Evaluator {
                 }
             }
         }
+        notices
     }
 
     pub(crate) fn builtin_fg(&mut self, args: &[String]) -> Result<(), EvalError> {
@@ -176,16 +198,25 @@ impl Evaluator {
         } else {
             self.jobs
                 .iter_mut()
-                .filter(|j| j.status == JobStatus::Running)
+                .filter(|j| matches!(j.status, JobStatus::Running | JobStatus::Stopped))
                 .last()
         };
 
         match job {
             Some(job) => {
                 eprintln!("{}", job.command);
+                // Resume a stopped job before waiting on it (issue #30)
+                if job.status == JobStatus::Stopped {
+                    crate::signals::continue_process(job.pgid)
+                        .map_err(|e| EvalError::ExecError(format!("fg: {}", e)))?;
+                    job.status = JobStatus::Running;
+                }
                 if let Some(ref mut child) = job.child {
-                    let status = child
-                        .wait()
+                    // Track the foreground pid while we block on it
+                    crate::signals::set_foreground_pid(job.pid as i32);
+                    let wait_result = child.wait();
+                    crate::signals::clear_foreground_pid();
+                    let status = wait_result
                         .map_err(|e| EvalError::ExecError(e.to_string()))?;
                     self.last_exit_code = status.code().unwrap_or(-1);
                     job.status = JobStatus::Done(self.last_exit_code);

--- a/src/eval/shell.rs
+++ b/src/eval/shell.rs
@@ -5,43 +5,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 impl Evaluator {
-    pub(crate) fn builtin_cd(&mut self, args: &[String]) -> Result<(), EvalError> {
-        let dir = if args.is_empty() {
-            PathBuf::from(&self.home_dir)
-        } else {
-            let expanded = self.expand_tilde(&args[0]);
-            PathBuf::from(expanded)
-        };
-
-        // Resolve relative paths
-        let new_cwd = if dir.is_absolute() {
-            dir.clone()
-        } else {
-            self.cwd.join(&dir)
-        };
-
-        // Canonicalize and verify it exists
-        let canonical = new_cwd.canonicalize().map_err(|e| {
-            EvalError::ExecError(format!("cd: {}: {}", new_cwd.display(), e))
-        })?;
-
-        if !canonical.is_dir() {
-            return Err(EvalError::ExecError(format!(
-                "cd: {}: Not a directory",
-                dir.display()
-            )));
-        }
-
-        // Also update the actual process directory so child processes inherit it
-        std::env::set_current_dir(&canonical).map_err(|e| {
-            EvalError::ExecError(format!("cd: {}: {}", canonical.display(), e))
-        })?;
-
-        self.cwd = canonical;
-        self.last_exit_code = 0;
-        Ok(())
-    }
-
     pub(crate) fn builtin_pwd(&mut self) -> Result<(), EvalError> {
         self.stack
             .push(Value::Output(self.cwd.to_string_lossy().to_string() + "\n"));

--- a/src/eval/shell.rs
+++ b/src/eval/shell.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError, JobStatus};
+use super::{EvalError, Evaluator, JobStatus};
 use crate::ast::Value;
 use crate::resolver::ExecutableResolver;
 use std::path::{Path, PathBuf};
@@ -40,12 +40,10 @@ impl Evaluator {
             [path, flag] if flag == "-r" => Path::new(path).exists(),
             [path, flag] if flag == "-w" => Path::new(path).exists(),
             [path, flag] if flag == "-x" => self.is_executable(path),
-            [path, flag] if flag == "-s" => {
-                Path::new(path)
-                    .metadata()
-                    .map(|m| m.len() > 0)
-                    .unwrap_or(false)
-            }
+            [path, flag] if flag == "-s" => Path::new(path)
+                .metadata()
+                .map(|m| m.len() > 0)
+                .unwrap_or(false),
             [s, flag] if flag == "-z" => s.is_empty(),
             [s, flag] if flag == "-n" => !s.is_empty(),
             [s1, s2, op] if op == "=" || op == "==" => s1 == s2,
@@ -132,7 +130,11 @@ impl Evaluator {
                 JobStatus::Running => "Running",
                 JobStatus::Stopped => "Stopped",
                 JobStatus::Done(code) => {
-                    if *code == 0 { "Done" } else { "Exit" }
+                    if *code == 0 {
+                        "Done"
+                    } else {
+                        "Exit"
+                    }
                 }
             };
             output.push_str(&format!(
@@ -216,8 +218,7 @@ impl Evaluator {
                     crate::signals::set_foreground_pid(job.pid as i32);
                     let wait_result = child.wait();
                     crate::signals::clear_foreground_pid();
-                    let status = wait_result
-                        .map_err(|e| EvalError::ExecError(e.to_string()))?;
+                    let status = wait_result.map_err(|e| EvalError::ExecError(e.to_string()))?;
                     self.last_exit_code = status.code().unwrap_or(-1);
                     job.status = JobStatus::Done(self.last_exit_code);
                 }
@@ -263,7 +264,10 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_exit(&mut self, args: &[String]) -> Result<(), EvalError> {
-        let code = args.first().and_then(|s| s.parse::<i32>().ok()).unwrap_or(0);
+        let code = args
+            .first()
+            .and_then(|s| s.parse::<i32>().ok())
+            .unwrap_or(0);
         std::process::exit(code);
     }
 
@@ -311,14 +315,37 @@ impl Evaluator {
 
             if matches!(
                 cmd.as_str(),
-                "cd" | "pwd" | "echo" | "printf" | "read"
-                    | "true" | "false" | "test" | "["
-                    | "export" | "unset" | "env" | "local" | "return"
-                    | "jobs" | "fg" | "bg" | "wait" | "kill"
-                    | "exit" | "tty"
-                    | "which" | "type" | "source" | "." | "hash"
-                    | "pushd" | "popd" | "dirs"
-                    | "alias" | "unalias" | "trap"
+                "cd" | "pwd"
+                    | "echo"
+                    | "printf"
+                    | "read"
+                    | "true"
+                    | "false"
+                    | "test"
+                    | "["
+                    | "export"
+                    | "unset"
+                    | "env"
+                    | "local"
+                    | "return"
+                    | "jobs"
+                    | "fg"
+                    | "bg"
+                    | "wait"
+                    | "kill"
+                    | "exit"
+                    | "tty"
+                    | "which"
+                    | "type"
+                    | "source"
+                    | "."
+                    | "hash"
+                    | "pushd"
+                    | "popd"
+                    | "dirs"
+                    | "alias"
+                    | "unalias"
+                    | "trap"
             ) {
                 output_lines.push(format!("{}: shell builtin", cmd));
                 found_any = true;
@@ -365,14 +392,37 @@ impl Evaluator {
 
             if matches!(
                 cmd.as_str(),
-                "cd" | "pwd" | "echo" | "printf" | "read"
-                    | "true" | "false" | "test" | "["
-                    | "export" | "unset" | "env" | "local" | "return"
-                    | "jobs" | "fg" | "bg" | "wait" | "kill"
-                    | "exit" | "tty"
-                    | "which" | "type" | "source" | "." | "hash"
-                    | "pushd" | "popd" | "dirs"
-                    | "alias" | "unalias" | "trap"
+                "cd" | "pwd"
+                    | "echo"
+                    | "printf"
+                    | "read"
+                    | "true"
+                    | "false"
+                    | "test"
+                    | "["
+                    | "export"
+                    | "unset"
+                    | "env"
+                    | "local"
+                    | "return"
+                    | "jobs"
+                    | "fg"
+                    | "bg"
+                    | "wait"
+                    | "kill"
+                    | "exit"
+                    | "tty"
+                    | "which"
+                    | "type"
+                    | "source"
+                    | "."
+                    | "hash"
+                    | "pushd"
+                    | "popd"
+                    | "dirs"
+                    | "alias"
+                    | "unalias"
+                    | "trap"
             ) {
                 output_lines.push(format!("{} is a shell builtin", cmd));
                 found_any = true;
@@ -467,7 +517,10 @@ impl Evaluator {
                 self.last_exit_code = 1;
             }
             Ok(_) => {
-                let value = line.trim_end_matches('\n').trim_end_matches('\r').to_string();
+                let value = line
+                    .trim_end_matches('\n')
+                    .trim_end_matches('\r')
+                    .to_string();
 
                 if args.is_empty() {
                     self.stack.push(Value::Output(value));
@@ -487,7 +540,9 @@ impl Evaluator {
 
     pub(crate) fn builtin_printf(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.is_empty() {
-            return Err(EvalError::ExecError("printf: format string required".into()));
+            return Err(EvalError::ExecError(
+                "printf: format string required".into(),
+            ));
         }
 
         let format = &args[0];
@@ -576,8 +631,8 @@ impl Evaluator {
             self.last_exit_code = last_exit;
         } else {
             let job_spec = &args[0];
-            let job_id: usize = if job_spec.starts_with('%') {
-                job_spec[1..].parse().unwrap_or(0)
+            let job_id: usize = if let Some(stripped) = job_spec.strip_prefix('%') {
+                stripped.parse().unwrap_or(0)
             } else {
                 job_spec.parse().unwrap_or(0)
             };
@@ -596,7 +651,10 @@ impl Evaluator {
                     }
                 }
             } else {
-                return Err(EvalError::ExecError(format!("wait: no such job: {}", job_spec)));
+                return Err(EvalError::ExecError(format!(
+                    "wait: no such job: {}",
+                    job_spec
+                )));
             }
         }
 
@@ -605,7 +663,9 @@ impl Evaluator {
 
     pub(crate) fn builtin_kill(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.is_empty() {
-            return Err(EvalError::ExecError("kill: usage: PID [-signal] kill".into()));
+            return Err(EvalError::ExecError(
+                "kill: usage: PID [-signal] kill".into(),
+            ));
         }
 
         let mut signal = 15i32;
@@ -615,8 +675,7 @@ impl Evaluator {
             let sig_arg = &args[0];
             pid_str = &args[1];
 
-            if sig_arg.starts_with('-') {
-                let sig_spec = &sig_arg[1..];
+            if let Some(sig_spec) = sig_arg.strip_prefix('-') {
                 signal = match sig_spec.to_uppercase().as_str() {
                     "HUP" | "SIGHUP" | "1" => 1,
                     "INT" | "SIGINT" | "2" => 2,
@@ -630,17 +689,20 @@ impl Evaluator {
             }
         }
 
-        let pid: i32 = if pid_str.starts_with('%') {
-            let job_id: usize = pid_str[1..].parse().unwrap_or(0);
+        let pid: i32 = if let Some(job_spec) = pid_str.strip_prefix('%') {
+            let job_id: usize = job_spec.parse().unwrap_or(0);
             if let Some(job) = self.jobs.iter().find(|j| j.id == job_id) {
                 job.pid as i32
             } else {
-                return Err(EvalError::ExecError(format!("kill: no such job: {}", pid_str)));
+                return Err(EvalError::ExecError(format!(
+                    "kill: no such job: {}",
+                    pid_str
+                )));
             }
         } else {
-            pid_str.parse().map_err(|_| {
-                EvalError::ExecError(format!("kill: invalid pid: {}", pid_str))
-            })?
+            pid_str
+                .parse()
+                .map_err(|_| EvalError::ExecError(format!("kill: invalid pid: {}", pid_str)))?
         };
 
         #[cfg(unix)]
@@ -654,7 +716,9 @@ impl Evaluator {
 
         #[cfg(not(unix))]
         {
-            return Err(EvalError::ExecError("kill: not supported on this platform".into()));
+            return Err(EvalError::ExecError(
+                "kill: not supported on this platform".into(),
+            ));
         }
 
         self.last_exit_code = 0;
@@ -837,8 +901,10 @@ impl Evaluator {
         if let Some(block) = self.traps.get(&signal) {
             let body_str = self.exprs_to_string(block);
             let sig_name = self.signal_name(signal);
-            self.stack
-                .push(Value::Output(format!("trap -- '[{}]' {}\n", body_str, sig_name)));
+            self.stack.push(Value::Output(format!(
+                "trap -- '[{}]' {}\n",
+                body_str, sig_name
+            )));
         }
 
         self.last_exit_code = 0;

--- a/src/eval/shell_native.rs
+++ b/src/eval/shell_native.rs
@@ -3,7 +3,7 @@
 //! These operations return useful values to the stack instead of being side-effect only.
 //! On error, they return nil (compositional, pipelines don't break).
 
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use std::fs;
 use std::path::Path;
@@ -21,7 +21,8 @@ impl Evaluator {
 
         match fs::File::create(path) {
             Ok(_) => {
-                let canonical = path.canonicalize()
+                let canonical = path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| path_str.clone());
                 self.stack.push(Value::Literal(canonical));
@@ -41,7 +42,8 @@ impl Evaluator {
 
         match fs::create_dir(path) {
             Ok(_) => {
-                let canonical = path.canonicalize()
+                let canonical = path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| path_str.clone());
                 self.stack.push(Value::Literal(canonical));
@@ -61,7 +63,8 @@ impl Evaluator {
 
         match fs::create_dir_all(path) {
             Ok(_) => {
-                let canonical = path.canonicalize()
+                let canonical = path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| path_str.clone());
                 self.stack.push(Value::Literal(canonical));
@@ -90,7 +93,8 @@ impl Evaluator {
 
         match fs::File::create(&path) {
             Ok(_) => {
-                let canonical = path.canonicalize()
+                let canonical = path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| path.to_string_lossy().to_string());
                 self.stack.push(Value::Literal(canonical));
@@ -118,7 +122,8 @@ impl Evaluator {
 
         match fs::create_dir(&path) {
             Ok(_) => {
-                let canonical = path.canonicalize()
+                let canonical = path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| path.to_string_lossy().to_string());
                 self.stack.push(Value::Literal(canonical));
@@ -143,7 +148,8 @@ impl Evaluator {
         match fs::copy(&src, &dst) {
             Ok(_) => {
                 let dst_path = Path::new(&dst);
-                let canonical = dst_path.canonicalize()
+                let canonical = dst_path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or(dst);
                 self.stack.push(Value::Literal(canonical));
@@ -164,7 +170,8 @@ impl Evaluator {
         match fs::rename(&src, &dst) {
             Ok(_) => {
                 let dst_path = Path::new(&dst);
-                let canonical = dst_path.canonicalize()
+                let canonical = dst_path
+                    .canonicalize()
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or(dst);
                 self.stack.push(Value::Literal(canonical));
@@ -306,7 +313,8 @@ impl Evaluator {
 
         match full_path.canonicalize() {
             Ok(canonical) => {
-                self.stack.push(Value::Literal(canonical.to_string_lossy().to_string()));
+                self.stack
+                    .push(Value::Literal(canonical.to_string_lossy().to_string()));
             }
             Err(_) => {
                 self.stack.push(Value::Nil);
@@ -331,14 +339,10 @@ impl Evaluator {
         };
 
         // Handle ~ expansion using existing home_dir field
-        let expanded = if path_str.starts_with('~') {
-            if path_str == "~" {
-                self.home_dir.clone()
-            } else if path_str.starts_with("~/") {
-                format!("{}{}", self.home_dir, &path_str[1..])
-            } else {
-                path_str.clone()
-            }
+        let expanded = if path_str == "~" {
+            self.home_dir.clone()
+        } else if let Some(rest) = path_str.strip_prefix("~/") {
+            format!("{}/{}", self.home_dir, rest)
         } else {
             path_str.clone()
         };
@@ -355,7 +359,8 @@ impl Evaluator {
                 if canonical.is_dir() {
                     self.cwd = canonical.clone();
                     std::env::set_current_dir(&canonical).ok();
-                    self.stack.push(Value::Literal(canonical.to_string_lossy().to_string()));
+                    self.stack
+                        .push(Value::Literal(canonical.to_string_lossy().to_string()));
                 } else {
                     self.stack.push(Value::Nil);
                 }
@@ -394,7 +399,8 @@ impl Evaluator {
 
         match path.extension() {
             Some(ext) => {
-                self.stack.push(Value::Literal(format!(".{}", ext.to_string_lossy())));
+                self.stack
+                    .push(Value::Literal(format!(".{}", ext.to_string_lossy())));
             }
             None => {
                 self.stack.push(Value::Literal(String::new()));
@@ -428,8 +434,6 @@ impl Evaluator {
             self.stack.pop();
         }
 
-        let dir = dir;
-
         let path = if dir == "." {
             self.cwd.clone()
         } else {
@@ -449,7 +453,9 @@ impl Evaluator {
                     files.push(Value::Literal(name));
                 }
                 files.sort_by(|a, b| {
-                    a.as_arg().unwrap_or_default().cmp(&b.as_arg().unwrap_or_default())
+                    a.as_arg()
+                        .unwrap_or_default()
+                        .cmp(&b.as_arg().unwrap_or_default())
                 });
                 self.stack.push(Value::List(files));
             }
@@ -479,7 +485,9 @@ impl Evaluator {
                     paths.push(Value::Literal(entry.to_string_lossy().to_string()));
                 }
                 paths.sort_by(|a, b| {
-                    a.as_arg().unwrap_or_default().cmp(&b.as_arg().unwrap_or_default())
+                    a.as_arg()
+                        .unwrap_or_default()
+                        .cmp(&b.as_arg().unwrap_or_default())
                 });
                 self.stack.push(Value::List(paths));
             }

--- a/src/eval/snapshot.rs
+++ b/src/eval/snapshot.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -30,9 +30,10 @@ impl Evaluator {
             // User must explicitly call with a name string.
 
             // Convert args back to Values and restore to stack
-            let values: Vec<Value> = args.iter()
-                .skip(1)  // Skip the name (args[0])
-                .rev()    // Reverse to restore original order
+            let values: Vec<Value> = args
+                .iter()
+                .skip(1) // Skip the name (args[0])
+                .rev() // Reverse to restore original order
                 .map(|s| Value::Literal(s.clone()))
                 .collect();
 
@@ -53,7 +54,9 @@ impl Evaluator {
     /// "name" snapshot-restore -> (stack replaced)
     pub(crate) fn builtin_snapshot_restore(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.is_empty() {
-            return Err(EvalError::ExecError("snapshot-restore: name required".into()));
+            return Err(EvalError::ExecError(
+                "snapshot-restore: name required".into(),
+            ));
         }
         let name = &args[0];
         match self.snapshots.get(name) {
@@ -84,7 +87,9 @@ impl Evaluator {
     /// "name" snapshot-delete -> ()
     pub(crate) fn builtin_snapshot_delete(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.is_empty() {
-            return Err(EvalError::ExecError("snapshot-delete: name required".into()));
+            return Err(EvalError::ExecError(
+                "snapshot-delete: name required".into(),
+            ));
         }
         let name = &args[0];
         if self.snapshots.remove(name).is_none() {

--- a/src/eval/stack.rs
+++ b/src/eval/stack.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -60,9 +60,10 @@ impl Evaluator {
         let n = self.pop_number("dig")? as usize;
         let len = self.stack.len();
         if n < 1 || n > len {
-            return Err(EvalError::ExecError(
-                format!("dig: index {} out of range (stack has {} items)", n, len)
-            ));
+            return Err(EvalError::ExecError(format!(
+                "dig: index {} out of range (stack has {} items)",
+                n, len
+            )));
         }
         let item = self.stack.remove(len - n);
         self.stack.push(item);
@@ -94,7 +95,9 @@ impl Evaluator {
             Value::Map(m) => format!("{{record:{}}}", m.len()),
             Value::Table { columns, rows } => format!("<table:{}x{}>", columns.len(), rows.len()),
             Value::Error { message, .. } => format!("Error: {}", message),
-            Value::Media { mime_type, data, .. } => format!("<media:{}:{}B>", mime_type, data.len()),
+            Value::Media {
+                mime_type, data, ..
+            } => format!("<media:{}:{}B>", mime_type, data.len()),
             Value::Link { url, .. } => format!("<link:{}>", url),
             Value::Bytes(data) => format!("<bytes:{}B>", data.len()),
             Value::BigInt(n) => format!("<bigint:{}>", n),
@@ -129,9 +132,13 @@ impl Evaluator {
                 Value::Block(exprs) => format!("[block:{}]", exprs.len()),
                 Value::List(items) => format!("[list:{}]", items.len()),
                 Value::Map(m) => format!("{{record:{}}}", m.len()),
-                Value::Table { columns, rows } => format!("<table:{}x{}>", columns.len(), rows.len()),
+                Value::Table { columns, rows } => {
+                    format!("<table:{}x{}>", columns.len(), rows.len())
+                }
                 Value::Error { message, .. } => format!("Error: {}", message),
-                Value::Media { mime_type, data, .. } => format!("<media:{}:{}B>", mime_type, data.len()),
+                Value::Media {
+                    mime_type, data, ..
+                } => format!("<media:{}:{}B>", mime_type, data.len()),
                 Value::Link { url, .. } => format!("<link:{}>", url),
                 Value::Bytes(data) => format!("<bytes:{}B>", data.len()),
                 Value::BigInt(n) => format!("<bigint:{}>", n),
@@ -146,12 +153,16 @@ impl Evaluator {
     /// Usage: 1 2 3 4 5  3 bury -> 1 2 5 3 4 (buries top item to position 3)
     pub(crate) fn stack_bury(&mut self) -> Result<(), EvalError> {
         let n = self.pop_number("bury")? as usize;
-        let top = self.stack.pop().ok_or_else(|| EvalError::StackUnderflow("bury".into()))?;
+        let top = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("bury".into()))?;
         let len = self.stack.len();
         if n < 1 || n > len + 1 {
-            return Err(EvalError::ExecError(
-                format!("bury: index {} out of range (stack has {} items)", n, len)
-            ));
+            return Err(EvalError::ExecError(format!(
+                "bury: index {} out of range (stack has {} items)",
+                n, len
+            )));
         }
         self.stack.insert(len + 1 - n, top);
         Ok(())

--- a/src/eval/stats.rs
+++ b/src/eval/stats.rs
@@ -15,7 +15,7 @@ fn extract_numbers(val: &Value, _op: &str) -> Result<Vec<f64>, EvalError> {
         }
         _ => Err(EvalError::TypeError {
             expected: "List".into(),
-            got: format!("{:?}", val),
+            got: val.type_name().to_string(),
         }),
     }
 }

--- a/src/eval/stats.rs
+++ b/src/eval/stats.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use std::collections::HashMap;
 
@@ -6,11 +6,14 @@ use std::collections::HashMap;
 fn extract_numbers(val: &Value, _op: &str) -> Result<Vec<f64>, EvalError> {
     match val {
         Value::List(items) => {
-            let nums: Vec<f64> = items.iter().filter_map(|v| match v {
-                Value::Number(n) => Some(*n),
-                Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
-                _ => None,
-            }).collect();
+            let nums: Vec<f64> = items
+                .iter()
+                .filter_map(|v| match v {
+                    Value::Number(n) => Some(*n),
+                    Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
+                    _ => None,
+                })
+                .collect();
             Ok(nums)
         }
         _ => Err(EvalError::TypeError {
@@ -24,8 +27,10 @@ impl Evaluator {
     /// product: Multiply all elements in a list
     /// [nums] product -> number
     pub(crate) fn builtin_product(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("product requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("product requires a list".into()))?;
         let nums = extract_numbers(&val, "product")?;
         let result = nums.iter().fold(1.0, |acc, &x| acc * x);
         self.stack.push(Value::Number(result));
@@ -36,8 +41,10 @@ impl Evaluator {
     /// median: Middle value of sorted list
     /// [nums] median -> number
     pub(crate) fn builtin_median(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("median requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("median requires a list".into()))?;
         let mut nums = extract_numbers(&val, "median")?;
         if nums.is_empty() {
             self.stack.push(Value::Nil);
@@ -59,8 +66,10 @@ impl Evaluator {
     /// mode: Most frequently occurring value
     /// [nums] mode -> number
     pub(crate) fn builtin_mode(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("mode requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("mode requires a list".into()))?;
         let nums = extract_numbers(&val, "mode")?;
         if nums.is_empty() {
             self.stack.push(Value::Nil);
@@ -73,9 +82,7 @@ impl Evaluator {
             let entry = counts.entry(key).or_insert((n, 0));
             entry.1 += 1;
         }
-        let (mode_val, _) = counts.values()
-            .max_by_key(|(_, count)| *count)
-            .unwrap();
+        let (mode_val, _) = counts.values().max_by_key(|(_, count)| *count).unwrap();
         self.stack.push(Value::Number(*mode_val));
         self.last_exit_code = 0;
         Ok(())
@@ -84,8 +91,10 @@ impl Evaluator {
     /// modes: All values sharing the highest frequency
     /// [nums] modes -> [numbers]
     pub(crate) fn builtin_modes(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("modes requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("modes requires a list".into()))?;
         let nums = extract_numbers(&val, "modes")?;
         if nums.is_empty() {
             self.stack.push(Value::List(vec![]));
@@ -99,7 +108,8 @@ impl Evaluator {
             entry.1 += 1;
         }
         let max_count = counts.values().map(|(_, c)| *c).max().unwrap_or(0);
-        let modes: Vec<Value> = counts.values()
+        let modes: Vec<Value> = counts
+            .values()
             .filter(|(_, c)| *c == max_count)
             .map(|(v, _)| Value::Number(*v))
             .collect();
@@ -111,8 +121,10 @@ impl Evaluator {
     /// variance: Population variance (divide by N)
     /// [nums] variance -> number
     pub(crate) fn builtin_variance(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("variance requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("variance requires a list".into()))?;
         let nums = extract_numbers(&val, "variance")?;
         if nums.is_empty() {
             self.stack.push(Value::Number(0.0));
@@ -129,8 +141,10 @@ impl Evaluator {
     /// sample-variance: Sample variance (divide by N-1, Bessel's correction)
     /// [nums] sample-variance -> number
     pub(crate) fn builtin_sample_variance(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("sample-variance requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("sample-variance requires a list".into()))?;
         let nums = extract_numbers(&val, "sample-variance")?;
         if nums.len() < 2 {
             self.stack.push(Value::Number(0.0));
@@ -138,7 +152,8 @@ impl Evaluator {
             return Ok(());
         }
         let mean = nums.iter().sum::<f64>() / nums.len() as f64;
-        let variance = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (nums.len() - 1) as f64;
+        let variance =
+            nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (nums.len() - 1) as f64;
         self.stack.push(Value::Number(variance));
         self.last_exit_code = 0;
         Ok(())
@@ -147,8 +162,10 @@ impl Evaluator {
     /// stdev: Population standard deviation
     /// [nums] stdev -> number
     pub(crate) fn builtin_stdev(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("stdev requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("stdev requires a list".into()))?;
         let nums = extract_numbers(&val, "stdev")?;
         if nums.is_empty() {
             self.stack.push(Value::Number(0.0));
@@ -165,8 +182,10 @@ impl Evaluator {
     /// sample-stdev: Sample standard deviation (uses N-1)
     /// [nums] sample-stdev -> number
     pub(crate) fn builtin_sample_stdev(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("sample-stdev requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("sample-stdev requires a list".into()))?;
         let nums = extract_numbers(&val, "sample-stdev")?;
         if nums.len() < 2 {
             self.stack.push(Value::Number(0.0));
@@ -174,7 +193,8 @@ impl Evaluator {
             return Ok(());
         }
         let mean = nums.iter().sum::<f64>() / nums.len() as f64;
-        let variance = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (nums.len() - 1) as f64;
+        let variance =
+            nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (nums.len() - 1) as f64;
         self.stack.push(Value::Number(variance.sqrt()));
         self.last_exit_code = 0;
         Ok(())
@@ -184,18 +204,21 @@ impl Evaluator {
     /// [nums] 0.5 percentile -> number (0.5 = 50th percentile = median)
     pub(crate) fn builtin_percentile(&mut self) -> Result<(), EvalError> {
         let p = self.pop_number("percentile")?;
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("percentile requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("percentile requires a list".into()))?;
         let mut nums = extract_numbers(&val, "percentile")?;
         if nums.is_empty() {
             self.stack.push(Value::Nil);
             self.last_exit_code = 0;
             return Ok(());
         }
-        if p < 0.0 || p > 1.0 {
-            return Err(EvalError::ExecError(
-                format!("percentile: p must be between 0.0 and 1.0, got {}", p)
-            ));
+        if !(0.0..=1.0).contains(&p) {
+            return Err(EvalError::ExecError(format!(
+                "percentile: p must be between 0.0 and 1.0, got {}",
+                p
+            )));
         }
         nums.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let pos = p * (nums.len() - 1) as f64;
@@ -215,8 +238,10 @@ impl Evaluator {
     /// five-num: Five-number summary [min, Q1, median, Q3, max]
     /// [nums] five-num -> [min, Q1, median, Q3, max]
     pub(crate) fn builtin_five_num(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("five-num requires a list".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("five-num requires a list".into()))?;
         let mut nums = extract_numbers(&val, "five-num")?;
         if nums.is_empty() {
             self.stack.push(Value::List(vec![]));

--- a/src/eval/string.rs
+++ b/src/eval/string.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -54,7 +54,8 @@ impl Evaluator {
         }
         self.restore_excess_args(args, 1);
         let s = &args[0];
-        self.stack.push(Value::Output(s.chars().count().to_string()));
+        self.stack
+            .push(Value::Output(s.chars().count().to_string()));
         self.last_exit_code = 0;
         Ok(())
     }
@@ -63,7 +64,9 @@ impl Evaluator {
     /// Usage: "hello" 1 3 slice -> "ell" (start at index 1, take 3 chars)
     pub(crate) fn builtin_slice(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 3 {
-            return Err(EvalError::ExecError("slice: string start length required".into()));
+            return Err(EvalError::ExecError(
+                "slice: string start length required".into(),
+            ));
         }
         self.restore_excess_args(args, 3);
         // Args in LIFO: [length, start, string] for "string start length slice"
@@ -81,7 +84,9 @@ impl Evaluator {
     /// Usage: "hello" "ll" indexof -> 2
     pub(crate) fn builtin_indexof(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 2 {
-            return Err(EvalError::ExecError("indexof: string needle required".into()));
+            return Err(EvalError::ExecError(
+                "indexof: string needle required".into(),
+            ));
         }
         self.restore_excess_args(args, 2);
         // Args in LIFO: [needle, haystack] for "haystack needle indexof"
@@ -101,7 +106,9 @@ impl Evaluator {
     /// Usage: "hello" "l" "L" str-replace -> "heLLo"
     pub(crate) fn builtin_str_replace(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.len() < 3 {
-            return Err(EvalError::ExecError("str-replace: string from to required".into()));
+            return Err(EvalError::ExecError(
+                "str-replace: string from to required".into(),
+            ));
         }
         self.restore_excess_args(args, 3);
         // Args in LIFO: [to, from, string] for "string from to str-replace"
@@ -119,7 +126,9 @@ impl Evaluator {
     /// Positional: alice bob "{1} meets {0}" format -> "alice meets bob"
     pub(crate) fn builtin_format(&mut self, args: &[String]) -> Result<(), EvalError> {
         if args.is_empty() {
-            return Err(EvalError::ExecError("format: template string required".into()));
+            return Err(EvalError::ExecError(
+                "format: template string required".into(),
+            ));
         }
 
         // Convention: value1 value2 template format (template pushed LAST, just before format)
@@ -138,7 +147,12 @@ impl Evaluator {
             if next_idx >= values.len() {
                 break;
             }
-            result = format!("{}{}{}", &result[..pos], values[next_idx], &result[pos + 2..]);
+            result = format!(
+                "{}{}{}",
+                &result[..pos],
+                values[next_idx],
+                &result[pos + 2..]
+            );
             next_idx += 1;
         }
 

--- a/src/eval/structured.rs
+++ b/src/eval/structured.rs
@@ -9,7 +9,8 @@ impl Evaluator {
             EvalError::StackUnderflow("typeof requires a value".into()))?;
 
         let type_name = match &val {
-            Value::Number(_) => "number",
+            // typeof treats numeric-looking strings as numbers (shell compat);
+            // everything else defers to Value::type_name()
             Value::Literal(s) | Value::Output(s) => {
                 if s.trim().parse::<f64>().is_ok() {
                     "number"
@@ -17,19 +18,7 @@ impl Evaluator {
                     "string"
                 }
             }
-            Value::Bool(_) => "boolean",
-            Value::List(_) => "list",
-            Value::Map(_) => "record",
-            Value::Table { .. } => "table",
-            Value::Block(_) => "block",
-            Value::Nil => "nil",
-            Value::Marker => "marker",
-            Value::Error { .. } => "error",
-            Value::Media { .. } => "media",
-            Value::Link { .. } => "link",
-            Value::Bytes(_) => "bytes",
-            Value::BigInt(_) => "bigint",
-            Value::Future { .. } => "future",
+            other => other.type_name(),
         };
 
         self.stack.push(Value::Literal(type_name.to_string()));
@@ -73,7 +62,7 @@ impl Evaluator {
         let key_val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("get requires key".into()))?;
         let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", key_val) })?;
+            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
 
         let target = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("get requires record/table".into()))?;
@@ -122,7 +111,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Record, Table, List, or Error".into(),
-                got: format!("{:?}", target),
+                got: target.type_name().to_string(),
             }),
         }
 
@@ -136,7 +125,7 @@ impl Evaluator {
         let key_val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("set requires key".into()))?;
         let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", key_val) })?;
+            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
         let target = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("set requires record".into()))?;
 
@@ -154,7 +143,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Record".into(),
-                got: format!("{:?}", target),
+                got: target.type_name().to_string(),
             }),
         }
 
@@ -166,7 +155,7 @@ impl Evaluator {
         let key_val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("del requires key".into()))?;
         let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", key_val) })?;
+            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
         let target = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("del requires record".into()))?;
 
@@ -177,7 +166,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Record".into(),
-                got: format!("{:?}", target),
+                got: target.type_name().to_string(),
             }),
         }
 
@@ -189,7 +178,7 @@ impl Evaluator {
         let key_val = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("has? requires key".into()))?;
         let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: format!("{:?}", key_val) })?;
+            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
         let target = self.stack.pop().ok_or_else(||
             EvalError::StackUnderflow("has? requires record".into()))?;
 
@@ -223,7 +212,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Record or Table".into(),
-                got: format!("{:?}", target),
+                got: target.type_name().to_string(),
             }),
         }
 
@@ -242,7 +231,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Record".into(),
-                got: format!("{:?}", target),
+                got: target.type_name().to_string(),
             }),
         }
 
@@ -280,7 +269,7 @@ impl Evaluator {
                 Value::Map(map) => records.push(map),
                 _ => return Err(EvalError::TypeError {
                     expected: "Record".into(),
-                    got: format!("{:?}", val),
+                    got: val.type_name().to_string(),
                 }),
             }
         }
@@ -315,7 +304,7 @@ impl Evaluator {
             Value::Block(exprs) => exprs,
             _ => return Err(EvalError::TypeError {
                 expected: "Block".into(),
-                got: format!("{:?}", predicate),
+                got: predicate.type_name().to_string(),
             }),
         };
 
@@ -351,7 +340,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         }
 
@@ -369,7 +358,7 @@ impl Evaluator {
         match data {
             Value::Table { columns, mut rows } => {
                 let col = key_val.as_arg().ok_or_else(||
-                    EvalError::TypeError { expected: "String".into(), got: format!("{:?}", key_val) })?;
+                    EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
 
                 if let Some(col_idx) = columns.iter().position(|c| c == &col) {
                     rows.sort_by(|a, b| {
@@ -393,7 +382,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table or List".into(),
-                got: format!("{:?}", data),
+                got: data.type_name().to_string(),
             }),
         }
 
@@ -436,7 +425,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "List or Block".into(),
-                got: format!("{:?}", cols_val),
+                got: cols_val.type_name().to_string(),
             }),
         };
 
@@ -461,7 +450,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         }
 
@@ -490,7 +479,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table or List".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         }
 
@@ -523,7 +512,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table or List".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         }
 
@@ -563,7 +552,7 @@ impl Evaluator {
             }
             _ => return Err(EvalError::TypeError {
                 expected: "Table or List".into(),
-                got: format!("{:?}", table),
+                got: table.type_name().to_string(),
             }),
         }
 
@@ -579,7 +568,7 @@ impl Evaluator {
             Value::Block(exprs) => exprs,
             _ => return Err(EvalError::TypeError {
                 expected: "Block".into(),
-                got: format!("{:?}", block),
+                got: block.type_name().to_string(),
             }),
         };
 
@@ -793,7 +782,7 @@ impl Evaluator {
             Some(Value::Block(b)) => b,
             Some(other) => return Err(EvalError::TypeError {
                 expected: "Block".into(),
-                got: format!("{:?}", other),
+                got: other.type_name().to_string(),
             }),
             None => return Err(EvalError::StackUnderflow("tap requires block".into())),
         };
@@ -819,7 +808,7 @@ impl Evaluator {
             Some(Value::Block(b)) => b,
             Some(other) => return Err(EvalError::TypeError {
                 expected: "Block".into(),
-                got: format!("{:?}", other),
+                got: other.type_name().to_string(),
             }),
             None => return Err(EvalError::StackUnderflow("dip requires block".into())),
         };

--- a/src/eval/structured.rs
+++ b/src/eval/structured.rs
@@ -1,12 +1,14 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::{Expr, Value};
 use indexmap::IndexMap;
 use std::path::{Path, PathBuf};
 
 impl Evaluator {
     pub(crate) fn builtin_typeof(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("typeof requires a value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("typeof requires a value".into()))?;
 
         let type_name = match &val {
             // typeof treats numeric-looking strings as numbers (shell compat);
@@ -38,7 +40,9 @@ impl Evaluator {
             let potential_key = self.stack.get(self.stack.len() - 2);
             match potential_key {
                 Some(Value::Literal(_)) | Some(Value::Output(_)) => {}
-                _ => { break; }
+                _ => {
+                    break;
+                }
             }
 
             let value = self.stack.pop().unwrap();
@@ -59,13 +63,19 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_get(&mut self) -> Result<(), EvalError> {
-        let key_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("get requires key".into()))?;
-        let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
+        let key_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("get requires key".into()))?;
+        let key = key_val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: key_val.type_name().to_string(),
+        })?;
 
-        let target = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("get requires record/table".into()))?;
+        let target = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("get requires record/table".into()))?;
 
         if key.contains('.') {
             let result = self.deep_get(&target, &key);
@@ -75,22 +85,22 @@ impl Evaluator {
         }
 
         match target {
-            Value::Map(map) => {
-                match map.get(&key) {
-                    Some(v) => self.stack.push(v.clone()),
-                    None => self.stack.push(Value::Nil),
-                }
-            }
+            Value::Map(map) => match map.get(&key) {
+                Some(v) => self.stack.push(v.clone()),
+                None => self.stack.push(Value::Nil),
+            },
             Value::List(items) => {
                 if let Ok(idx) = key.parse::<usize>() {
-                    self.stack.push(items.get(idx).cloned().unwrap_or(Value::Nil));
+                    self.stack
+                        .push(items.get(idx).cloned().unwrap_or(Value::Nil));
                 } else {
                     self.stack.push(Value::Nil);
                 }
             }
             Value::Table { columns, rows } => {
                 if let Some(col_idx) = columns.iter().position(|c| c == &key) {
-                    let values: Vec<Value> = rows.iter()
+                    let values: Vec<Value> = rows
+                        .iter()
                         .map(|row| row.get(col_idx).cloned().unwrap_or(Value::Nil))
                         .collect();
                     self.stack.push(Value::List(values));
@@ -98,7 +108,13 @@ impl Evaluator {
                     self.stack.push(Value::Nil);
                 }
             }
-            Value::Error { kind, message, code, source, command } => {
+            Value::Error {
+                kind,
+                message,
+                code,
+                source,
+                command,
+            } => {
                 let field = match key.as_str() {
                     "kind" => Some(Value::Literal(kind)),
                     "message" => Some(Value::Literal(message)),
@@ -109,10 +125,12 @@ impl Evaluator {
                 };
                 self.stack.push(field.unwrap_or(Value::Nil));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Record, Table, List, or Error".into(),
-                got: target.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Record, Table, List, or Error".into(),
+                    got: target.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -120,14 +138,22 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_set(&mut self) -> Result<(), EvalError> {
-        let value = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("set requires value".into()))?;
-        let key_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("set requires key".into()))?;
-        let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
-        let target = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("set requires record".into()))?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("set requires value".into()))?;
+        let key_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("set requires key".into()))?;
+        let key = key_val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: key_val.type_name().to_string(),
+        })?;
+        let target = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("set requires record".into()))?;
 
         if key.contains('.') {
             let result = self.deep_set(target, &key, value)?;
@@ -141,10 +167,12 @@ impl Evaluator {
                 map.insert(key, value);
                 self.stack.push(Value::Map(map));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Record".into(),
-                got: target.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Record".into(),
+                    got: target.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -152,22 +180,30 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_del(&mut self) -> Result<(), EvalError> {
-        let key_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("del requires key".into()))?;
-        let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
-        let target = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("del requires record".into()))?;
+        let key_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("del requires key".into()))?;
+        let key = key_val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: key_val.type_name().to_string(),
+        })?;
+        let target = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("del requires record".into()))?;
 
         match target {
             Value::Map(mut map) => {
                 map.shift_remove(&key);
                 self.stack.push(Value::Map(map));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Record".into(),
-                got: target.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Record".into(),
+                    got: target.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -175,12 +211,18 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_has(&mut self) -> Result<(), EvalError> {
-        let key_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("has? requires key".into()))?;
-        let key = key_val.as_arg().ok_or_else(||
-            EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
-        let target = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("has? requires record".into()))?;
+        let key_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("has? requires key".into()))?;
+        let key = key_val.as_arg().ok_or_else(|| EvalError::TypeError {
+            expected: "String".into(),
+            got: key_val.type_name().to_string(),
+        })?;
+        let target = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("has? requires record".into()))?;
 
         let has_key = match target {
             Value::Map(map) => map.contains_key(&key),
@@ -194,26 +236,26 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_keys(&mut self) -> Result<(), EvalError> {
-        let target = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("keys requires record".into()))?;
+        let target = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("keys requires record".into()))?;
 
         match target {
             Value::Map(map) => {
-                let keys: Vec<Value> = map.keys()
-                    .map(|k| Value::Literal(k.clone()))
-                    .collect();
+                let keys: Vec<Value> = map.keys().map(|k| Value::Literal(k.clone())).collect();
                 self.stack.push(Value::List(keys));
             }
             Value::Table { columns, .. } => {
-                let keys: Vec<Value> = columns.iter()
-                    .map(|k| Value::Literal(k.clone()))
-                    .collect();
+                let keys: Vec<Value> = columns.iter().map(|k| Value::Literal(k.clone())).collect();
                 self.stack.push(Value::List(keys));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Record or Table".into(),
-                got: target.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Record or Table".into(),
+                    got: target.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -221,18 +263,22 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_values(&mut self) -> Result<(), EvalError> {
-        let target = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("values requires record".into()))?;
+        let target = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("values requires record".into()))?;
 
         match target {
             Value::Map(map) => {
                 let values: Vec<Value> = map.values().cloned().collect();
                 self.stack.push(Value::List(values));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Record".into(),
-                got: target.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Record".into(),
+                    got: target.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -240,20 +286,26 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_merge(&mut self) -> Result<(), EvalError> {
-        let right = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("merge requires two records".into()))?;
-        let left = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("merge requires two records".into()))?;
+        let right = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("merge requires two records".into()))?;
+        let left = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("merge requires two records".into()))?;
 
         match (left, right) {
             (Value::Map(mut left_map), Value::Map(right_map)) => {
                 left_map.extend(right_map);
                 self.stack.push(Value::Map(left_map));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "two Records".into(),
-                got: "non-record values".into(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "two Records".into(),
+                    got: "non-record values".into(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -267,26 +319,33 @@ impl Evaluator {
             match val {
                 Value::Marker => break,
                 Value::Map(map) => records.push(map),
-                _ => return Err(EvalError::TypeError {
-                    expected: "Record".into(),
-                    got: val.type_name().to_string(),
-                }),
+                _ => {
+                    return Err(EvalError::TypeError {
+                        expected: "Record".into(),
+                        got: val.type_name().to_string(),
+                    })
+                }
             }
         }
 
         records.reverse();
 
         if records.is_empty() {
-            self.stack.push(Value::Table { columns: vec![], rows: vec![] });
+            self.stack.push(Value::Table {
+                columns: vec![],
+                rows: vec![],
+            });
             self.last_exit_code = 0;
             return Ok(());
         }
 
         let columns: Vec<String> = records[0].keys().cloned().collect();
 
-        let rows: Vec<Vec<Value>> = records.iter()
+        let rows: Vec<Vec<Value>> = records
+            .iter()
             .map(|rec| {
-                columns.iter()
+                columns
+                    .iter()
                     .map(|col| rec.get(col).cloned().unwrap_or(Value::Nil))
                     .collect()
             })
@@ -298,25 +357,32 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_where(&mut self) -> Result<(), EvalError> {
-        let predicate = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("where requires predicate block".into()))?;
+        let predicate = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("where requires predicate block".into()))?;
         let pred_block = match predicate {
             Value::Block(exprs) => exprs,
-            _ => return Err(EvalError::TypeError {
-                expected: "Block".into(),
-                got: predicate.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Block".into(),
+                    got: predicate.type_name().to_string(),
+                })
+            }
         };
 
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("where requires table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("where requires table".into()))?;
 
         match table {
             Value::Table { columns, rows } => {
                 let mut filtered_rows = Vec::new();
 
                 for row in rows {
-                    let record: IndexMap<String, Value> = columns.iter()
+                    let record: IndexMap<String, Value> = columns
+                        .iter()
                         .zip(row.iter())
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect();
@@ -336,12 +402,17 @@ impl Evaluator {
                     }
                 }
 
-                self.stack.push(Value::Table { columns, rows: filtered_rows });
+                self.stack.push(Value::Table {
+                    columns,
+                    rows: filtered_rows,
+                });
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -349,16 +420,22 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_sort_by(&mut self) -> Result<(), EvalError> {
-        let key_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("sort-by requires key/column".into()))?;
+        let key_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("sort-by requires key/column".into()))?;
 
-        let data = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("sort-by requires table or list".into()))?;
+        let data = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("sort-by requires table or list".into()))?;
 
         match data {
             Value::Table { columns, mut rows } => {
-                let col = key_val.as_arg().ok_or_else(||
-                    EvalError::TypeError { expected: "String".into(), got: key_val.type_name().to_string() })?;
+                let col = key_val.as_arg().ok_or_else(|| EvalError::TypeError {
+                    expected: "String".into(),
+                    got: key_val.type_name().to_string(),
+                })?;
 
                 if let Some(col_idx) = columns.iter().position(|c| c == &col) {
                     rows.sort_by(|a, b| {
@@ -380,10 +457,12 @@ impl Evaluator {
 
                 self.stack.push(Value::List(items));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table or List".into(),
-                got: data.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table or List".into(),
+                    got: data.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -392,9 +471,7 @@ impl Evaluator {
 
     pub(crate) fn extract_sort_key(val: &Value, key: &str) -> String {
         match val {
-            Value::Map(m) => m.get(key)
-                .and_then(|v| v.as_arg())
-                .unwrap_or_default(),
+            Value::Map(m) => m.get(key).and_then(|v| v.as_arg()).unwrap_or_default(),
             _ => val.as_arg().unwrap_or_default(),
         }
     }
@@ -407,51 +484,62 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_select(&mut self) -> Result<(), EvalError> {
-        let cols_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("select requires column list".into()))?;
+        let cols_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("select requires column list".into()))?;
 
         let cols: Vec<String> = match cols_val {
-            Value::List(items) => items.iter()
-                .filter_map(|v| v.as_arg())
+            Value::List(items) => items.iter().filter_map(|v| v.as_arg()).collect(),
+            Value::Block(exprs) => exprs
+                .iter()
+                .filter_map(|e| match e {
+                    Expr::Literal(s) => Some(s.clone()),
+                    Expr::Quoted { content, .. } => Some(content.clone()),
+                    _ => None,
+                })
                 .collect(),
-            Value::Block(exprs) => {
-                exprs.iter()
-                    .filter_map(|e| match e {
-                        Expr::Literal(s) => Some(s.clone()),
-                        Expr::Quoted { content, .. } => Some(content.clone()),
-                        _ => None,
-                    })
-                    .collect()
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "List or Block".into(),
+                    got: cols_val.type_name().to_string(),
+                })
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "List or Block".into(),
-                got: cols_val.type_name().to_string(),
-            }),
         };
 
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("select requires table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("select requires table".into()))?;
 
         match table {
             Value::Table { columns, rows } => {
-                let indices: Vec<usize> = cols.iter()
+                let indices: Vec<usize> = cols
+                    .iter()
                     .filter_map(|c| columns.iter().position(|col| col == c))
                     .collect();
 
-                let new_rows: Vec<Vec<Value>> = rows.iter()
+                let new_rows: Vec<Vec<Value>> = rows
+                    .iter()
                     .map(|row| {
-                        indices.iter()
+                        indices
+                            .iter()
                             .map(|&i| row.get(i).cloned().unwrap_or(Value::Nil))
                             .collect()
                     })
                     .collect();
 
-                self.stack.push(Value::Table { columns: cols, rows: new_rows });
+                self.stack.push(Value::Table {
+                    columns: cols,
+                    rows: new_rows,
+                });
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -459,28 +547,35 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_first(&mut self) -> Result<(), EvalError> {
-        let n_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("first requires count".into()))?;
-        let n: usize = n_val.as_arg()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1);
+        let n_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("first requires count".into()))?;
+        let n: usize = n_val.as_arg().and_then(|s| s.parse().ok()).unwrap_or(1);
 
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("first requires table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("first requires table".into()))?;
 
         match table {
             Value::Table { columns, rows } => {
                 let new_rows: Vec<Vec<Value>> = rows.into_iter().take(n).collect();
-                self.stack.push(Value::Table { columns, rows: new_rows });
+                self.stack.push(Value::Table {
+                    columns,
+                    rows: new_rows,
+                });
             }
             Value::List(items) => {
                 let new_items: Vec<Value> = items.into_iter().take(n).collect();
                 self.stack.push(Value::List(new_items));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table or List".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table or List".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -488,21 +583,26 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_last(&mut self) -> Result<(), EvalError> {
-        let n_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("last requires count".into()))?;
-        let n: usize = n_val.as_arg()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1);
+        let n_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("last requires count".into()))?;
+        let n: usize = n_val.as_arg().and_then(|s| s.parse().ok()).unwrap_or(1);
 
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("last requires table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("last requires table".into()))?;
 
         match table {
             Value::Table { columns, rows } => {
                 let len = rows.len();
                 let skip = len.saturating_sub(n);
                 let new_rows: Vec<Vec<Value>> = rows.into_iter().skip(skip).collect();
-                self.stack.push(Value::Table { columns, rows: new_rows });
+                self.stack.push(Value::Table {
+                    columns,
+                    rows: new_rows,
+                });
             }
             Value::List(items) => {
                 let len = items.len();
@@ -510,10 +610,12 @@ impl Evaluator {
                 let new_items: Vec<Value> = items.into_iter().skip(skip).collect();
                 self.stack.push(Value::List(new_items));
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table or List".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table or List".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -521,20 +623,23 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_nth(&mut self) -> Result<(), EvalError> {
-        let n_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nth requires index".into()))?;
-        let n: usize = n_val.as_arg()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        let n_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nth requires index".into()))?;
+        let n: usize = n_val.as_arg().and_then(|s| s.parse().ok()).unwrap_or(0);
 
-        let table = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nth requires table".into()))?;
+        let table = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nth requires table".into()))?;
 
         match table {
             Value::Table { columns, rows } => {
                 if n < rows.len() {
                     let row = &rows[n];
-                    let record: IndexMap<String, Value> = columns.iter()
+                    let record: IndexMap<String, Value> = columns
+                        .iter()
                         .zip(row.iter())
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect();
@@ -550,10 +655,12 @@ impl Evaluator {
                     self.stack.push(Value::Nil);
                 }
             }
-            _ => return Err(EvalError::TypeError {
-                expected: "Table or List".into(),
-                got: table.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table or List".into(),
+                    got: table.type_name().to_string(),
+                })
+            }
         }
 
         self.last_exit_code = 0;
@@ -561,15 +668,19 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_try(&mut self) -> Result<(), EvalError> {
-        let block = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("try requires block".into()))?;
+        let block = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("try requires block".into()))?;
 
         let exprs = match block {
             Value::Block(exprs) => exprs,
-            _ => return Err(EvalError::TypeError {
-                expected: "Block".into(),
-                got: block.type_name().to_string(),
-            }),
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Block".into(),
+                    got: block.type_name().to_string(),
+                })
+            }
         };
 
         let saved_stack = self.stack.clone();
@@ -602,8 +713,10 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_error_predicate(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("error? requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("error? requires value".into()))?;
 
         let is_error = matches!(val, Value::Error { .. });
         self.stack.push(val);
@@ -616,8 +729,10 @@ impl Evaluator {
     /// Check if value is nil (non-destructive)
     /// Usage: value nil?
     pub(crate) fn builtin_nil_predicate(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nil? requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nil? requires value".into()))?;
 
         let is_nil = matches!(val, Value::Nil);
         self.stack.push(val);
@@ -631,8 +746,10 @@ impl Evaluator {
     /// Includes Value::Number and string literals that parse as f64
     /// Usage: value number?
     pub(crate) fn builtin_number_predicate(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("number? requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("number? requires value".into()))?;
 
         let is_number = match &val {
             Value::Number(_) => true,
@@ -648,8 +765,10 @@ impl Evaluator {
     /// Check if value is a string (non-destructive)
     /// Usage: value string?
     pub(crate) fn builtin_string_predicate(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("string? requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("string? requires value".into()))?;
 
         let is_string = matches!(val, Value::Literal(_) | Value::Output(_));
         self.stack.push(val);
@@ -661,8 +780,10 @@ impl Evaluator {
     /// Check if value is a list/array (non-destructive)
     /// Usage: value array?
     pub(crate) fn builtin_array_predicate(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("array? requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("array? requires value".into()))?;
 
         let is_array = matches!(val, Value::List(_));
         self.stack.push(val);
@@ -674,8 +795,10 @@ impl Evaluator {
     /// Check if value is a block/function (non-destructive)
     /// Usage: value function?
     pub(crate) fn builtin_function_predicate(&mut self) -> Result<(), EvalError> {
-        let val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("function? requires value".into()))?;
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("function? requires value".into()))?;
 
         let is_function = matches!(val, Value::Block(_));
         self.stack.push(val);
@@ -695,10 +818,14 @@ impl Evaluator {
     /// Usage: <expr1> <expr2> xor
     /// Pops two booleans/values, checks their truthiness, XORs them
     pub(crate) fn builtin_xor(&mut self) -> Result<(), EvalError> {
-        let b = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("xor requires two values".into()))?;
-        let a = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("xor requires two values".into()))?;
+        let b = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("xor requires two values".into()))?;
+        let a = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("xor requires two values".into()))?;
 
         let a_truthy = Self::value_is_truthy(&a);
         let b_truthy = Self::value_is_truthy(&b);
@@ -710,10 +837,14 @@ impl Evaluator {
     /// Logical NAND: true unless both values are truthy
     /// Usage: <expr1> <expr2> nand
     pub(crate) fn builtin_nand(&mut self) -> Result<(), EvalError> {
-        let b = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nand requires two values".into()))?;
-        let a = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nand requires two values".into()))?;
+        let b = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nand requires two values".into()))?;
+        let a = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nand requires two values".into()))?;
 
         let a_truthy = Self::value_is_truthy(&a);
         let b_truthy = Self::value_is_truthy(&b);
@@ -725,10 +856,14 @@ impl Evaluator {
     /// Logical NOR: true only if both values are falsy
     /// Usage: <expr1> <expr2> nor
     pub(crate) fn builtin_nor(&mut self) -> Result<(), EvalError> {
-        let b = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nor requires two values".into()))?;
-        let a = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("nor requires two values".into()))?;
+        let b = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nor requires two values".into()))?;
+        let a = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("nor requires two values".into()))?;
 
         let a_truthy = Self::value_is_truthy(&a);
         let b_truthy = Self::value_is_truthy(&b);
@@ -761,9 +896,13 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_throw(&mut self) -> Result<(), EvalError> {
-        let msg_val = self.stack.pop().ok_or_else(||
-            EvalError::StackUnderflow("throw requires message".into()))?;
-        let message = msg_val.as_arg().unwrap_or_else(|| "unknown error".to_string());
+        let msg_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("throw requires message".into()))?;
+        let message = msg_val
+            .as_arg()
+            .unwrap_or_else(|| "unknown error".to_string());
 
         self.stack.push(Value::Error {
             kind: "thrown".to_string(),
@@ -780,15 +919,19 @@ impl Evaluator {
     pub(crate) fn builtin_tap(&mut self) -> Result<(), EvalError> {
         let block = match self.stack.pop() {
             Some(Value::Block(b)) => b,
-            Some(other) => return Err(EvalError::TypeError {
-                expected: "Block".into(),
-                got: other.type_name().to_string(),
-            }),
+            Some(other) => {
+                return Err(EvalError::TypeError {
+                    expected: "Block".into(),
+                    got: other.type_name().to_string(),
+                })
+            }
             None => return Err(EvalError::StackUnderflow("tap requires block".into())),
         };
 
-        let original = self.stack.last().cloned()
-            .ok_or_else(|| EvalError::StackUnderflow("tap requires a value under block".into()))?;
+        let original =
+            self.stack.last().cloned().ok_or_else(|| {
+                EvalError::StackUnderflow("tap requires a value under block".into())
+            })?;
 
         let depth_before_original = self.stack.len() - 1;
 
@@ -806,14 +949,18 @@ impl Evaluator {
     pub(crate) fn builtin_dip(&mut self) -> Result<(), EvalError> {
         let block = match self.stack.pop() {
             Some(Value::Block(b)) => b,
-            Some(other) => return Err(EvalError::TypeError {
-                expected: "Block".into(),
-                got: other.type_name().to_string(),
-            }),
+            Some(other) => {
+                return Err(EvalError::TypeError {
+                    expected: "Block".into(),
+                    got: other.type_name().to_string(),
+                })
+            }
             None => return Err(EvalError::StackUnderflow("dip requires block".into())),
         };
 
-        let saved = self.stack.pop()
+        let saved = self
+            .stack
+            .pop()
             .ok_or_else(|| EvalError::StackUnderflow("dip requires a value under block".into()))?;
 
         for expr in &block {
@@ -845,7 +992,10 @@ impl Evaluator {
         };
 
         let entries = fs::read_dir(&dir_path).map_err(|e| {
-            EvalError::IoError(std::io::Error::new(e.kind(), format!("{}: {}", dir_path.display(), e)))
+            EvalError::IoError(std::io::Error::new(
+                e.kind(),
+                format!("{}: {}", dir_path.display(), e),
+            ))
         })?;
 
         let columns = vec![
@@ -857,27 +1007,31 @@ impl Evaluator {
 
         let mut rows: Vec<Vec<Value>> = Vec::new();
 
-        for entry in entries {
-            if let Ok(entry) = entry {
-                let name = entry.file_name().to_string_lossy().to_string();
-                let metadata = entry.metadata();
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let metadata = entry.metadata();
 
-                let (file_type, size, modified) = if let Ok(meta) = &metadata {
-                    let ft = if meta.is_dir() { "dir" } else if meta.is_file() { "file" } else { "other" };
-                    let sz = meta.len();
-                    let mod_time = meta.mtime();
-                    (ft.to_string(), sz, mod_time)
+            let (file_type, size, modified) = if let Ok(meta) = &metadata {
+                let ft = if meta.is_dir() {
+                    "dir"
+                } else if meta.is_file() {
+                    "file"
                 } else {
-                    ("unknown".to_string(), 0, 0)
+                    "other"
                 };
+                let sz = meta.len();
+                let mod_time = meta.mtime();
+                (ft.to_string(), sz, mod_time)
+            } else {
+                ("unknown".to_string(), 0, 0)
+            };
 
-                rows.push(vec![
-                    Value::Literal(name),
-                    Value::Literal(file_type),
-                    Value::Number(size as f64),
-                    Value::Number(modified as f64),
-                ]);
-            }
+            rows.push(vec![
+                Value::Literal(name),
+                Value::Literal(file_type),
+                Value::Number(size as f64),
+                Value::Number(modified as f64),
+            ]);
         }
 
         rows.sort_by(|a, b| {

--- a/src/eval/structured.rs
+++ b/src/eval/structured.rs
@@ -1,6 +1,6 @@
 use super::{Evaluator, EvalError};
 use crate::ast::{Expr, Value};
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::path::{Path, PathBuf};
 
 impl Evaluator {
@@ -63,7 +63,7 @@ impl Evaluator {
         }
 
         pairs.reverse();
-        let map: HashMap<String, Value> = pairs.into_iter().collect();
+        let map: IndexMap<String, Value> = pairs.into_iter().collect();
         self.stack.push(Value::Map(map));
         self.last_exit_code = 0;
         Ok(())
@@ -172,7 +172,7 @@ impl Evaluator {
 
         match target {
             Value::Map(mut map) => {
-                map.remove(&key);
+                map.shift_remove(&key);
                 self.stack.push(Value::Map(map));
             }
             _ => return Err(EvalError::TypeError {
@@ -272,7 +272,7 @@ impl Evaluator {
     }
 
     pub(crate) fn builtin_table(&mut self) -> Result<(), EvalError> {
-        let mut records: Vec<HashMap<String, Value>> = Vec::new();
+        let mut records: Vec<IndexMap<String, Value>> = Vec::new();
 
         while let Some(val) = self.stack.pop() {
             match val {
@@ -327,7 +327,7 @@ impl Evaluator {
                 let mut filtered_rows = Vec::new();
 
                 for row in rows {
-                    let record: HashMap<String, Value> = columns.iter()
+                    let record: IndexMap<String, Value> = columns.iter()
                         .zip(row.iter())
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect();
@@ -545,7 +545,7 @@ impl Evaluator {
             Value::Table { columns, rows } => {
                 if n < rows.len() {
                     let row = &rows[n];
-                    let record: HashMap<String, Value> = columns.iter()
+                    let record: IndexMap<String, Value> = columns.iter()
                         .zip(row.iter())
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect();

--- a/src/eval/terminal.rs
+++ b/src/eval/terminal.rs
@@ -53,7 +53,7 @@ impl Evaluator {
 
         match link {
             Value::Link { url, text } => {
-                let mut map = std::collections::HashMap::new();
+                let mut map = indexmap::IndexMap::new();
                 map.insert("url".to_string(), Value::Literal(url));
                 if let Some(t) = text {
                     map.insert("text".to_string(), Value::Literal(t));

--- a/src/eval/terminal.rs
+++ b/src/eval/terminal.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -6,13 +6,14 @@ impl Evaluator {
     /// The link will be displayed as a clickable hyperlink in supported terminals
     pub(crate) fn builtin_link(&mut self) -> Result<(), EvalError> {
         // Check if we have 2 items (url + text) or 1 item (url only)
-        let top = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError("link requires URL on stack".to_string())
-        })?;
+        let top = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError("link requires URL on stack".to_string()))?;
 
-        let url = top.as_arg().ok_or_else(|| {
-            EvalError::ExecError("link requires URL string".to_string())
-        })?;
+        let url = top
+            .as_arg()
+            .ok_or_else(|| EvalError::ExecError("link requires URL string".to_string()))?;
 
         // Check if there's another item that could be text
         let text = if let Some(prev) = self.stack.last() {
@@ -63,7 +64,9 @@ impl Evaluator {
             }
             other => {
                 self.stack.push(other);
-                return Err(EvalError::ExecError("link-info requires a Link value".to_string()));
+                return Err(EvalError::ExecError(
+                    "link-info requires a Link value".to_string(),
+                ));
             }
         }
 
@@ -73,11 +76,12 @@ impl Evaluator {
     /// Copy value to system clipboard using OSC 52
     /// value .copy -> (value unchanged, data copied to clipboard)
     pub(crate) fn builtin_clip_copy(&mut self) -> Result<(), EvalError> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
 
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError(".copy requires a value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError(".copy requires a value on stack".to_string()))?;
 
         // Get string representation of value
         let text = value.as_arg().ok_or_else(|| {
@@ -103,11 +107,12 @@ impl Evaluator {
     /// Copy value to clipboard and drop it from stack (destructive)
     /// value .cut -> ()
     pub(crate) fn builtin_clip_cut(&mut self) -> Result<(), EvalError> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
 
-        let value = self.stack.pop().ok_or_else(|| {
-            EvalError::ExecError(".cut requires a value on stack".to_string())
-        })?;
+        let value = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::ExecError(".cut requires a value on stack".to_string()))?;
 
         let text = value.as_arg().ok_or_else(|| {
             EvalError::ExecError(".cut requires a value with string representation".to_string())
@@ -125,7 +130,7 @@ impl Evaluator {
     /// Query the system clipboard using OSC 52 and return contents
     #[cfg(unix)]
     pub(crate) fn query_clipboard(&self) -> Result<String, EvalError> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
         use std::io::{Read, Write};
         use std::os::unix::io::AsRawFd;
 
@@ -133,13 +138,17 @@ impl Evaluator {
 
         // Check if stdin is a TTY
         if unsafe { libc::isatty(stdin_fd) } == 0 {
-            return Err(EvalError::ExecError("Clipboard access requires a terminal".to_string()));
+            return Err(EvalError::ExecError(
+                "Clipboard access requires a terminal".to_string(),
+            ));
         }
 
         // Save current terminal settings
         let mut orig_termios: libc::termios = unsafe { std::mem::zeroed() };
         if unsafe { libc::tcgetattr(stdin_fd, &mut orig_termios) } != 0 {
-            return Err(EvalError::ExecError("Failed to get terminal attributes".to_string()));
+            return Err(EvalError::ExecError(
+                "Failed to get terminal attributes".to_string(),
+            ));
         }
 
         // Set raw mode (disable canonical mode and echo)
@@ -158,7 +167,9 @@ impl Evaluator {
         print!("\x1b]52;c;?\x07");
         if std::io::stdout().flush().is_err() {
             restore(stdin_fd, &orig_termios);
-            return Err(EvalError::ExecError("Failed to send clipboard query".to_string()));
+            return Err(EvalError::ExecError(
+                "Failed to send clipboard query".to_string(),
+            ));
         }
 
         // Read response with timeout
@@ -179,14 +190,12 @@ impl Evaluator {
             if start.elapsed() > timeout {
                 restore(stdin_fd, &orig_termios);
                 return Err(EvalError::ExecError(
-                    "Clipboard query timed out (terminal may not support OSC 52)".to_string()
+                    "Clipboard query timed out (terminal may not support OSC 52)".to_string(),
                 ));
             }
 
             // Poll for input with short timeout
-            let poll_result = unsafe {
-                libc::poll(poll_fd.as_mut_ptr(), 1, 50)
-            };
+            let poll_result = unsafe { libc::poll(poll_fd.as_mut_ptr(), 1, 50) };
 
             if poll_result > 0 && (poll_fd[0].revents & libc::POLLIN) != 0 {
                 let mut buf = [0u8; 1];
@@ -199,7 +208,7 @@ impl Evaluator {
                     }
                     if response.len() >= 2 {
                         let len = response.len();
-                        if response[len-2] == 0x1b && response[len-1] == b'\\' {
+                        if response[len - 2] == 0x1b && response[len - 1] == b'\\' {
                             break;
                         }
                     }
@@ -215,7 +224,8 @@ impl Evaluator {
 
         // Find the base64 data between "52;c;" and the terminator
         let start_marker = "52;c;";
-        let start_pos = response_str.find(start_marker)
+        let start_pos = response_str
+            .find(start_marker)
             .ok_or_else(|| EvalError::ExecError("Invalid clipboard response".to_string()))?;
 
         let b64_start = start_pos + start_marker.len();
@@ -230,18 +240,19 @@ impl Evaluator {
         }
 
         // Decode base64
-        let decoded = STANDARD.decode(&b64_data).map_err(|e| {
-            EvalError::ExecError(format!("Failed to decode clipboard data: {}", e))
-        })?;
+        let decoded = STANDARD
+            .decode(&b64_data)
+            .map_err(|e| EvalError::ExecError(format!("Failed to decode clipboard data: {}", e)))?;
 
-        String::from_utf8(decoded).map_err(|e| {
-            EvalError::ExecError(format!("Clipboard data is not valid UTF-8: {}", e))
-        })
+        String::from_utf8(decoded)
+            .map_err(|e| EvalError::ExecError(format!("Clipboard data is not valid UTF-8: {}", e)))
     }
 
     #[cfg(not(unix))]
     pub(crate) fn query_clipboard(&self) -> Result<String, EvalError> {
-        Err(EvalError::ExecError("Clipboard access is only supported on Unix".to_string()))
+        Err(EvalError::ExecError(
+            "Clipboard access is only supported on Unix".to_string(),
+        ))
     }
 
     /// Paste from system clipboard using OSC 52 query

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -1,7 +1,10 @@
+// The file is eval/tests.rs, so the conventional `mod tests` wrapper
+// trips clippy::module_inception; the path is intentional.
+#[allow(clippy::module_inception)]
 #[cfg(test)]
 mod tests {
-    use crate::eval::*;
     use crate::ast::{Expr, Value};
+    use crate::eval::*;
     use crate::lexer::lex;
     use crate::parser::parse;
 
@@ -188,7 +191,10 @@ mod tests {
         let eval = Evaluator::new();
 
         // Test various expression types
-        assert_eq!(eval.expr_to_string(&Expr::Literal("test".to_string())), "test");
+        assert_eq!(
+            eval.expr_to_string(&Expr::Literal("test".to_string())),
+            "test"
+        );
         assert_eq!(eval.expr_to_string(&Expr::Dup), "dup");
         assert_eq!(eval.expr_to_string(&Expr::Swap), "swap");
         assert_eq!(eval.expr_to_string(&Expr::Pipe), "|");
@@ -220,7 +226,8 @@ mod tests {
     fn test_limbo_ref_resolves_value() {
         let mut eval = Evaluator::new();
         // Insert a value in limbo
-        eval.limbo.insert("0001".to_string(), Value::Literal("hello".to_string()));
+        eval.limbo
+            .insert("0001".to_string(), Value::Literal("hello".to_string()));
 
         // Parse and eval a limbo reference (note: `&` prefix, ID extracted)
         let tokens = lex("`&0001`").expect("lex");
@@ -272,7 +279,8 @@ mod tests {
     #[test]
     fn test_limbo_ref_double_use_second_is_nil() {
         let mut eval = Evaluator::new();
-        eval.limbo.insert("once".to_string(), Value::Literal("value".to_string()));
+        eval.limbo
+            .insert("once".to_string(), Value::Literal("value".to_string()));
 
         // Use the same ref twice
         let tokens = lex("`&once` `&once`").expect("lex");
@@ -419,7 +427,8 @@ mod tests {
 
     #[test]
     fn test_snapshot_clear() {
-        let tokens = lex("\"a\" snapshot \"b\" snapshot snapshot-clear snapshot-list").expect("lex");
+        let tokens =
+            lex("\"a\" snapshot \"b\" snapshot snapshot-clear snapshot-list").expect("lex");
         let program = parse(tokens).expect("parse");
         let mut eval = Evaluator::new();
         eval.eval(&program).expect("eval");
@@ -465,7 +474,10 @@ mod tests {
         if let Some(s) = eval.stack[0].as_arg() {
             assert_eq!(s, "42");
         } else {
-            panic!("Expected value with string representation, got {:?}", eval.stack[0]);
+            panic!(
+                "Expected value with string representation, got {:?}",
+                eval.stack[0]
+            );
         }
     }
 
@@ -538,7 +550,11 @@ mod tests {
         // Should have one result (either "1" or "2" as Literal)
         assert_eq!(eval.stack.len(), 1);
         let result = format!("{:?}", eval.stack[0]);
-        assert!(result.contains("1") || result.contains("2"), "Expected 1 or 2, got: {}", result);
+        assert!(
+            result.contains("1") || result.contains("2"),
+            "Expected 1 or 2, got: {}",
+            result
+        );
     }
 
     #[test]
@@ -588,16 +604,15 @@ mod tests {
     fn test_future_await_n() {
         let mut eval = Evaluator::new();
         // Create 3 futures and await them all with future-await-n
-        let tokens = lex("#[\"a\"] async #[\"b\"] async #[\"c\"] async 3 future-await-n").expect("lex");
+        let tokens =
+            lex("#[\"a\"] async #[\"b\"] async #[\"c\"] async 3 future-await-n").expect("lex");
         let program = parse(tokens).expect("parse");
         eval.eval(&program).expect("eval");
 
         // Should have 3 results on stack (not in a list, just on stack)
         assert_eq!(eval.stack.len(), 3);
         // Results should be "a", "b", "c" (in order they were created)
-        let results: Vec<String> = eval.stack.iter()
-            .filter_map(|v| v.as_arg())
-            .collect();
+        let results: Vec<String> = eval.stack.iter().filter_map(|v| v.as_arg()).collect();
         assert!(results.contains(&"a".to_string()));
         assert!(results.contains(&"b".to_string()));
         assert!(results.contains(&"c".to_string()));
@@ -641,7 +656,8 @@ mod tests {
     fn test_fields() {
         let mut eval = Evaluator::new();
         // Create a record using the correct syntax
-        let tokens = lex("\"name\" \"Alice\" \"age\" 30 \"email\" \"a@b.com\" record").expect("lex");
+        let tokens =
+            lex("\"name\" \"Alice\" \"age\" 30 \"email\" \"a@b.com\" record").expect("lex");
         let program = parse(tokens).expect("parse");
         eval.eval(&program).expect("eval");
         // Push the list of keys
@@ -656,9 +672,7 @@ mod tests {
 
         // Should have 2 values on stack (no marker)
         assert_eq!(eval.stack.len(), 2);
-        let results: Vec<String> = eval.stack.iter()
-            .filter_map(|v| v.as_arg())
-            .collect();
+        let results: Vec<String> = eval.stack.iter().filter_map(|v| v.as_arg()).collect();
         assert!(results.contains(&"Alice".to_string()));
         assert!(results.contains(&"30".to_string()));
     }
@@ -786,70 +800,193 @@ mod tests {
         assert!(eval.local_values.last().unwrap().contains_key("c"));
 
         // Verify values
-        assert_eq!(eval.local_values.last().unwrap().get("a").unwrap().as_arg().unwrap(), "1");
-        assert_eq!(eval.local_values.last().unwrap().get("b").unwrap().as_arg().unwrap(), "2");
-        assert_eq!(eval.local_values.last().unwrap().get("c").unwrap().as_arg().unwrap(), "3");
+        assert_eq!(
+            eval.local_values
+                .last()
+                .unwrap()
+                .get("a")
+                .unwrap()
+                .as_arg()
+                .unwrap(),
+            "1"
+        );
+        assert_eq!(
+            eval.local_values
+                .last()
+                .unwrap()
+                .get("b")
+                .unwrap()
+                .as_arg()
+                .unwrap(),
+            "2"
+        );
+        assert_eq!(
+            eval.local_values
+                .last()
+                .unwrap()
+                .get("c")
+                .unwrap()
+                .as_arg()
+                .unwrap(),
+            "3"
+        );
     }
 
     // === HTTP Client Tests ===
-    // Note: These tests use httpbin.org as a test endpoint
+    // Hermetic (issue #34): each test spawns a tiny local TcpListener server
+    // with a canned response instead of hitting httpbin.org.
+
+    /// Read a full HTTP request (headers + Content-Length body) from a stream.
+    fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+        use std::io::Read;
+        let mut data: Vec<u8> = Vec::new();
+        let mut buf = [0u8; 1024];
+        let header_end = loop {
+            if let Some(pos) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => return String::from_utf8_lossy(&data).to_string(),
+                Ok(n) => data.extend_from_slice(&buf[..n]),
+            }
+        };
+        let headers = String::from_utf8_lossy(&data[..header_end]).to_string();
+        let content_length: usize = headers
+            .lines()
+            .find_map(|l| {
+                let (name, value) = l.split_once(':')?;
+                if name.eq_ignore_ascii_case("content-length") {
+                    value.trim().parse().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+        while data.len() < header_end + content_length {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => data.extend_from_slice(&buf[..n]),
+            }
+        }
+        String::from_utf8_lossy(&data).to_string()
+    }
+
+    /// Spawn a one-shot local HTTP server. Serves a single request with the
+    /// given status/content-type/body; if `echo_request` is true the body is
+    /// the received request text instead. Returns the server's base URL.
+    fn serve_once(
+        status: u16,
+        content_type: &'static str,
+        body: String,
+        extra_headers: &'static str,
+        echo_request: bool,
+    ) -> String {
+        use std::io::Write;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let request = read_http_request(&mut stream);
+                let body = if echo_request { request } else { body };
+                let response = format!(
+                    "HTTP/1.1 {} X\r\nContent-Type: {}\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    status,
+                    content_type,
+                    extra_headers,
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        format!("http://{}", addr)
+    }
 
     #[test]
     fn test_fetch_get_basic() {
+        let url = serve_once(
+            200,
+            "text/plain",
+            "hello from local server".into(),
+            "",
+            false,
+        );
         let mut eval = Evaluator::new();
-        // Simple GET request
-        let tokens = lex("\"https://httpbin.org/get\" fetch").expect("lex");
+        let tokens = lex(&format!("\"{}\" fetch", url)).expect("lex");
         let program = parse(tokens).expect("parse");
         let result = eval.eval(&program);
 
-        // Should succeed and return response body
-        assert!(result.is_ok(), "fetch should succeed");
+        assert!(result.is_ok(), "fetch should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        // Response should contain the URL we requested
         let response = eval.stack[0].as_arg().unwrap();
-        assert!(response.contains("httpbin.org"), "response should contain the URL");
+        assert!(
+            response.contains("hello from local server"),
+            "response should contain the served body: {}",
+            response
+        );
     }
 
     #[test]
     fn test_fetch_get_json_response() {
+        let url = serve_once(
+            200,
+            "application/json",
+            "{\"key\":\"value\"}".into(),
+            "",
+            false,
+        );
         let mut eval = Evaluator::new();
-        // GET request that returns JSON
-        let tokens = lex("\"https://httpbin.org/json\" fetch").expect("lex");
+        let tokens = lex(&format!("\"{}\" fetch", url)).expect("lex");
         let program = parse(tokens).expect("parse");
         let result = eval.eval(&program);
 
-        assert!(result.is_ok(), "fetch should succeed");
+        assert!(result.is_ok(), "fetch should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        // Response should be parsed as a Map (JSON object)
-        assert!(matches!(eval.stack[0], Value::Map(_)), "JSON response should be parsed as Map");
+        // JSON response should be parsed as a Map
+        assert!(
+            matches!(eval.stack[0], Value::Map(_)),
+            "JSON response should be parsed as Map"
+        );
     }
 
     #[test]
     fn test_fetch_post_with_body() {
+        // Echo server: response body is the raw request (method, headers, body)
+        let url = serve_once(200, "text/plain", String::new(), "", true);
         let mut eval = Evaluator::new();
-        // POST request with JSON body
-        let tokens = lex("\"{\\\"name\\\":\\\"test\\\"}\" \"https://httpbin.org/post\" \"POST\" fetch").expect("lex");
+        let tokens = lex(&format!(
+            "\"{{\\\"name\\\":\\\"test\\\"}}\" \"{}\" \"POST\" fetch",
+            url
+        ))
+        .expect("lex");
         let program = parse(tokens).expect("parse");
         let result = eval.eval(&program);
 
-        assert!(result.is_ok(), "fetch POST should succeed");
+        assert!(result.is_ok(), "fetch POST should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        // httpbin echoes back what you send
         let response = eval.stack[0].as_arg().unwrap_or_default();
-        assert!(response.contains("test"), "response should contain echoed data");
+        assert!(
+            response.contains("POST"),
+            "request method should be POST: {}",
+            response
+        );
+        assert!(
+            response.contains("test"),
+            "response should contain echoed data: {}",
+            response
+        );
     }
 
     #[test]
     fn test_fetch_status() {
+        let url = serve_once(200, "text/plain", "ok".into(), "", false);
         let mut eval = Evaluator::new();
-        // Get status code
-        let tokens = lex("\"https://httpbin.org/status/200\" fetch-status").expect("lex");
+        let tokens = lex(&format!("\"{}\" fetch-status", url)).expect("lex");
         let program = parse(tokens).expect("parse");
         let result = eval.eval(&program);
 
-        assert!(result.is_ok(), "fetch-status should succeed");
+        assert!(result.is_ok(), "fetch-status should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        // Should return numeric status code
         if let Value::Number(n) = &eval.stack[0] {
             assert_eq!(*n, 200.0);
         } else {
@@ -858,32 +995,76 @@ mod tests {
     }
 
     #[test]
-    fn test_fetch_headers() {
+    fn test_fetch_status_error_code() {
+        let url = serve_once(404, "text/plain", "not found".into(), "", false);
         let mut eval = Evaluator::new();
-        // Get response headers
-        let tokens = lex("\"https://httpbin.org/headers\" fetch-headers").expect("lex");
+        let tokens = lex(&format!("\"{}\" fetch-status", url)).expect("lex");
         let program = parse(tokens).expect("parse");
         let result = eval.eval(&program);
 
-        assert!(result.is_ok(), "fetch-headers should succeed");
+        assert!(result.is_ok(), "fetch-status should succeed: {:?}", result);
+        if let Value::Number(n) = &eval.stack[0] {
+            assert_eq!(*n, 404.0);
+        } else {
+            panic!("Expected Number for status code");
+        }
+    }
+
+    #[test]
+    fn test_fetch_headers() {
+        let url = serve_once(
+            200,
+            "text/plain",
+            "ok".into(),
+            "X-Test-Header: hsab\r\n",
+            false,
+        );
+        let mut eval = Evaluator::new();
+        let tokens = lex(&format!("\"{}\" fetch-headers", url)).expect("lex");
+        let program = parse(tokens).expect("parse");
+        let result = eval.eval(&program);
+
+        assert!(result.is_ok(), "fetch-headers should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        // Should return a Map of headers
-        assert!(matches!(eval.stack[0], Value::Map(_)), "headers should be a Map");
+        match &eval.stack[0] {
+            Value::Map(headers) => {
+                assert!(
+                    headers
+                        .keys()
+                        .any(|k| k.eq_ignore_ascii_case("x-test-header")),
+                    "headers should include the served X-Test-Header: {:?}",
+                    headers.keys().collect::<Vec<_>>()
+                );
+            }
+            other => panic!("headers should be a Map, got {}", other.type_name()),
+        }
     }
 
     #[test]
     fn test_fetch_put_method() {
+        let url = serve_once(200, "text/plain", String::new(), "", true);
         let mut eval = Evaluator::new();
-        // Test PUT method
-        let tokens = lex("\"{\\\"data\\\":\\\"test\\\"}\" \"https://httpbin.org/put\" \"PUT\" fetch").expect("lex");
+        let tokens = lex(&format!(
+            "\"{{\\\"data\\\":\\\"test\\\"}}\" \"{}\" \"PUT\" fetch",
+            url
+        ))
+        .expect("lex");
         let program = parse(tokens).expect("parse");
         let result = eval.eval(&program);
 
-        assert!(result.is_ok(), "fetch PUT should succeed");
+        assert!(result.is_ok(), "fetch PUT should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        // httpbin echoes back the request
         let response = eval.stack[0].as_arg().unwrap_or_default();
-        assert!(response.contains("test"), "response should contain echoed data");
+        assert!(
+            response.contains("PUT"),
+            "request method should be PUT: {}",
+            response
+        );
+        assert!(
+            response.contains("test"),
+            "response should contain echoed data: {}",
+            response
+        );
     }
 
     #[test]
@@ -895,8 +1076,10 @@ mod tests {
         let result = eval.eval(&program);
 
         // Should fail gracefully
-        assert!(result.is_err() || eval.last_exit_code != 0,
-            "fetch to invalid domain should fail");
+        assert!(
+            result.is_err() || eval.last_exit_code != 0,
+            "fetch to invalid domain should fail"
+        );
     }
 
     // === Watch Mode Tests ===
@@ -905,7 +1088,6 @@ mod tests {
 
     #[cfg(feature = "plugins")]
     #[test]
-    #[cfg(feature = "plugins")]
     fn test_watch_requires_pattern() {
         let mut eval = Evaluator::new();
         // watch with no pattern should fail
@@ -919,7 +1101,6 @@ mod tests {
 
     #[cfg(feature = "plugins")]
     #[test]
-    #[cfg(feature = "plugins")]
     fn test_watch_requires_block() {
         let mut eval = Evaluator::new();
         // watch with pattern but no block should fail

--- a/src/eval/vector.rs
+++ b/src/eval/vector.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::Value;
 
 impl Evaluator {
@@ -11,13 +11,12 @@ impl Evaluator {
         if vec1.len() != vec2.len() {
             return Err(EvalError::ExecError(format!(
                 "dot-product: vectors must have same length ({} vs {})",
-                vec1.len(), vec2.len()
+                vec1.len(),
+                vec2.len()
             )));
         }
 
-        let result: f64 = vec1.iter().zip(vec2.iter())
-            .map(|(a, b)| a * b)
-            .sum();
+        let result: f64 = vec1.iter().zip(vec2.iter()).map(|(a, b)| a * b).sum();
 
         self.stack.push(Value::Number(result));
         self.last_exit_code = 0;
@@ -65,13 +64,12 @@ impl Evaluator {
         if vec1.len() != vec2.len() {
             return Err(EvalError::ExecError(format!(
                 "cosine-similarity: vectors must have same length ({} vs {})",
-                vec1.len(), vec2.len()
+                vec1.len(),
+                vec2.len()
             )));
         }
 
-        let dot: f64 = vec1.iter().zip(vec2.iter())
-            .map(|(a, b)| a * b)
-            .sum();
+        let dot: f64 = vec1.iter().zip(vec2.iter()).map(|(a, b)| a * b).sum();
         let mag1: f64 = vec1.iter().map(|x| x * x).sum::<f64>().sqrt();
         let mag2: f64 = vec2.iter().map(|x| x * x).sum::<f64>().sqrt();
 
@@ -95,11 +93,14 @@ impl Evaluator {
         if vec1.len() != vec2.len() {
             return Err(EvalError::ExecError(format!(
                 "euclidean-distance: vectors must have same length ({} vs {})",
-                vec1.len(), vec2.len()
+                vec1.len(),
+                vec2.len()
             )));
         }
 
-        let sum_sq: f64 = vec1.iter().zip(vec2.iter())
+        let sum_sq: f64 = vec1
+            .iter()
+            .zip(vec2.iter())
             .map(|(a, b)| (a - b).powi(2))
             .sum();
         let result = sum_sq.sqrt();

--- a/src/eval/watch.rs
+++ b/src/eval/watch.rs
@@ -6,17 +6,17 @@
 //!   "src/*.rs" [cargo build] watch        # Watch with defaults
 //!   "src/*.rs" [cargo build] 500 watch    # Watch with 500ms debounce
 
-use super::{Evaluator, EvalError};
+use super::{EvalError, Evaluator};
 use crate::ast::{Expr, Value};
 
 #[cfg(feature = "plugins")]
 mod watch_impl {
     use super::*;
-    use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher, Event};
+    use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+    use std::collections::HashSet;
     use std::path::Path;
     use std::sync::mpsc::{channel, RecvTimeoutError};
     use std::time::{Duration, Instant};
-    use std::collections::HashSet;
 
     impl Evaluator {
         /// watch: "pattern" #[block] watch -> (blocks until Ctrl+C)
@@ -28,8 +28,14 @@ mod watch_impl {
             // Check for optional debounce value
             let (pattern, debounce_ms) = if let Some(Value::Number(_)) = self.stack.last() {
                 let debounce = self.stack.pop().unwrap();
-                let d = if let Value::Number(n) = debounce { n as u64 } else { 200 };
-                let p = self.stack.pop()
+                let d = if let Value::Number(n) = debounce {
+                    n as u64
+                } else {
+                    200
+                };
+                let p = self
+                    .stack
+                    .pop()
                     .ok_or_else(|| EvalError::StackUnderflow("watch requires pattern".into()))?
                     .as_arg()
                     .ok_or_else(|| EvalError::TypeError {
@@ -38,7 +44,9 @@ mod watch_impl {
                     })?;
                 (p, d)
             } else {
-                let p = self.stack.pop()
+                let p = self
+                    .stack
+                    .pop()
                     .ok_or_else(|| EvalError::StackUnderflow("watch requires pattern".into()))?
                     .as_arg()
                     .ok_or_else(|| EvalError::TypeError {
@@ -64,7 +72,8 @@ mod watch_impl {
 
             if watch_paths.is_empty() {
                 return Err(EvalError::ExecError(format!(
-                    "watch: no directories found for pattern '{}'", pattern
+                    "watch: no directories found for pattern '{}'",
+                    pattern
                 )));
             }
 
@@ -79,23 +88,26 @@ mod watch_impl {
                     }
                 },
                 Config::default(),
-            ).map_err(|e| EvalError::ExecError(format!("watch: failed to create watcher: {}", e)))?;
+            )
+            .map_err(|e| EvalError::ExecError(format!("watch: failed to create watcher: {}", e)))?;
 
             // Watch the directories (canonicalize to handle symlinks like /tmp -> /private/tmp)
             for path in &watch_paths {
                 let watch_path = Path::new(path);
-                let canonical_path = watch_path.canonicalize().unwrap_or_else(|_| watch_path.to_path_buf());
-                watcher.watch(&canonical_path, RecursiveMode::Recursive)
-                    .map_err(|e| EvalError::ExecError(format!(
-                        "watch: failed to watch '{}': {}", path, e
-                    )))?;
+                let canonical_path = watch_path
+                    .canonicalize()
+                    .unwrap_or_else(|_| watch_path.to_path_buf());
+                watcher
+                    .watch(&canonical_path, RecursiveMode::Recursive)
+                    .map_err(|e| {
+                        EvalError::ExecError(format!("watch: failed to watch '{}': {}", path, e))
+                    })?;
             }
 
             // Compile the glob pattern for filtering
-            let glob = glob::Pattern::new(&glob_pattern)
-                .map_err(|e| EvalError::ExecError(format!(
-                    "watch: invalid pattern '{}': {}", pattern, e
-                )))?;
+            let glob = glob::Pattern::new(&glob_pattern).map_err(|e| {
+                EvalError::ExecError(format!("watch: invalid pattern '{}': {}", pattern, e))
+            })?;
 
             // Print initial message
             eprintln!("\x1b[36m◉ Watching: {}\x1b[0m", pattern);
@@ -107,7 +119,10 @@ mod watch_impl {
             match self.run_block_capture(block) {
                 Ok(_) => {
                     let elapsed = start.elapsed();
-                    eprintln!("\x1b[32m✓ Completed in {:.2}s\x1b[0m", elapsed.as_secs_f64());
+                    eprintln!(
+                        "\x1b[32m✓ Completed in {:.2}s\x1b[0m",
+                        elapsed.as_secs_f64()
+                    );
                 }
                 Err(e) => {
                     eprintln!("\x1b[31m✗ Failed: {}\x1b[0m", e);
@@ -127,7 +142,9 @@ mod watch_impl {
                         for path in event.paths {
                             if let Some(path_str) = path.to_str() {
                                 // Check if path matches our glob
-                                if glob.matches(path_str) || self.path_matches_pattern(path_str, &glob_pattern) {
+                                if glob.matches(path_str)
+                                    || self.path_matches_pattern(path_str, &glob_pattern)
+                                {
                                     pending_changes.insert(path_str.to_string());
                                 }
                             }
@@ -138,20 +155,27 @@ mod watch_impl {
                         if !pending_changes.is_empty() && last_run.elapsed() >= debounce {
                             // Clear terminal line and show what changed
                             let changed: Vec<_> = pending_changes.drain().collect();
-                            eprintln!("\n\x1b[33m▶ Changed: {}\x1b[0m",
-                                changed.iter()
-                                    .map(|p| Path::new(p).file_name()
+                            eprintln!(
+                                "\n\x1b[33m▶ Changed: {}\x1b[0m",
+                                changed
+                                    .iter()
+                                    .map(|p| Path::new(p)
+                                        .file_name()
                                         .map(|n| n.to_string_lossy().to_string())
                                         .unwrap_or_else(|| p.clone()))
                                     .collect::<Vec<_>>()
-                                    .join(", "));
+                                    .join(", ")
+                            );
 
                             // Run the block
                             let start = Instant::now();
                             match self.run_block_capture(block) {
                                 Ok(_) => {
                                     let elapsed = start.elapsed();
-                                    eprintln!("\x1b[32m✓ Completed in {:.2}s\x1b[0m", elapsed.as_secs_f64());
+                                    eprintln!(
+                                        "\x1b[32m✓ Completed in {:.2}s\x1b[0m",
+                                        elapsed.as_secs_f64()
+                                    );
                                 }
                                 Err(e) => {
                                     eprintln!("\x1b[31m✗ Failed: {}\x1b[0m", e);
@@ -191,7 +215,8 @@ mod watch_impl {
                 if comp_str.contains('*') || comp_str.contains('?') || comp_str.contains('[') {
                     glob_start = i;
                     // Collect the glob portion of the pattern
-                    glob_suffix = path.components()
+                    glob_suffix = path
+                        .components()
                         .skip(i)
                         .map(|c| c.as_os_str().to_string_lossy().to_string())
                         .collect::<Vec<_>>()
@@ -218,13 +243,11 @@ mod watch_impl {
             // This handles symlinks like /tmp -> /private/tmp on macOS
             let full_pattern = if glob_start == 0 {
                 // Pattern starts with glob, use cwd
-                let canonical_cwd = self.cwd.canonicalize()
-                    .unwrap_or_else(|_| self.cwd.clone());
+                let canonical_cwd = self.cwd.canonicalize().unwrap_or_else(|_| self.cwd.clone());
                 format!("{}/{}", canonical_cwd.display(), pattern)
             } else if path.is_absolute() {
                 // Absolute path - canonicalize the base directory
-                let canonical_base = watch_dir.canonicalize()
-                    .unwrap_or(watch_dir);
+                let canonical_base = watch_dir.canonicalize().unwrap_or(watch_dir);
                 if glob_suffix.is_empty() {
                     canonical_base.to_string_lossy().to_string()
                 } else {
@@ -233,8 +256,7 @@ mod watch_impl {
             } else {
                 // Relative path - join with cwd and canonicalize base
                 let abs_base = self.cwd.join(&watch_dir);
-                let canonical_base = abs_base.canonicalize()
-                    .unwrap_or(abs_base);
+                let canonical_base = abs_base.canonicalize().unwrap_or(abs_base);
                 if glob_suffix.is_empty() {
                     canonical_base.to_string_lossy().to_string()
                 } else {
@@ -307,6 +329,8 @@ mod watch_impl {
 impl Evaluator {
     /// watch: requires plugins feature
     pub(crate) fn builtin_watch(&mut self) -> Result<(), EvalError> {
-        Err(EvalError::ExecError("watch: requires 'plugins' feature (notify crate)".into()))
+        Err(EvalError::ExecError(
+            "watch: requires 'plugins' feature (notify crate)".into(),
+        ))
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -15,17 +15,17 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Operator {
-    And,             // &&
-    Or,              // ||
-    Pipe,            // |
-    Write,           // >
-    Append,          // >>
-    Read,            // <
-    Background,      // &
-    WriteErr,        // 2>
-    AppendErr,       // 2>>
-    WriteBoth,       // &>
-    ErrToOut,        // 2>&1
+    And,        // &&
+    Or,         // ||
+    Pipe,       // |
+    Write,      // >
+    Append,     // >>
+    Read,       // <
+    Background, // &
+    WriteErr,   // 2>
+    AppendErr,  // 2>>
+    WriteBoth,  // &>
+    ErrToOut,   // 2>&1
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -108,7 +108,7 @@ fn double_quoted_string(input: &str) -> IResult<&str, Token> {
 
     loop {
         // Find next special character (quote or backslash)
-        match remaining.find(|c| c == '"' || c == '\\') {
+        match remaining.find(['"', '\\']) {
             Some(0) => {
                 // Special char at start
                 let c = remaining.chars().next().unwrap();
@@ -352,17 +352,17 @@ fn token(input: &str) -> IResult<&str, Token> {
             alt((
                 and_op,
                 or_op,
-                err_to_out_op,   // 2>&1 before 2>> and 2>
-                append_err_op,   // 2>> before 2>
-                write_err_op,    // 2>
-                append_op,       // >> before >
-                write_both_op,   // &> before &
+                err_to_out_op, // 2>&1 before 2>> and 2>
+                append_err_op, // 2>> before 2>
+                write_err_op,  // 2>
+                append_op,     // >> before >
+                write_both_op, // &> before &
             )),
             // Group 2: Block markers, strings, and backtick sequences
             alt((
-                block_start,   // #[ must come before array_start [
-                array_start,   // [ for array literals
-                block_end,     // ] closes both blocks and arrays
+                block_start, // #[ must come before array_start [
+                array_start, // [ for array literals
+                block_end,   // ] closes both blocks and arrays
                 triple_double_quoted_string,
                 triple_single_quoted_string,
                 double_quoted_string,
@@ -414,7 +414,8 @@ fn strip_comments(input: &str) -> String {
         }
 
         let c = chars[i];
-        let in_any_quote = in_single_quote || in_double_quote || in_triple_single || in_triple_double;
+        let in_any_quote =
+            in_single_quote || in_double_quote || in_triple_single || in_triple_double;
 
         match c {
             '\'' if !in_double_quote && !in_triple_single && !in_triple_double => {
@@ -487,9 +488,12 @@ fn expand_brace_pattern(s: &str) -> Option<Vec<String>> {
             .map(|item| format!("{}{}{}", prefix, item, suffix))
             .collect();
         // Recursively expand any remaining braces in suffix
-        return Some(results.into_iter()
-            .flat_map(|s| expand_brace_pattern(&s).unwrap_or_else(|| vec![s]))
-            .collect());
+        return Some(
+            results
+                .into_iter()
+                .flat_map(|s| expand_brace_pattern(&s).unwrap_or_else(|| vec![s]))
+                .collect(),
+        );
     }
 
     // Check for comma-separated list: {a,b,c}
@@ -500,9 +504,12 @@ fn expand_brace_pattern(s: &str) -> Option<Vec<String>> {
             .map(|item| format!("{}{}{}", prefix, item, suffix))
             .collect();
         // Recursively expand any remaining braces
-        return Some(results.into_iter()
-            .flat_map(|s| expand_brace_pattern(&s).unwrap_or_else(|| vec![s]))
-            .collect());
+        return Some(
+            results
+                .into_iter()
+                .flat_map(|s| expand_brace_pattern(&s).unwrap_or_else(|| vec![s]))
+                .collect(),
+        );
     }
 
     None
@@ -512,8 +519,8 @@ fn expand_brace_pattern(s: &str) -> Option<Vec<String>> {
 fn find_matching_brace(s: &str, start: usize) -> Option<usize> {
     let chars: Vec<char> = s.chars().collect();
     let mut depth = 0;
-    for i in start..chars.len() {
-        match chars[i] {
+    for (i, ch) in chars.iter().enumerate().skip(start) {
+        match ch {
             '{' => depth += 1,
             '}' => {
                 depth -= 1;
@@ -578,7 +585,10 @@ fn try_range_expansion(content: &str) -> Option<Vec<String>> {
             let range: Vec<String> = if start_char <= end_char {
                 (start_char..=end_char).map(|c| c.to_string()).collect()
             } else {
-                (end_char..=start_char).rev().map(|c| c.to_string()).collect()
+                (end_char..=start_char)
+                    .rev()
+                    .map(|c| c.to_string())
+                    .collect()
             };
             return Some(range);
         }
@@ -592,21 +602,17 @@ pub fn lex(input: &str) -> Result<Vec<Token>, LexError> {
     // Strip inline comments first
     let input = strip_comments(input);
 
-    let (remaining, tokens) = many0(token)(&input)
-        .map_err(|e| LexError::ParseError(format!("{:?}", e)))?;
+    let (remaining, tokens) =
+        many0(token)(&input).map_err(|e| LexError::ParseError(format!("{:?}", e)))?;
 
     // Check for any remaining unparsed content
     let remaining = remaining.trim();
     if !remaining.is_empty() {
-        return Err(LexError::UnexpectedChar(
-            remaining.chars().next().unwrap(),
-        ));
+        return Err(LexError::UnexpectedChar(remaining.chars().next().unwrap()));
     }
 
     // Expand brace patterns
-    let tokens: Vec<Token> = tokens.into_iter()
-        .flat_map(expand_braces)
-        .collect();
+    let tokens: Vec<Token> = tokens.into_iter().flat_map(expand_braces).collect();
 
     Ok(tokens)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub mod signals;
 pub mod util;
 
 // Re-export commonly used items
-pub use ast::{Expr, Program, Value, FutureState};
+pub use ast::{Expr, FutureState, Program, Value};
 pub use eval::{EvalError, EvalResult, Evaluator};
 pub use lexer::{lex, LexError, Operator, Token};
 pub use parser::{parse, ParseError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod parser;
 pub mod plugin;
 pub mod resolver;
 pub mod signals;
+pub mod util;
 
 // Re-export commonly used items
 pub use ast::{Expr, Program, Value, FutureState};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -38,7 +38,7 @@ fn process_escapes(s: &str) -> String {
                 Some('r') => result.push('\r'),
                 Some('\\') => result.push('\\'),
                 Some('"') => result.push('"'),
-                Some('e') => result.push('\x1b'),  // ANSI escape alias
+                Some('e') => result.push('\x1b'), // ANSI escape alias
                 Some('x') => {
                     // Hex escape: \x1b, \x1B, etc.
                     let mut hex = String::new();
@@ -236,8 +236,14 @@ impl Parser {
                         let name = &w[..eq_pos];
                         let value = &w[eq_pos + 1..];
                         // Name must be valid identifier (alphanumeric + underscore, not starting with digit)
-                        if !name.is_empty() && name.chars().next().map(|c| c.is_ascii_alphabetic() || c == '_').unwrap_or(false)
-                            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                        if !name.is_empty()
+                            && name
+                                .chars()
+                                .next()
+                                .map(|c| c.is_ascii_alphabetic() || c == '_')
+                                .unwrap_or(false)
+                            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                        {
                             assignments.push((name.to_string(), value.to_string()));
                             lookahead += 1;
                             continue;
@@ -274,8 +280,14 @@ impl Parser {
 
         match token {
             Token::Word(s) => Ok(self.word_to_exprs(&s)),
-            Token::DoubleQuoted(s) => Ok(vec![Expr::Quoted { content: process_escapes(&s), double: true }]),
-            Token::SingleQuoted(s) => Ok(vec![Expr::Quoted { content: s, double: false }]),
+            Token::DoubleQuoted(s) => Ok(vec![Expr::Quoted {
+                content: process_escapes(&s),
+                double: true,
+            }]),
+            Token::SingleQuoted(s) => Ok(vec![Expr::Quoted {
+                content: s,
+                double: false,
+            }]),
             Token::Variable(s) => Ok(vec![Expr::Variable(s)]),
             Token::BlockStart => self.parse_block().map(|e| vec![e]),
             Token::ArrayStart => self.parse_array_literal().map(|e| vec![e]),
@@ -443,10 +455,7 @@ mod tests {
         let program = parse(tokens).unwrap();
         assert_eq!(
             program.expressions,
-            vec![
-                Expr::Literal("hello".into()),
-                Expr::Literal("world".into()),
-            ]
+            vec![Expr::Literal("hello".into()), Expr::Literal("world".into()),]
         );
     }
 
@@ -514,10 +523,7 @@ mod tests {
         let program = parse(tokens).unwrap();
         assert_eq!(
             program.expressions,
-            vec![
-                Expr::Literal("42".into()),
-                Expr::Peek,
-            ]
+            vec![Expr::Literal("42".into()), Expr::Peek,]
         );
     }
 
@@ -605,8 +611,14 @@ mod tests {
         assert_eq!(
             program.expressions,
             vec![
-                Expr::Quoted { content: "hello world".into(), double: true },
-                Expr::Quoted { content: "literal".into(), double: false },
+                Expr::Quoted {
+                    content: "hello world".into(),
+                    double: true
+                },
+                Expr::Quoted {
+                    content: "literal".into(),
+                    double: false
+                },
             ]
         );
     }
@@ -617,10 +629,7 @@ mod tests {
         let program = parse(tokens).unwrap();
         assert_eq!(
             program.expressions,
-            vec![
-                Expr::Variable("$HOME".into()),
-                Expr::Literal("echo".into()),
-            ]
+            vec![Expr::Variable("$HOME".into()), Expr::Literal("echo".into()),]
         );
     }
 

--- a/src/plugin/abi.rs
+++ b/src/plugin/abi.rs
@@ -337,7 +337,7 @@ fn json_value_to_hsab_value(json: &serde_json::Value) -> crate::Value {
             }
 
             // Regular object -> Map with Value entries
-            let map: std::collections::HashMap<String, Value> =
+            let map: indexmap::IndexMap<String, Value> =
                 obj.iter()
                     .map(|(k, v)| (k.clone(), json_value_to_hsab_value(v)))
                     .collect();

--- a/src/plugin/abi.rs
+++ b/src/plugin/abi.rs
@@ -9,8 +9,8 @@
 
 #![allow(dead_code)]
 
-use wasmer::{Memory, MemoryView, StoreMut, WasmPtr};
 use crate::util::lock_or_recover;
+use wasmer::{Memory, MemoryView, StoreMut, WasmPtr};
 
 /// Maximum size for string buffers in plugin communication
 pub const MAX_STRING_LEN: u32 = 65536; // 64KB
@@ -56,13 +56,7 @@ pub fn read_string(memory: &Memory, store: &StoreMut, ptr: u32, len: u32) -> Opt
 }
 
 /// Write a string to WASM memory, returning the number of bytes written
-pub fn write_string(
-    memory: &Memory,
-    store: &StoreMut,
-    ptr: u32,
-    max_len: u32,
-    data: &str,
-) -> u32 {
+pub fn write_string(memory: &Memory, store: &StoreMut, ptr: u32, max_len: u32, data: &str) -> u32 {
     let bytes = data.as_bytes();
     let write_len = std::cmp::min(bytes.len(), max_len as usize);
 
@@ -102,13 +96,7 @@ pub fn read_bytes(memory: &Memory, store: &StoreMut, ptr: u32, len: u32) -> Opti
 }
 
 /// Write bytes to WASM memory, returning the number of bytes written
-pub fn write_bytes(
-    memory: &Memory,
-    store: &StoreMut,
-    ptr: u32,
-    max_len: u32,
-    data: &[u8],
-) -> u32 {
+pub fn write_bytes(memory: &Memory, store: &StoreMut, ptr: u32, max_len: u32, data: &[u8]) -> u32 {
     let write_len = std::cmp::min(data.len(), max_len as usize);
 
     if write_len == 0 {
@@ -166,7 +154,13 @@ pub fn value_to_json(value: &crate::Value) -> String {
             });
             serde_json::to_string(&json_obj).unwrap_or_else(|_| "null".to_string())
         }
-        Value::Error { kind, message, code, source, command } => {
+        Value::Error {
+            kind,
+            message,
+            code,
+            source,
+            command,
+        } => {
             let mut json_obj = serde_json::Map::new();
             json_obj.insert("__type".to_string(), serde_json::json!("error"));
             json_obj.insert("kind".to_string(), serde_json::json!(kind));
@@ -182,8 +176,15 @@ pub fn value_to_json(value: &crate::Value) -> String {
             }
             serde_json::to_string(&json_obj).unwrap_or_else(|_| "null".to_string())
         }
-        Value::Media { mime_type, data, width, height, alt, source } => {
-            use base64::{Engine as _, engine::general_purpose::STANDARD};
+        Value::Media {
+            mime_type,
+            data,
+            width,
+            height,
+            alt,
+            source,
+        } => {
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
             let mut json_obj = serde_json::Map::new();
             json_obj.insert("__type".to_string(), serde_json::json!("media"));
             json_obj.insert("mime_type".to_string(), serde_json::json!(mime_type));
@@ -213,7 +214,7 @@ pub fn value_to_json(value: &crate::Value) -> String {
             serde_json::to_string(&json_obj).unwrap_or_else(|_| "null".to_string())
         }
         Value::Bytes(data) => {
-            use base64::{Engine as _, engine::general_purpose::STANDARD};
+            use base64::{engine::general_purpose::STANDARD, Engine as _};
             let mut json_obj = serde_json::Map::new();
             json_obj.insert("__type".to_string(), serde_json::json!("bytes"));
             json_obj.insert("data".to_string(), serde_json::json!(STANDARD.encode(data)));
@@ -233,7 +234,7 @@ pub fn value_to_json(value: &crate::Value) -> String {
             let mut json_obj = serde_json::Map::new();
             json_obj.insert("__type".to_string(), serde_json::json!("future"));
             json_obj.insert("id".to_string(), serde_json::json!(id));
-            let guard = lock_or_recover(&state);
+            let guard = lock_or_recover(state);
             let status = match &*guard {
                 FutureState::Pending => "pending",
                 FutureState::Completed(_) => "completed",
@@ -277,21 +278,20 @@ fn json_value_to_hsab_value(json: &serde_json::Value) -> crate::Value {
                 match type_str {
                     "marker" => return Value::Marker,
                     "error" => {
-                        let kind = obj.get("kind")
+                        let kind = obj
+                            .get("kind")
                             .and_then(|v| v.as_str())
                             .unwrap_or("error")
                             .to_string();
-                        let message = obj.get("message")
+                        let message = obj
+                            .get("message")
                             .and_then(|v| v.as_str())
                             .unwrap_or("Unknown error")
                             .to_string();
-                        let code = obj.get("code")
-                            .and_then(|v| v.as_i64())
-                            .map(|c| c as i32);
-                        let source = obj.get("source")
-                            .and_then(|v| v.as_str())
-                            .map(String::from);
-                        let command = obj.get("command")
+                        let code = obj.get("code").and_then(|v| v.as_i64()).map(|c| c as i32);
+                        let source = obj.get("source").and_then(|v| v.as_str()).map(String::from);
+                        let command = obj
+                            .get("command")
                             .and_then(|v| v.as_str())
                             .map(String::from);
                         return Value::Error {
@@ -303,9 +303,7 @@ fn json_value_to_hsab_value(json: &serde_json::Value) -> crate::Value {
                         };
                     }
                     "table" => {
-                        if let (Some(columns), Some(rows)) =
-                            (obj.get("columns"), obj.get("rows"))
-                        {
+                        if let (Some(columns), Some(rows)) = (obj.get("columns"), obj.get("rows")) {
                             let columns: Vec<String> = columns
                                 .as_array()
                                 .map(|arr| {
@@ -321,9 +319,7 @@ fn json_value_to_hsab_value(json: &serde_json::Value) -> crate::Value {
                                         .map(|row| {
                                             row.as_array()
                                                 .map(|r| {
-                                                    r.iter()
-                                                        .map(json_value_to_hsab_value)
-                                                        .collect()
+                                                    r.iter().map(json_value_to_hsab_value).collect()
                                                 })
                                                 .unwrap_or_default()
                                         })
@@ -338,10 +334,10 @@ fn json_value_to_hsab_value(json: &serde_json::Value) -> crate::Value {
             }
 
             // Regular object -> Map with Value entries
-            let map: indexmap::IndexMap<String, Value> =
-                obj.iter()
-                    .map(|(k, v)| (k.clone(), json_value_to_hsab_value(v)))
-                    .collect();
+            let map: indexmap::IndexMap<String, Value> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), json_value_to_hsab_value(v)))
+                .collect();
             Value::Map(map)
         }
     }

--- a/src/plugin/abi.rs
+++ b/src/plugin/abi.rs
@@ -10,6 +10,7 @@
 #![allow(dead_code)]
 
 use wasmer::{Memory, MemoryView, StoreMut, WasmPtr};
+use crate::util::lock_or_recover;
 
 /// Maximum size for string buffers in plugin communication
 pub const MAX_STRING_LEN: u32 = 65536; // 64KB
@@ -232,7 +233,7 @@ pub fn value_to_json(value: &crate::Value) -> String {
             let mut json_obj = serde_json::Map::new();
             json_obj.insert("__type".to_string(), serde_json::json!("future"));
             json_obj.insert("id".to_string(), serde_json::json!(id));
-            let guard = state.lock().unwrap();
+            let guard = lock_or_recover(&state);
             let status = match &*guard {
                 FutureState::Pending => "pending",
                 FutureState::Completed(_) => "completed",

--- a/src/plugin/host.rs
+++ b/src/plugin/host.rs
@@ -6,11 +6,11 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::Value;
 use super::hot_reload::{try_create_hot_reloader, HotReloader};
 use super::manifest::PluginManifest;
 use super::registry::{PluginInfo, PluginRegistry};
 use super::PluginError;
+use crate::Value;
 
 /// The plugin host manages all plugin operations
 pub struct PluginHost {
@@ -78,11 +78,7 @@ impl PluginHost {
                 // Look for a .wasm file in the directory
                 let wasm_file = std::fs::read_dir(path)?
                     .filter_map(|e| e.ok())
-                    .find(|e| {
-                        e.path()
-                            .extension()
-                            .map_or(false, |ext| ext == "wasm")
-                    })
+                    .find(|e| e.path().extension().is_some_and(|ext| ext == "wasm"))
                     .map(|e| e.path())
                     .ok_or_else(|| {
                         PluginError::NotFound(format!(
@@ -92,7 +88,7 @@ impl PluginHost {
                     })?;
                 PluginManifest::from_wasm_file(&wasm_file)
             }
-        } else if path.extension().map_or(false, |ext| ext == "wasm") {
+        } else if path.extension().is_some_and(|ext| ext == "wasm") {
             PluginManifest::from_wasm_file(path)
         } else {
             return Err(PluginError::NotFound(format!(

--- a/src/plugin/imports.rs
+++ b/src/plugin/imports.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use wasmer::{Function, FunctionEnv, FunctionEnvMut, Imports, Memory, Store};
 
+use super::abi::{json_to_value, read_string, value_to_json, write_string};
 #[allow(unused_imports)]
 use crate::Value;
-use super::abi::{read_string, write_string, value_to_json, json_to_value};
 
 /// Shared state between host functions and the plugin host
 pub struct PluginEnv {
@@ -66,10 +66,7 @@ impl PluginEnv {
 }
 
 /// Create the imports object for a plugin
-pub fn create_imports(
-    store: &mut Store,
-    env: &FunctionEnv<PluginEnv>,
-) -> Imports {
+pub fn create_imports(store: &mut Store, env: &FunctionEnv<PluginEnv>) -> Imports {
     let mut imports = Imports::new();
 
     // Stack operations

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -9,10 +9,10 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use wasmer::{Engine, FunctionEnv, Instance, Module, Store};
 
-use crate::Value;
 use super::imports::{create_imports, PluginEnv};
 use super::manifest::PluginManifest;
 use super::PluginError;
+use crate::Value;
 
 /// A loaded and instantiated plugin
 pub struct LoadedPlugin {
@@ -42,7 +42,9 @@ impl LoadedPlugin {
             .instance
             .exports
             .get_function(function_name)
-            .map_err(|e| PluginError::CallFailed(format!("Function '{}' not found: {}", function_name, e)))?;
+            .map_err(|e| {
+                PluginError::CallFailed(format!("Function '{}' not found: {}", function_name, e))
+            })?;
 
         // Get the memory to write command and args
         let memory = self
@@ -71,12 +73,15 @@ impl LoadedPlugin {
 
         // Call the function with (cmd_ptr, cmd_len, args_ptr, args_len)
         let result = func
-            .call(store, &[
-                wasmer::Value::I32(cmd_offset as i32),
-                wasmer::Value::I32(cmd_bytes.len() as i32),
-                wasmer::Value::I32(args_offset as i32),
-                wasmer::Value::I32(args_bytes.len() as i32),
-            ])
+            .call(
+                store,
+                &[
+                    wasmer::Value::I32(cmd_offset as i32),
+                    wasmer::Value::I32(cmd_bytes.len() as i32),
+                    wasmer::Value::I32(args_offset as i32),
+                    wasmer::Value::I32(args_bytes.len() as i32),
+                ],
+            )
             .map_err(|e| PluginError::CallFailed(format!("Function call failed: {}", e)))?;
 
         // Get return code

--- a/src/plugin/manifest.rs
+++ b/src/plugin/manifest.rs
@@ -214,10 +214,19 @@ preopens = [
         assert_eq!(manifest.plugin.author, "Test Author");
         assert_eq!(manifest.plugin.wasm, "test.wasm");
         assert_eq!(manifest.commands.len(), 2);
-        assert_eq!(manifest.commands.get("test-cmd"), Some(&"cmd_test".to_string()));
-        assert_eq!(manifest.commands.get("another"), Some(&"cmd_another".to_string()));
+        assert_eq!(
+            manifest.commands.get("test-cmd"),
+            Some(&"cmd_test".to_string())
+        );
+        assert_eq!(
+            manifest.commands.get("another"),
+            Some(&"cmd_another".to_string())
+        );
         assert_eq!(manifest.dependencies.len(), 1);
-        assert_eq!(manifest.dependencies.get("other-plugin"), Some(&">=1.0.0".to_string()));
+        assert_eq!(
+            manifest.dependencies.get("other-plugin"),
+            Some(&">=1.0.0".to_string())
+        );
         assert!(manifest.wasi.inherit_env);
         assert!(!manifest.wasi.inherit_args);
         assert!(manifest.wasi.inherit_stdin);
@@ -268,7 +277,7 @@ wasm = "test.wasm"
 [config]
 string_val = "hello"
 int_val = 42
-float_val = 3.14
+float_val = 2.5
 bool_val = true
 array_val = [1, 2, 3]
 "#;
@@ -285,13 +294,26 @@ array_val = [1, 2, 3]
             Some(42)
         );
         assert!(
-            (manifest.config.get("float_val").unwrap().as_float().unwrap() - 3.14).abs() < 0.001
+            (manifest
+                .config
+                .get("float_val")
+                .unwrap()
+                .as_float()
+                .unwrap()
+                - 2.5)
+                .abs()
+                < 0.001
         );
         assert_eq!(
             manifest.config.get("bool_val").unwrap().as_bool(),
             Some(true)
         );
-        assert!(manifest.config.get("array_val").unwrap().as_array().is_some());
+        assert!(manifest
+            .config
+            .get("array_val")
+            .unwrap()
+            .as_array()
+            .is_some());
     }
 
     #[test]
@@ -311,10 +333,22 @@ exact = "=3.0.0"
 
         let manifest: PluginManifest = toml::from_str(toml_content).unwrap();
         assert_eq!(manifest.dependencies.len(), 4);
-        assert_eq!(manifest.dependencies.get("core"), Some(&"^1.0.0".to_string()));
-        assert_eq!(manifest.dependencies.get("utils"), Some(&">=0.5.0, <2.0.0".to_string()));
-        assert_eq!(manifest.dependencies.get("optional"), Some(&"~1.2.3".to_string()));
-        assert_eq!(manifest.dependencies.get("exact"), Some(&"=3.0.0".to_string()));
+        assert_eq!(
+            manifest.dependencies.get("core"),
+            Some(&"^1.0.0".to_string())
+        );
+        assert_eq!(
+            manifest.dependencies.get("utils"),
+            Some(&">=0.5.0, <2.0.0".to_string())
+        );
+        assert_eq!(
+            manifest.dependencies.get("optional"),
+            Some(&"~1.2.3".to_string())
+        );
+        assert_eq!(
+            manifest.dependencies.get("exact"),
+            Some(&"=3.0.0".to_string())
+        );
     }
 
     #[test]
@@ -378,7 +412,10 @@ version = "1.0.0"
         assert_eq!(manifest.plugin.description, "");
         assert_eq!(manifest.plugin.author, "");
         assert!(manifest.commands.contains_key("my-cool-plugin"));
-        assert_eq!(manifest.commands.get("my-cool-plugin"), Some(&"hsab_call".to_string()));
+        assert_eq!(
+            manifest.commands.get("my-cool-plugin"),
+            Some(&"hsab_call".to_string())
+        );
         assert!(manifest.dependencies.is_empty());
         assert!(manifest.config.is_empty());
     }
@@ -392,7 +429,10 @@ version = "1.0.0"
         assert_eq!(manifest.plugin.wasm, "my_plugin_name.wasm");
         // Command converts underscores to dashes
         assert!(manifest.commands.contains_key("my-plugin-name"));
-        assert_eq!(manifest.commands.get("my-plugin-name"), Some(&"hsab_call".to_string()));
+        assert_eq!(
+            manifest.commands.get("my-plugin-name"),
+            Some(&"hsab_call".to_string())
+        );
     }
 
     #[test]
@@ -540,7 +580,10 @@ new_key = "user value"
             config: {
                 let mut c = HashMap::new();
                 c.insert("timeout".to_string(), toml::Value::Integer(30));
-                c.insert("existing".to_string(), toml::Value::String("original".to_string()));
+                c.insert(
+                    "existing".to_string(),
+                    toml::Value::String("original".to_string()),
+                );
                 c
             },
             wasi: WasiConfig::default(),
@@ -549,11 +592,20 @@ new_key = "user value"
         manifest.load_user_config(dir.path()).unwrap();
 
         // User value overrides default
-        assert_eq!(manifest.config.get("timeout").unwrap().as_integer(), Some(60));
+        assert_eq!(
+            manifest.config.get("timeout").unwrap().as_integer(),
+            Some(60)
+        );
         // New key added
-        assert_eq!(manifest.config.get("new_key").unwrap().as_str(), Some("user value"));
+        assert_eq!(
+            manifest.config.get("new_key").unwrap().as_str(),
+            Some("user value")
+        );
         // Existing key preserved
-        assert_eq!(manifest.config.get("existing").unwrap().as_str(), Some("original"));
+        assert_eq!(
+            manifest.config.get("existing").unwrap().as_str(),
+            Some("original")
+        );
     }
 
     #[test]

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -10,10 +10,10 @@ use std::sync::{Arc, Mutex};
 use semver::{Version, VersionReq};
 use wasmer::Store;
 
-use crate::Value;
 use super::loader::{LoadedPlugin, PluginLoader};
 use super::manifest::PluginManifest;
 use super::PluginError;
+use crate::Value;
 
 /// An entry in the registry for a loaded plugin
 pub struct PluginEntry {
@@ -114,7 +114,10 @@ impl PluginRegistry {
     }
 
     /// Scan a directory for plugins (returns manifests by name)
-    fn scan_plugins(&self, plugin_dir: &Path) -> Result<HashMap<String, (PathBuf, PluginManifest)>, PluginError> {
+    fn scan_plugins(
+        &self,
+        plugin_dir: &Path,
+    ) -> Result<HashMap<String, (PathBuf, PluginManifest)>, PluginError> {
         let mut manifests = HashMap::new();
 
         for entry in std::fs::read_dir(plugin_dir)? {
@@ -132,11 +135,15 @@ impl PluginRegistry {
                             manifests.insert(manifest.plugin.name.clone(), (path, manifest));
                         }
                         Err(e) => {
-                            eprintln!("Warning: Failed to parse {}: {}", manifest_path.display(), e);
+                            eprintln!(
+                                "Warning: Failed to parse {}: {}",
+                                manifest_path.display(),
+                                e
+                            );
                         }
                     }
                 }
-            } else if path.extension().map_or(false, |ext| ext == "wasm") {
+            } else if path.extension().is_some_and(|ext| ext == "wasm") {
                 // Standalone WASM file
                 let manifest = PluginManifest::from_wasm_file(&path);
                 manifests.insert(manifest.plugin.name.clone(), (path, manifest));
@@ -196,7 +203,10 @@ impl PluginRegistry {
                 }
 
                 // Add edge: dep_name -> name (dep must load before name)
-                graph.get_mut(dep_name.as_str()).unwrap().push(name.as_str());
+                graph
+                    .get_mut(dep_name.as_str())
+                    .unwrap()
+                    .push(name.as_str());
                 *in_degree.get_mut(name.as_str()).unwrap() += 1;
             }
         }
@@ -246,21 +256,26 @@ impl PluginRegistry {
             path
         };
 
-        let (plugin, store) = self.loader.load(plugin_dir, manifest, Arc::clone(&self.stack))?;
+        let (plugin, store) = self
+            .loader
+            .load(plugin_dir, manifest, Arc::clone(&self.stack))?;
 
         // Get modification time for hot reload
         let wasm_path = plugin_dir.join(&manifest.plugin.wasm);
-        let mtime = std::fs::metadata(&wasm_path).ok().and_then(|m| m.modified().ok());
+        let mtime = std::fs::metadata(&wasm_path)
+            .ok()
+            .and_then(|m| m.modified().ok());
 
         // Register commands
-        for (cmd, _handler) in &manifest.commands {
+        for cmd in manifest.commands.keys() {
             if self.commands.contains_key(cmd) {
                 eprintln!(
                     "Warning: Plugin '{}' shadows command '{}' from another plugin",
                     manifest.plugin.name, cmd
                 );
             }
-            self.commands.insert(cmd.clone(), manifest.plugin.name.clone());
+            self.commands
+                .insert(cmd.clone(), manifest.plugin.name.clone());
         }
 
         // Call init
@@ -280,9 +295,10 @@ impl PluginRegistry {
     /// Unload a plugin
     pub fn unload_plugin(&mut self, name: &str) -> Result<(), PluginError> {
         // Get plugin entry
-        let mut entry = self.plugins.remove(name).ok_or_else(|| {
-            PluginError::NotFound(name.to_string())
-        })?;
+        let mut entry = self
+            .plugins
+            .remove(name)
+            .ok_or_else(|| PluginError::NotFound(name.to_string()))?;
 
         // Call cleanup
         let _ = entry.plugin.call_cleanup(&mut entry.store);
@@ -296,9 +312,10 @@ impl PluginRegistry {
     /// Reload a plugin
     pub fn reload_plugin(&mut self, name: &str) -> Result<(), PluginError> {
         // Get current plugin info
-        let entry = self.plugins.get(name).ok_or_else(|| {
-            PluginError::NotFound(name.to_string())
-        })?;
+        let entry = self
+            .plugins
+            .get(name)
+            .ok_or_else(|| PluginError::NotFound(name.to_string()))?;
 
         let path = entry.plugin.path.clone();
         let manifest = entry.plugin.manifest.clone();
@@ -311,20 +328,19 @@ impl PluginRegistry {
     }
 
     /// Call a plugin command
-    pub fn call(
-        &mut self,
-        cmd: &str,
-        args: &[String],
-    ) -> Result<i32, PluginError> {
+    pub fn call(&mut self, cmd: &str, args: &[String]) -> Result<i32, PluginError> {
         // Find which plugin handles this command
-        let plugin_name = self.commands.get(cmd).ok_or_else(|| {
-            PluginError::CommandNotFound(cmd.to_string())
-        })?.clone();
+        let plugin_name = self
+            .commands
+            .get(cmd)
+            .ok_or_else(|| PluginError::CommandNotFound(cmd.to_string()))?
+            .clone();
 
         // Get the handler function name
-        let entry = self.plugins.get_mut(&plugin_name).ok_or_else(|| {
-            PluginError::NotFound(plugin_name.clone())
-        })?;
+        let entry = self
+            .plugins
+            .get_mut(&plugin_name)
+            .ok_or_else(|| PluginError::NotFound(plugin_name.clone()))?;
 
         let handler = entry
             .plugin
@@ -338,7 +354,9 @@ impl PluginRegistry {
         let args_json = serde_json::to_string(args).unwrap_or_else(|_| "[]".to_string());
 
         // Call the handler
-        entry.plugin.call_function(&mut entry.store, &handler, cmd, &args_json)
+        entry
+            .plugin
+            .call_function(&mut entry.store, &handler, cmd, &args_json)
     }
 
     /// Check for plugins that need reloading based on file modification time
@@ -363,10 +381,8 @@ impl PluginRegistry {
                 if let Ok(metadata) = std::fs::metadata(&manifest_path) {
                     if let Ok(current_mtime) = metadata.modified() {
                         if let Some(cached_mtime) = entry.mtime {
-                            if current_mtime > cached_mtime {
-                                if !changed.contains(name) {
-                                    changed.push(name.clone());
-                                }
+                            if current_mtime > cached_mtime && !changed.contains(name) {
+                                changed.push(name.clone());
                             }
                         }
                     }
@@ -458,7 +474,10 @@ mod tests {
                 }
 
                 // Add edge: dep_name -> name (dep must load before name)
-                graph.get_mut(dep_name.as_str()).unwrap().push(name.as_str());
+                graph
+                    .get_mut(dep_name.as_str())
+                    .unwrap()
+                    .push(name.as_str());
                 *in_degree.get_mut(name.as_str()).unwrap() += 1;
             }
         }
@@ -582,7 +601,11 @@ mod tests {
         //     \   /
         //     bottom
         let plugins: HashMap<String, PluginDepInfo> = [
-            make_plugin("top", "1.0.0", vec![("left", "^1.0.0"), ("right", "^1.0.0")]),
+            make_plugin(
+                "top",
+                "1.0.0",
+                vec![("left", "^1.0.0"), ("right", "^1.0.0")],
+            ),
             make_plugin("left", "1.0.0", vec![("bottom", "^1.0.0")]),
             make_plugin("right", "1.0.0", vec![("bottom", "^1.0.0")]),
             make_plugin("bottom", "1.0.0", vec![]),
@@ -608,11 +631,15 @@ mod tests {
     #[test]
     fn test_multiple_dependencies_single_plugin() {
         let plugins: HashMap<String, PluginDepInfo> = [
-            make_plugin("app", "1.0.0", vec![
-                ("utils", "^1.0.0"),
-                ("core", "^2.0.0"),
-                ("logging", "^1.0.0"),
-            ]),
+            make_plugin(
+                "app",
+                "1.0.0",
+                vec![
+                    ("utils", "^1.0.0"),
+                    ("core", "^2.0.0"),
+                    ("logging", "^1.0.0"),
+                ],
+            ),
             make_plugin("utils", "1.5.0", vec![]),
             make_plugin("core", "2.1.0", vec![]),
             make_plugin("logging", "1.2.0", vec![]),
@@ -649,11 +676,10 @@ mod tests {
     #[test]
     fn test_self_dependency() {
         // a -> a
-        let plugins: HashMap<String, PluginDepInfo> = [
-            make_plugin("a", "1.0.0", vec![("a", "^1.0.0")]),
-        ]
-        .into_iter()
-        .collect();
+        let plugins: HashMap<String, PluginDepInfo> =
+            [make_plugin("a", "1.0.0", vec![("a", "^1.0.0")])]
+                .into_iter()
+                .collect();
 
         let result = resolve_plugin_dependencies(&plugins);
         assert!(matches!(result, Err(PluginError::CircularDependency)));
@@ -696,11 +722,10 @@ mod tests {
 
     #[test]
     fn test_missing_dependency() {
-        let plugins: HashMap<String, PluginDepInfo> = [
-            make_plugin("app", "1.0.0", vec![("nonexistent", "^1.0.0")]),
-        ]
-        .into_iter()
-        .collect();
+        let plugins: HashMap<String, PluginDepInfo> =
+            [make_plugin("app", "1.0.0", vec![("nonexistent", "^1.0.0")])]
+                .into_iter()
+                .collect();
 
         let result = resolve_plugin_dependencies(&plugins);
         assert!(matches!(result, Err(PluginError::MissingDependency(_))));
@@ -871,7 +896,11 @@ mod tests {
 
         let result = resolve_plugin_dependencies(&plugins);
         match result {
-            Err(PluginError::VersionMismatch { plugin, required, found }) => {
+            Err(PluginError::VersionMismatch {
+                plugin,
+                required,
+                found,
+            }) => {
                 assert_eq!(plugin, "consumer");
                 assert_eq!(required, "^3.0.0");
                 assert_eq!(found, "2.5.0");
@@ -897,11 +926,14 @@ mod tests {
     fn test_invalid_plugin_version() {
         let plugins: HashMap<String, PluginDepInfo> = [
             make_plugin("app", "1.0.0", vec![("lib", "^1.0.0")]),
-            ("lib".to_string(), PluginDepInfo {
-                name: "lib".to_string(),
-                version: "not-semver".to_string(),
-                dependencies: HashMap::new(),
-            }),
+            (
+                "lib".to_string(),
+                PluginDepInfo {
+                    name: "lib".to_string(),
+                    version: "not-semver".to_string(),
+                    dependencies: HashMap::new(),
+                },
+            ),
         ]
         .into_iter()
         .collect();
@@ -924,7 +956,11 @@ mod tests {
         //      \ | /
         //       core
         let plugins: HashMap<String, PluginDepInfo> = [
-            make_plugin("app", "1.0.0", vec![("a", "^1.0.0"), ("b", "^1.0.0"), ("c", "^1.0.0")]),
+            make_plugin(
+                "app",
+                "1.0.0",
+                vec![("a", "^1.0.0"), ("b", "^1.0.0"), ("c", "^1.0.0")],
+            ),
             make_plugin("a", "1.0.0", vec![("d", "^1.0.0"), ("e", "^1.0.0")]),
             make_plugin("b", "1.0.0", vec![("e", "^1.0.0"), ("f", "^1.0.0")]),
             make_plugin("c", "1.0.0", vec![("f", "^1.0.0"), ("g", "^1.0.0")]),
@@ -987,11 +1023,8 @@ mod tests {
 
     #[test]
     fn test_single_plugin_no_deps() {
-        let plugins: HashMap<String, PluginDepInfo> = [
-            make_plugin("solo", "1.0.0", vec![]),
-        ]
-        .into_iter()
-        .collect();
+        let plugins: HashMap<String, PluginDepInfo> =
+            [make_plugin("solo", "1.0.0", vec![])].into_iter().collect();
 
         let order = resolve_plugin_dependencies(&plugins).unwrap();
         assert_eq!(order, vec!["solo"]);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,5 +1,5 @@
-use hsab::{Evaluator, Value};
 use crate::terminal::execute_line;
+use hsab::{Evaluator, Value};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
@@ -119,7 +119,11 @@ pub(crate) fn git_prompt_info(cwd: &Path) -> Option<GitPromptInfo> {
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let info = GitPromptInfo { branch, dirty, repo };
+    let info = GitPromptInfo {
+        branch,
+        dirty,
+        repo,
+    };
     *hsab::util::lock_or_recover(&GIT_CACHE) = Some((key, info.clone()));
     Some(info)
 }
@@ -129,7 +133,7 @@ pub(crate) fn set_prompt_context(eval: &Evaluator, cmd_num: usize) {
     // Version info
     let version_parts: Vec<&str> = VERSION.split('.').collect();
     std::env::set_var("_VERSION", VERSION);
-    std::env::set_var("_VERSION_MAJOR", version_parts.get(0).unwrap_or(&"0"));
+    std::env::set_var("_VERSION_MAJOR", version_parts.first().unwrap_or(&"0"));
     std::env::set_var("_VERSION_MINOR", version_parts.get(1).unwrap_or(&"0"));
     std::env::set_var("_VERSION_PATCH", version_parts.get(2).unwrap_or(&"0"));
 
@@ -141,14 +145,23 @@ pub(crate) fn set_prompt_context(eval: &Evaluator, cmd_num: usize) {
     std::env::set_var("_LIMBO", eval.limbo_count().to_string());
     std::env::set_var("_FUTURES", eval.futures_count().to_string());
     std::env::set_var("_CMD_NUM", cmd_num.to_string());
-    std::env::set_var("_SHLVL", std::env::var("SHLVL").unwrap_or_else(|_| "1".to_string()));
+    std::env::set_var(
+        "_SHLVL",
+        std::env::var("SHLVL").unwrap_or_else(|_| "1".to_string()),
+    );
 
     // Environment
     std::env::set_var("_CWD", eval.cwd().display().to_string());
-    std::env::set_var("_USER", std::env::var("USER").unwrap_or_else(|_| "".to_string()));
-    std::env::set_var("_HOST", hostname::get()
-        .map(|h| h.to_string_lossy().to_string())
-        .unwrap_or_else(|_| "".to_string()));
+    std::env::set_var(
+        "_USER",
+        std::env::var("USER").unwrap_or_else(|_| "".to_string()),
+    );
+    std::env::set_var(
+        "_HOST",
+        hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "".to_string()),
+    );
 
     // Time
     let now = chrono::Local::now();

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,7 +1,128 @@
 use hsab::{Evaluator, Value};
 use crate::terminal::execute_line;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// ============================================
+// Git prompt info cache (issue #35)
+// ============================================
+//
+// The prompt used to shell out to `git` three times on every render. Instead
+// we run a single `git status --porcelain=v2 --branch` and cache the parsed
+// result keyed on (cwd, .git/HEAD mtime, .git/index mtime). Non-git
+// directories are detected by walking up for a `.git` entry, spawning no
+// subprocess at all.
+//
+// Known limitation (per the issue spec): an unstaged edit to a tracked file
+// does not touch `.git/index`, so the dirty flag may lag until HEAD/index
+// change (checkout, add, commit) or the cwd changes.
+
+/// Cached git info for the prompt.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct GitPromptInfo {
+    pub branch: String,
+    pub dirty: bool,
+    pub repo: String,
+}
+
+/// Cache key: invalidates when the cwd or the repo metadata files change.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct GitCacheKey {
+    cwd: PathBuf,
+    head_mtime: Option<SystemTime>,
+    index_mtime: Option<SystemTime>,
+}
+
+static GIT_CACHE: Mutex<Option<(GitCacheKey, GitPromptInfo)>> = Mutex::new(None);
+
+/// Walk up from `cwd` looking for a `.git` entry. Returns the repo root
+/// (directory containing `.git`) and the git dir itself.
+/// Cheap: pure filesystem metadata, no subprocess.
+pub(crate) fn find_git_dir(cwd: &Path) -> Option<(PathBuf, PathBuf)> {
+    for dir in cwd.ancestors() {
+        let dot_git = dir.join(".git");
+        if dot_git.is_dir() {
+            return Some((dir.to_path_buf(), dot_git));
+        }
+        if dot_git.is_file() {
+            // Worktree/submodule: `.git` is a file with "gitdir: <path>"
+            if let Ok(contents) = std::fs::read_to_string(&dot_git) {
+                if let Some(gitdir) = contents.strip_prefix("gitdir:") {
+                    let gitdir = gitdir.trim();
+                    let gitdir_path = if Path::new(gitdir).is_absolute() {
+                        PathBuf::from(gitdir)
+                    } else {
+                        dir.join(gitdir)
+                    };
+                    return Some((dir.to_path_buf(), gitdir_path));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Build the cache key for a repo. `None` mtimes are fine (missing files);
+/// they still participate in equality so appearance/disappearance invalidates.
+pub(crate) fn git_cache_key(cwd: &Path, git_dir: &Path) -> GitCacheKey {
+    let mtime = |p: &Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+    GitCacheKey {
+        cwd: cwd.to_path_buf(),
+        head_mtime: mtime(&git_dir.join("HEAD")),
+        index_mtime: mtime(&git_dir.join("index")),
+    }
+}
+
+/// Parse `git status --porcelain=v2 --branch` output into (branch, dirty).
+pub(crate) fn parse_porcelain_v2(output: &str) -> (String, bool) {
+    let mut branch = String::new();
+    let mut dirty = false;
+    for line in output.lines() {
+        if let Some(rest) = line.strip_prefix("# branch.head ") {
+            branch = rest.trim().to_string();
+        } else if !line.starts_with('#') && !line.is_empty() {
+            dirty = true;
+        }
+    }
+    (branch, dirty)
+}
+
+/// Compute git info for the prompt with caching. Returns `None` outside a
+/// git repo (and spawns no subprocess in that case).
+pub(crate) fn git_prompt_info(cwd: &Path) -> Option<GitPromptInfo> {
+    let (repo_root, git_dir) = find_git_dir(cwd)?;
+    let key = git_cache_key(cwd, &git_dir);
+
+    {
+        let cache = hsab::util::lock_or_recover(&GIT_CACHE);
+        if let Some((cached_key, cached_info)) = cache.as_ref() {
+            if *cached_key == key {
+                return Some(cached_info.clone());
+            }
+        }
+    }
+
+    // Single git invocation for branch + dirty state.
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain=v2", "--branch"])
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let (branch, dirty) = parse_porcelain_v2(&String::from_utf8_lossy(&output.stdout));
+
+    let repo = repo_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let info = GitPromptInfo { branch, dirty, repo };
+    *hsab::util::lock_or_recover(&GIT_CACHE) = Some((key, info.clone()));
+    Some(info)
+}
 
 /// Set prompt context variables for PS1/PS2/STACK_HINT functions
 pub(crate) fn set_prompt_context(eval: &Evaluator, cmd_num: usize) {
@@ -34,42 +155,18 @@ pub(crate) fn set_prompt_context(eval: &Evaluator, cmd_num: usize) {
     std::env::set_var("_TIME", now.format("%H:%M:%S").to_string());
     std::env::set_var("_DATE", now.format("%Y-%m-%d").to_string());
 
-    // Git info (only if in a git repo)
-    let git_branch = std::process::Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_default();
-    std::env::set_var("_GIT_BRANCH", &git_branch);
-
-    if !git_branch.is_empty() {
-        let git_dirty = std::process::Command::new("git")
-            .args(["status", "--porcelain"])
-            .output()
-            .ok()
-            .map(|o| if o.stdout.is_empty() { "0" } else { "1" })
-            .unwrap_or("0");
-        std::env::set_var("_GIT_DIRTY", git_dirty);
-
-        let git_repo = std::process::Command::new("git")
-            .args(["rev-parse", "--show-toplevel"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| {
-                let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
-                std::path::Path::new(&path)
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default()
-            })
-            .unwrap_or_default();
-        std::env::set_var("_GIT_REPO", git_repo);
-    } else {
-        std::env::set_var("_GIT_DIRTY", "0");
-        std::env::set_var("_GIT_REPO", "");
+    // Git info (only if in a git repo); cached, single subprocess on miss
+    match git_prompt_info(eval.cwd()) {
+        Some(info) => {
+            std::env::set_var("_GIT_BRANCH", &info.branch);
+            std::env::set_var("_GIT_DIRTY", if info.dirty { "1" } else { "0" });
+            std::env::set_var("_GIT_REPO", &info.repo);
+        }
+        None => {
+            std::env::set_var("_GIT_BRANCH", "");
+            std::env::set_var("_GIT_DIRTY", "0");
+            std::env::set_var("_GIT_REPO", "");
+        }
     }
 }
 
@@ -155,4 +252,105 @@ pub(crate) fn extract_hint_format(eval: &mut Evaluator) -> (String, String, Stri
     eval.restore_stack(saved_stack);
     eval.set_last_exit_code(saved_exit_code);
     default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_porcelain_v2_clean() {
+        let out = "# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n";
+        let (branch, dirty) = parse_porcelain_v2(out);
+        assert_eq!(branch, "main");
+        assert!(!dirty);
+    }
+
+    #[test]
+    fn test_parse_porcelain_v2_dirty() {
+        let out = "# branch.oid abc123\n# branch.head feature/x\n1 .M N... 100644 100644 100644 abc def src/main.rs\n";
+        let (branch, dirty) = parse_porcelain_v2(out);
+        assert_eq!(branch, "feature/x");
+        assert!(dirty);
+    }
+
+    #[test]
+    fn test_parse_porcelain_v2_untracked_is_dirty() {
+        let out = "# branch.head main\n? newfile.txt\n";
+        let (_, dirty) = parse_porcelain_v2(out);
+        assert!(dirty);
+    }
+
+    #[test]
+    fn test_find_git_dir_none_outside_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(find_git_dir(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_find_git_dir_walks_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        let nested = root.join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+        let (repo_root, git_dir) = find_git_dir(&nested).unwrap();
+        assert_eq!(repo_root, root);
+        assert_eq!(git_dir, root.join(".git"));
+    }
+
+    #[test]
+    fn test_git_cache_key_invalidates_on_head_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let git_dir = root.join(".git");
+        std::fs::create_dir(&git_dir).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let key1 = git_cache_key(root, &git_dir);
+        let key2 = git_cache_key(root, &git_dir);
+        assert_eq!(key1, key2, "unchanged repo must produce an equal key");
+
+        // Simulate `git checkout`: HEAD is rewritten with a newer mtime
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/other\n").unwrap();
+        let key3 = git_cache_key(root, &git_dir);
+        assert_ne!(key1, key3, "HEAD mtime change must invalidate the key");
+    }
+
+    #[test]
+    fn test_git_cache_key_invalidates_on_index_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let git_dir = root.join(".git");
+        std::fs::create_dir(&git_dir).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let key1 = git_cache_key(root, &git_dir);
+        // Simulate `git add`: index appears / changes
+        std::fs::write(git_dir.join("index"), "fake index").unwrap();
+        let key2 = git_cache_key(root, &git_dir);
+        assert_ne!(key1, key2, "index change must invalidate the key");
+    }
+
+    #[test]
+    fn test_git_cache_key_differs_per_cwd() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let git_dir = root.join(".git");
+        std::fs::create_dir(&git_dir).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+
+        let key1 = git_cache_key(root, &git_dir);
+        let key2 = git_cache_key(&sub, &git_dir);
+        assert_ne!(key1, key2, "cache must be per-cwd");
+    }
+
+    #[test]
+    fn test_git_prompt_info_none_outside_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(git_prompt_info(tmp.path()).is_none());
+    }
 }

--- a/src/rcfile.rs
+++ b/src/rcfile.rs
@@ -1,5 +1,5 @@
-use hsab::Evaluator;
 use crate::terminal::execute_line;
+use hsab::Evaluator;
 use std::env;
 use std::fs;
 
@@ -46,7 +46,9 @@ pub(crate) fn load_hsab_profile(eval: &mut Evaluator) {
                     let trimmed = line.trim();
 
                     // Skip empty lines and comments (but not #[ block syntax)
-                    if trimmed.is_empty() || (trimmed.starts_with('#') && !trimmed.starts_with("#[")) {
+                    if trimmed.is_empty()
+                        || (trimmed.starts_with('#') && !trimmed.starts_with("#["))
+                    {
                         continue;
                     }
 
@@ -117,7 +119,9 @@ fn load_rc_content(eval: &mut Evaluator, content: &str, source: &str) {
 
         // Skip empty lines and comment-only lines when not in a multiline block
         // Note: #[ is a block delimiter, not a comment
-        if bracket_depth == 0 && (trimmed.is_empty() || (trimmed.starts_with('#') && !trimmed.starts_with("#["))) {
+        if bracket_depth == 0
+            && (trimmed.is_empty() || (trimmed.starts_with('#') && !trimmed.starts_with("#[")))
+        {
             continue;
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1281,6 +1281,13 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
     let fallback_multiline = format!("hsab-{}… ", VERSION);
 
     loop {
+        // Reap finished background jobs when SIGCHLD was flagged (issue #30)
+        if hsab::signals::check_sigchld() {
+            for notice in eval.reap_jobs() {
+                eprintln!("{}", notice);
+            }
+        }
+
         // Check if Ctrl+U requested limbo values to be returned to stack
         {
             let mut state = lock_or_recover(&shared_state);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -14,6 +14,7 @@ use crate::prompt::{set_prompt_context, eval_prompt_definition, extract_hint_for
 use crate::rcfile::{load_hsabrc, load_hsab_profile, load_stdlib, dirs_home};
 use crate::terminal::{execute_line, is_triple_quotes_balanced};
 use crate::cli::print_help;
+use hsab::util::lock_or_recover;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -269,7 +270,7 @@ impl SharedState {
             }
             Value::Error { kind, .. } => format!("error:{}", kind),
             Value::Future { id: fid, state } => {
-                                let guard = state.lock().unwrap();
+                                let guard = lock_or_recover(&state);
                 let status = match &*guard {
                     FutureState::Pending => "pending",
                     FutureState::Completed(_) => "completed",
@@ -323,7 +324,7 @@ impl SharedState {
                         }
                     }
                     Value::Future { id, state } => {
-                                                let guard = state.lock().unwrap();
+                                                let guard = lock_or_recover(&state);
                         let status = match &*guard {
                             FutureState::Pending => "pending",
                             FutureState::Completed(_) => "completed",
@@ -1252,7 +1253,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
     // Extract hint format from STACK_HINT definition (for real-time stack display)
     {
         let format = extract_hint_format(&mut eval);
-        let mut state = shared_state.lock().unwrap();
+        let mut state = lock_or_recover(&shared_state);
         state.hint_format = format;
     }
 
@@ -1282,7 +1283,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
     loop {
         // Check if Ctrl+U requested limbo values to be returned to stack
         {
-            let mut state = shared_state.lock().unwrap();
+            let mut state = lock_or_recover(&shared_state);
             if state.return_limbo_to_stack {
                 // Return limbo values to the real stack in reverse order (like Ctrl+C)
                 let mut limbo_items: Vec<_> = state.limbo.drain().collect();
@@ -1299,7 +1300,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
 
         // Sync evaluator stack with shared state, auto-converting huge values to limbo refs
         {
-            let mut state = shared_state.lock().unwrap();
+            let mut state = lock_or_recover(&shared_state);
             let eval_stack = eval.stack();
             state.stack = state.sync_stack_with_auto_limbo(eval_stack);
         }
@@ -1345,7 +1346,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                 // Process any pending pushes from Ctrl+\ (before executing the line)
                 // and apply pending pops from Ctrl+] to the real evaluator stack
                 {
-                    let mut state = shared_state.lock().unwrap();
+                    let mut state = lock_or_recover(&shared_state);
 
                     // Push words from input to stack
                     for word in state.pending_push.drain(..) {
@@ -1370,7 +1371,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
 
                         // Transfer limbo from SharedState to evaluator before execution
                         {
-                            let mut state = shared_state.lock().unwrap();
+                            let mut state = lock_or_recover(&shared_state);
                             for (id, value) in state.limbo.drain() {
                                 eval.limbo.insert(id, value);
                             }
@@ -1380,7 +1381,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
 
                         // Clear limbo and pending state after execution
                         {
-                            let mut state = shared_state.lock().unwrap();
+                            let mut state = lock_or_recover(&shared_state);
                             state.clear();
                         }
                         eval.clear_limbo();
@@ -1428,7 +1429,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                         // Clear the stack and the screen
                         eval.clear_stack();
                         {
-                            let mut state = shared_state.lock().unwrap();
+                            let mut state = lock_or_recover(&shared_state);
                             state.clear();
                         }
                         // Clear screen using ANSI escape codes
@@ -1440,7 +1441,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                         // Clear just the stack
                         eval.clear_stack();
                         {
-                            let mut state = shared_state.lock().unwrap();
+                            let mut state = lock_or_recover(&shared_state);
                             state.clear();
                         }
                         continue;
@@ -1485,21 +1486,21 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                     }
                     ".types" | ".t" => {
                         // Toggle type annotations in hint
-                        let mut state = shared_state.lock().unwrap();
+                        let mut state = lock_or_recover(&shared_state);
                         state.show_types = !state.show_types;
                         println!("Type annotations: {}", if state.show_types { "ON" } else { "OFF" });
                         continue;
                     }
                     ".hint" => {
                         // Toggle hint visibility
-                        let mut state = shared_state.lock().unwrap();
+                        let mut state = lock_or_recover(&shared_state);
                         state.hint_visible = !state.hint_visible;
                         println!("Hint: {}", if state.hint_visible { "ON" } else { "OFF" });
                         continue;
                     }
                     ".highlight" | ".hl" => {
                         // Toggle syntax highlighting
-                        let mut state = shared_state.lock().unwrap();
+                        let mut state = lock_or_recover(&shared_state);
                         state.highlight_enabled = !state.highlight_enabled;
                         println!("Syntax highlighting: {}", if state.highlight_enabled { "ON" } else { "OFF" });
                         continue;
@@ -1605,7 +1606,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
 
                 // Transfer limbo from SharedState to evaluator before execution
                 {
-                    let mut state = shared_state.lock().unwrap();
+                    let mut state = lock_or_recover(&shared_state);
                     for (id, value) in state.limbo.drain() {
                         eval.limbo.insert(id, value);
                     }
@@ -1616,7 +1617,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
 
                 // Clear limbo and pending state after execution (refs are consumed or lost)
                 {
-                    let mut state = shared_state.lock().unwrap();
+                    let mut state = lock_or_recover(&shared_state);
                     state.clear();
                 }
                 eval.clear_limbo();
@@ -1639,7 +1640,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                 // Ctrl-C - return limbo values to stack, clear pending state, continue
                 prefill.clear();
                 {
-                    let mut state = shared_state.lock().unwrap();
+                    let mut state = lock_or_recover(&shared_state);
                     // Return limbo values to the real stack in reverse order
                     let mut limbo_items: Vec<_> = state.limbo.drain().collect();
                     // Sort by ID to get deterministic order (IDs are hex counters)

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -831,60 +831,19 @@ impl HsabHelper {
     }
 }
 
-/// Get default builtins for tab completion
-fn default_builtins() -> HashSet<&'static str> {
-    [
-        // Shell builtins
-        "cd", "pwd", "echo", "true", "false", "test", "[",
-        "export", "unset", "env", "exit", "jobs", "fg", "bg",
-        "tty", "which", "source", ".", "hash", "type",
-        "read", "printf", "wait", "kill", "local", "return",
-        "pushd", "popd", "dirs", "alias", "unalias", "trap",
-        // Stack operations
-        "dup", "swap", "drop", "over", "rot", "depth",
-        // Path operations
-        "path-join", "suffix", "basename", "dirname", "path-resolve",
-        // String operations
-        "split1", "rsplit1", "len", "slice", "indexof", "str-replace", "format",
-        // List operations
-        "marker", "spread", "each", "keep", "collect", "map", "filter",
-        // Control flow
-        "if", "elseif", "else", "times", "while", "until", "break",
-        // Parallel
-        "parallel", "fork",
-        // Process substitution
-        "subst", "fifo",
-        // JSON / Structured data
-        "json", "unjson", "typeof",
-        // Record operations
-        "record", "get", "set", "del", "has?", "keys", "values", "merge",
-        // Table operations
-        "table", "where", "sort-by", "select", "first", "last", "nth",
-        "group-by", "unique", "reverse", "flatten",
-        // Error handling
-        "try", "error?", "throw",
-        // Serialization (into-X = serialize, from-X = parse)
-        "into-json", "into-csv", "into-lines", "into-kv", "into-tsv", "into-delimited",
-        "to-json", "to-csv", "to-lines", "to-kv", "to-tsv", "to-delimited",
-        "from-json", "from-csv", "from-lines", "from-kv", "from-tsv", "from-delimited",
-        // Stack utilities
-        "tap", "dip",
-        // Aggregations
-        "sum", "avg", "min", "max", "count",
-        // Predicates
-        "file?", "dir?", "exists?", "empty?", "eq?", "ne?",
-        "=?", "!=?", "lt?", "gt?", "le?", "ge?",
-        // Arithmetic
-        "plus", "minus", "mul", "div", "mod",
-        // Other
-        "timeout", "pipestatus", ".import",
-        // Plugins
-        "plugin-load", "plugin-unload", "plugin-reload", "plugin-list", "plugin-info",
-        // Media / Image operations
-        "image-load", "image-show", "image-info", "to-base64", "from-base64",
-    ]
-    .into_iter()
-    .collect()
+/// Builtin names offered by tab completion and syntax highlighting.
+///
+/// Sourced from the single registry in `hsab::resolver` (issue #32):
+/// `default_builtins()` (shell + stack-native builtins, including dot-commands)
+/// plus the language constructs the parser turns into `Expr` variants
+/// (`STACK_OPS`, `PATH_OPS`, `LANGUAGE_KEYWORDS`). There is no separate
+/// hand-maintained list, so completion cannot drift from the dispatcher.
+fn completion_builtins() -> HashSet<&'static str> {
+    let mut set: HashSet<&'static str> = hsab::resolver::default_builtins().clone();
+    set.extend(hsab::resolver::STACK_OPS.iter().copied());
+    set.extend(hsab::resolver::PATH_OPS.iter().copied());
+    set.extend(hsab::resolver::LANGUAGE_KEYWORDS.iter().copied());
+    set
 }
 
 impl Hinter for HsabHelper {
@@ -1171,7 +1130,7 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
     // Set helper with shared state for live stack display and tab completion
     rl.set_helper(Some(HsabHelper {
         state: Arc::clone(&shared_state),
-        builtins: default_builtins(),
+        builtins: completion_builtins(),
         definitions: HashSet::new(),
         resolver: Mutex::new(ExecutableResolver::new()),
     }));
@@ -1711,4 +1670,62 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::completion_builtins;
+
+    /// Drift guard (issue #32): the REPL completion set must offer every
+    /// builtin in the authoritative registry. `complete_command` iterates
+    /// `HsabHelper.builtins`, which is populated from `completion_builtins()`,
+    /// so registry membership here means the completer offers the name.
+    #[test]
+    fn test_completion_offers_every_registry_builtin() {
+        let completions = completion_builtins();
+        let mut missing: Vec<&str> = hsab::resolver::default_builtins()
+            .iter()
+            .filter(|b| !completions.contains(*b))
+            .copied()
+            .collect();
+        missing.sort_unstable();
+        assert!(
+            missing.is_empty(),
+            "REPL completion is missing registry builtins: {:?}",
+            missing
+        );
+    }
+
+    /// Language constructs and stack/path ops must also be offered.
+    #[test]
+    fn test_completion_offers_language_keywords() {
+        let completions = completion_builtins();
+        for word in hsab::resolver::STACK_OPS
+            .iter()
+            .chain(hsab::resolver::PATH_OPS)
+            .chain(hsab::resolver::LANGUAGE_KEYWORDS)
+        {
+            assert!(
+                completions.contains(word),
+                "REPL completion is missing language keyword: {word}"
+            );
+        }
+    }
+
+    /// Meta commands must keep their dot prefix in the completion set
+    /// (the old hand-maintained list offered bare `export`/`unset`).
+    #[test]
+    fn test_completion_dot_prefixed_meta_commands() {
+        let completions = completion_builtins();
+        for word in [".export", ".unset", ".jobs", ".fg", ".bg", ".plugin-load"] {
+            assert!(completions.contains(word), "missing meta command: {word}");
+        }
+        // The drifted bare forms from the old list must be gone.
+        for word in ["export", "unset", "jobs", "plugin-load"] {
+            assert!(
+                !completions.contains(word),
+                "bare (non-dot) meta command should not be offered: {word}"
+            );
+        }
+    }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,19 +1,22 @@
-use hsab::{Evaluator, ExecutableResolver, Value, FutureState};
+use hsab::{Evaluator, ExecutableResolver, FutureState, Value};
+use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
-use rustyline::completion::{Completer, Pair};
-use rustyline::{Cmd, ConditionalEventHandler, Editor, Event, EventContext, KeyCode, KeyEvent, Modifiers, Movement, RepeatCount};
+use rustyline::{
+    Cmd, ConditionalEventHandler, Editor, Event, EventContext, KeyCode, KeyEvent, Modifiers,
+    Movement, RepeatCount,
+};
 use rustyline::{Helper, Result as RlResult};
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
-use crate::prompt::{set_prompt_context, eval_prompt_definition, extract_hint_format};
-use crate::rcfile::{load_hsabrc, load_hsab_profile, load_stdlib, dirs_home};
-use crate::terminal::{execute_line, is_triple_quotes_balanced};
 use crate::cli::print_help;
+use crate::prompt::{eval_prompt_definition, extract_hint_format, set_prompt_context};
+use crate::rcfile::{dirs_home, load_hsab_profile, load_hsabrc, load_stdlib};
+use crate::terminal::{execute_line, is_triple_quotes_balanced};
 use hsab::util::lock_or_recover;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -119,19 +122,22 @@ impl SharedState {
     /// Sync stack from evaluator, auto-converting huge values to limbo refs
     /// Returns the synced stack with huge values replaced by limbo ref literals
     fn sync_stack_with_auto_limbo(&mut self, eval_stack: &[Value]) -> Vec<Value> {
-        eval_stack.iter().map(|value| {
-            if self.is_huge_value(value) {
-                // Convert huge value to limbo ref immediately
-                let id = self.generate_limbo_id();
-                let limbo_ref = self.format_limbo_ref(&id, value);
-                self.limbo.insert(id, value.clone());
-                // Return the limbo ref as a Literal so it displays in hint
-                // and pops directly as the ref string
-                Value::Literal(limbo_ref)
-            } else {
-                value.clone()
-            }
-        }).collect()
+        eval_stack
+            .iter()
+            .map(|value| {
+                if self.is_huge_value(value) {
+                    // Convert huge value to limbo ref immediately
+                    let id = self.generate_limbo_id();
+                    let limbo_ref = self.format_limbo_ref(&id, value);
+                    self.limbo.insert(id, value.clone());
+                    // Return the limbo ref as a Literal so it displays in hint
+                    // and pops directly as the ref string
+                    Value::Literal(limbo_ref)
+                } else {
+                    value.clone()
+                }
+            })
+            .collect()
     }
 
     /// Extract the first token from input, handling quoted strings and limbo refs
@@ -243,12 +249,15 @@ impl SharedState {
             Value::Table { columns, rows } => {
                 format!("table[{}x{}]", columns.len(), rows.len())
             }
-            Value::Media { mime_type, width, height, .. } => {
-                match (width, height) {
-                    (Some(w), Some(h)) => format!("{}[{}x{}]", mime_type, w, h),
-                    _ => mime_type.clone(),
-                }
-            }
+            Value::Media {
+                mime_type,
+                width,
+                height,
+                ..
+            } => match (width, height) {
+                (Some(w), Some(h)) => format!("{}[{}x{}]", mime_type, w, h),
+                _ => mime_type.clone(),
+            },
             Value::Block(_) => "block:[...]".to_string(),
             Value::BigInt(n) => {
                 let s = n.to_string();
@@ -270,7 +279,7 @@ impl SharedState {
             }
             Value::Error { kind, .. } => format!("error:{}", kind),
             Value::Future { id: fid, state } => {
-                                let guard = lock_or_recover(&state);
+                let guard = lock_or_recover(state);
                 let status = match &*guard {
                     FutureState::Pending => "pending",
                     FutureState::Completed(_) => "completed",
@@ -297,54 +306,61 @@ impl SharedState {
             return None;
         }
 
-        let items: Vec<String> = self.stack.iter().filter_map(|v| {
-            if self.show_types {
-                // Show type annotations
-                match v {
-                    Value::Literal(s) if s.len() > 15 => Some(format!("{}...(str)", &s[..12])),
-                    Value::Literal(s) => Some(format!("{}(str)", s)),
-                    Value::Output(s) if s.len() > 15 => Some(format!("{}...(out)", &s[..12])),
-                    Value::Output(s) => Some(format!("{}(out)", s)),
-                    Value::Block(_) => Some("[...](blk)".to_string()),
-                    Value::Map(_) => Some("{...}(map)".to_string()),
-                    Value::Table { .. } => Some("[table](tbl)".to_string()),
-                    Value::List(_) => Some("[list](lst)".to_string()),
-                    Value::Number(n) => Some(format!("{}(num)", n)),
-                    Value::Bool(b) => Some(format!("{}(bool)", b)),
-                    Value::Error { message, .. } => Some(format!("ERR:{}", message)),
-                    Value::Media { data, .. } => Some(format!("<img:{}B>(media)", data.len())),
-                    Value::Link { url, .. } => Some(format!("<link:{}>(link)", if url.len() > 10 { &url[..10] } else { url })),
-                    Value::Bytes(data) => Some(format!("<{}B>(bytes)", data.len())),
-                    Value::BigInt(n) => {
-                        let s = n.to_string();
-                        if s.len() > 12 {
-                            Some(format!("{}...(bigint)", &s[..9]))
-                        } else {
-                            Some(format!("{}(bigint)", s))
+        let items: Vec<String> = self
+            .stack
+            .iter()
+            .filter_map(|v| {
+                if self.show_types {
+                    // Show type annotations
+                    match v {
+                        Value::Literal(s) if s.len() > 15 => Some(format!("{}...(str)", &s[..12])),
+                        Value::Literal(s) => Some(format!("{}(str)", s)),
+                        Value::Output(s) if s.len() > 15 => Some(format!("{}...(out)", &s[..12])),
+                        Value::Output(s) => Some(format!("{}(out)", s)),
+                        Value::Block(_) => Some("[...](blk)".to_string()),
+                        Value::Map(_) => Some("{...}(map)".to_string()),
+                        Value::Table { .. } => Some("[table](tbl)".to_string()),
+                        Value::List(_) => Some("[list](lst)".to_string()),
+                        Value::Number(n) => Some(format!("{}(num)", n)),
+                        Value::Bool(b) => Some(format!("{}(bool)", b)),
+                        Value::Error { message, .. } => Some(format!("ERR:{}", message)),
+                        Value::Media { data, .. } => Some(format!("<img:{}B>(media)", data.len())),
+                        Value::Link { url, .. } => Some(format!(
+                            "<link:{}>(link)",
+                            if url.len() > 10 { &url[..10] } else { url }
+                        )),
+                        Value::Bytes(data) => Some(format!("<{}B>(bytes)", data.len())),
+                        Value::BigInt(n) => {
+                            let s = n.to_string();
+                            if s.len() > 12 {
+                                Some(format!("{}...(bigint)", &s[..9]))
+                            } else {
+                                Some(format!("{}(bigint)", s))
+                            }
                         }
+                        Value::Future { id, state } => {
+                            let guard = lock_or_recover(state);
+                            let status = match &*guard {
+                                FutureState::Pending => "pending",
+                                FutureState::Completed(_) => "completed",
+                                FutureState::Failed(_) => "failed",
+                                FutureState::Cancelled => "cancelled",
+                            };
+                            Some(format!("<{}:{}>(future)", status, id))
+                        }
+                        Value::Marker => None,
+                        Value::Nil => None,
                     }
-                    Value::Future { id, state } => {
-                                                let guard = lock_or_recover(&state);
-                        let status = match &*guard {
-                            FutureState::Pending => "pending",
-                            FutureState::Completed(_) => "completed",
-                            FutureState::Failed(_) => "failed",
-                            FutureState::Cancelled => "cancelled",
-                        };
-                        Some(format!("<{}:{}>(future)", status, id))
+                } else {
+                    // Simple display
+                    match v.as_arg() {
+                        Some(s) if s.len() > 20 => Some(format!("{}...", &s[..17])),
+                        Some(s) => Some(s),
+                        None => None,
                     }
-                    Value::Marker => None,
-                    Value::Nil => None,
                 }
-            } else {
-                // Simple display
-                match v.as_arg() {
-                    Some(s) if s.len() > 20 => Some(format!("{}...", &s[..17])),
-                    Some(s) => Some(s),
-                    None => None,
-                }
-            }
-        }).collect();
+            })
+            .collect();
 
         if items.is_empty() {
             return None;
@@ -367,7 +383,13 @@ struct PopToInputHandler {
 }
 
 impl ConditionalEventHandler for PopToInputHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
         let mut state = self.state.lock().ok()?;
 
         // First check if we have a pending prepend to complete
@@ -389,7 +411,9 @@ impl ConditionalEventHandler for PopToInputHandler {
             // Simple values are inserted directly, complex values use limbo refs
             let insert_text = if state.is_simple_value(&value) {
                 // Direct representation - no limbo needed
-                state.simple_value_repr(&value).unwrap_or_else(|| "nil".to_string())
+                state
+                    .simple_value_repr(&value)
+                    .unwrap_or_else(|| "nil".to_string())
             } else {
                 // Complex value - generate limbo reference
                 let id = state.generate_limbo_id();
@@ -427,7 +451,13 @@ struct PushToStackHandler {
 }
 
 impl ConditionalEventHandler for PushToStackHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
         let line = ctx.line().to_string();
 
         // Extract first token (handles quoted strings, limbo refs, regular words)
@@ -455,7 +485,13 @@ struct PushAllToStackHandler {
 }
 
 impl ConditionalEventHandler for PushAllToStackHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
         let line = ctx.line().to_string();
 
         // Tokenize input (handles quoted strings, limbo refs, regular words)
@@ -482,13 +518,19 @@ struct ClearStackHandler {
 }
 
 impl ConditionalEventHandler for ClearStackHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, _ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        _ctx: &EventContext,
+    ) -> Option<Cmd> {
         if let Ok(mut state) = self.state.lock() {
             // Mark all items in stack copy as needing to be popped from real stack
             let count = state.stack.len();
             state.stack.clear();
             state.clear();
-            state.pops_to_apply = count;  // Set after clearing so it's not overwritten
+            state.pops_to_apply = count; // Set after clearing so it's not overwritten
         }
         // No change to the input line
         Some(Cmd::Noop)
@@ -502,7 +544,13 @@ struct ClearLineWithLimboHandler {
 }
 
 impl ConditionalEventHandler for ClearLineWithLimboHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, _ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        _ctx: &EventContext,
+    ) -> Option<Cmd> {
         if let Ok(mut state) = self.state.lock() {
             // If there are limbo values, mark them for return to stack
             if !state.limbo.is_empty() {
@@ -520,7 +568,13 @@ struct ToggleTypesHandler {
 }
 
 impl ConditionalEventHandler for ToggleTypesHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
         if let Ok(mut state) = self.state.lock() {
             state.show_types = !state.show_types;
         }
@@ -536,7 +590,13 @@ struct ToggleHintHandler {
 }
 
 impl ConditionalEventHandler for ToggleHintHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
         if let Ok(mut state) = self.state.lock() {
             state.hint_visible = !state.hint_visible;
         }
@@ -552,8 +612,14 @@ struct ClipCopyHandler {
 }
 
 impl ConditionalEventHandler for ClipCopyHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
         use std::io::Write;
 
         let state = self.state.lock().ok()?;
@@ -576,8 +642,14 @@ struct ClipCutHandler {
 }
 
 impl ConditionalEventHandler for ClipCutHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
-        use base64::{Engine as _, engine::general_purpose::STANDARD};
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
         use std::io::Write;
 
         let mut state = self.state.lock().ok()?;
@@ -602,7 +674,13 @@ struct PopAllToInputHandler {
 }
 
 impl ConditionalEventHandler for PopAllToInputHandler {
-    fn handle(&self, _evt: &Event, _n: RepeatCount, _positive: bool, ctx: &EventContext) -> Option<Cmd> {
+    fn handle(
+        &self,
+        _evt: &Event,
+        _n: RepeatCount,
+        _positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd> {
         let mut state = self.state.lock().ok()?;
 
         if state.stack.is_empty() {
@@ -615,7 +693,9 @@ impl ConditionalEventHandler for PopAllToInputHandler {
             state.pops_to_apply += 1;
             // Simple values are inserted directly, complex values use limbo refs
             let text = if state.is_simple_value(&value) {
-                state.simple_value_repr(&value).unwrap_or_else(|| "nil".to_string())
+                state
+                    .simple_value_repr(&value)
+                    .unwrap_or_else(|| "nil".to_string())
             } else {
                 let id = state.generate_limbo_id();
                 let limbo_ref = state.format_limbo_ref(&id, &value);
@@ -680,34 +760,37 @@ impl Completer for HsabHelper {
         }
 
         // Check stack state for postfix-aware completion
-        let stack_has_items = self.state.lock()
+        let stack_has_items = self
+            .state
+            .lock()
             .map(|s| !s.stack.is_empty())
             .unwrap_or(false);
 
         // Check if line already has content before cursor (indicates values already entered)
         let line_has_values = start > 0;
 
-        let completions = if prefix.contains('/') || prefix.starts_with('.') || prefix.starts_with('~') {
-            // Explicit path completion
-            self.complete_path(prefix)
-        } else if stack_has_items || line_has_values {
-            // Stack has values OR line has previous words -> prioritize operations (commands)
-            // This is postfix: values are on stack, user is typing the operation
-            let mut cmds = self.complete_command(prefix);
-            // Still include files, but after commands
-            cmds.extend(self.complete_current_dir(prefix));
-            cmds.sort();
-            cmds.dedup();
-            cmds
-        } else {
-            // Empty stack, first word -> prioritize files (values in postfix)
-            // User is likely entering values first before applying operations
-            let mut files = self.complete_current_dir(prefix);
-            files.extend(self.complete_command(prefix));
-            files.sort();
-            files.dedup();
-            files
-        };
+        let completions =
+            if prefix.contains('/') || prefix.starts_with('.') || prefix.starts_with('~') {
+                // Explicit path completion
+                self.complete_path(prefix)
+            } else if stack_has_items || line_has_values {
+                // Stack has values OR line has previous words -> prioritize operations (commands)
+                // This is postfix: values are on stack, user is typing the operation
+                let mut cmds = self.complete_command(prefix);
+                // Still include files, but after commands
+                cmds.extend(self.complete_current_dir(prefix));
+                cmds.sort();
+                cmds.dedup();
+                cmds
+            } else {
+                // Empty stack, first word -> prioritize files (values in postfix)
+                // User is likely entering values first before applying operations
+                let mut files = self.complete_current_dir(prefix);
+                files.extend(self.complete_command(prefix));
+                files.sort();
+                files.dedup();
+                files
+            };
 
         let pairs: Vec<Pair> = completions
             .into_iter()
@@ -767,7 +850,8 @@ impl HsabHelper {
                 if let Ok(entries) = std::fs::read_dir(dir) {
                     for entry in entries.filter_map(|e| e.ok()) {
                         if let Some(name) = entry.file_name().to_str() {
-                            if name.starts_with(prefix) && !completions.contains(&name.to_string()) {
+                            if name.starts_with(prefix) && !completions.contains(&name.to_string())
+                            {
                                 completions.push(name.to_string());
                                 found += 1;
                                 if found >= 50 {
@@ -862,7 +946,9 @@ impl Hinter for HsabHelper {
 
 impl Highlighter for HsabHelper {
     fn highlight<'l>(&self, line: &'l str, _pos: usize) -> Cow<'l, str> {
-        let highlight_enabled = self.state.lock()
+        let highlight_enabled = self
+            .state
+            .lock()
             .map(|s| s.highlight_enabled)
             .unwrap_or(false);
         if !highlight_enabled || line.is_empty() {
@@ -881,14 +967,14 @@ impl Highlighter for HsabHelper {
 
             // Apply color based on token type
             let colored = match token.kind {
-                TokenKind::Builtin => format!("\x1b[34m{}\x1b[0m", token.text),      // Blue
-                TokenKind::Definition => format!("\x1b[1m{}\x1b[0m", token.text),    // Bold
-                TokenKind::String => format!("\x1b[32m{}\x1b[0m", token.text),       // Green
-                TokenKind::Number => format!("\x1b[33m{}\x1b[0m", token.text),       // Yellow
-                TokenKind::Block => format!("\x1b[35m{}\x1b[0m", token.text),        // Magenta
-                TokenKind::Operator => format!("\x1b[36m{}\x1b[0m", token.text),     // Cyan
-                TokenKind::Variable => format!("\x1b[36m{}\x1b[0m", token.text),     // Cyan
-                TokenKind::Comment => format!("\x1b[90m{}\x1b[0m", token.text),      // Dim
+                TokenKind::Builtin => format!("\x1b[34m{}\x1b[0m", token.text), // Blue
+                TokenKind::Definition => format!("\x1b[1m{}\x1b[0m", token.text), // Bold
+                TokenKind::String => format!("\x1b[32m{}\x1b[0m", token.text),  // Green
+                TokenKind::Number => format!("\x1b[33m{}\x1b[0m", token.text),  // Yellow
+                TokenKind::Block => format!("\x1b[35m{}\x1b[0m", token.text),   // Magenta
+                TokenKind::Operator => format!("\x1b[36m{}\x1b[0m", token.text), // Cyan
+                TokenKind::Variable => format!("\x1b[36m{}\x1b[0m", token.text), // Cyan
+                TokenKind::Comment => format!("\x1b[90m{}\x1b[0m", token.text), // Dim
                 TokenKind::Normal => token.text.to_string(),
             };
             result.push_str(&colored);
@@ -904,7 +990,8 @@ impl Highlighter for HsabHelper {
     }
 
     fn highlight_char(&self, _line: &str, _pos: usize) -> bool {
-        self.state.lock()
+        self.state
+            .lock()
             .map(|s| s.highlight_enabled)
             .unwrap_or(false)
     }
@@ -918,15 +1005,15 @@ impl Highlighter for HsabHelper {
 /// Token kinds for syntax highlighting
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum TokenKind {
-    Builtin,      // Built-in commands (blue)
-    Definition,   // User definitions (bold)
-    String,       // Quoted strings (green)
-    Number,       // Numbers (yellow)
-    Block,        // [ ] blocks (magenta)
-    Operator,     // |, >, @, etc. (cyan)
-    Variable,     // $VAR (cyan)
-    Comment,      // # comments (dim)
-    Normal,       // Default
+    Builtin,    // Built-in commands (blue)
+    Definition, // User definitions (bold)
+    String,     // Quoted strings (green)
+    Number,     // Numbers (yellow)
+    Block,      // [ ] blocks (magenta)
+    Operator,   // |, >, @, etc. (cyan)
+    Variable,   // $VAR (cyan)
+    Comment,    // # comments (dim)
+    Normal,     // Default
 }
 
 /// Token with position and kind
@@ -941,7 +1028,9 @@ impl HsabHelper {
     /// Check if a word is a dynamic operator pattern (e.g., 3+, 2/, 10log, 2pow)
     fn is_dynamic_pattern(word: &str) -> bool {
         let len = word.len();
-        if len < 2 { return false; }
+        if len < 2 {
+            return false;
+        }
         let bytes = word.as_bytes();
         let last = bytes[len - 1];
         // Trailing operator: 3+, 14*, 2.5/, etc.
@@ -974,7 +1063,11 @@ impl HsabHelper {
             }
 
             let start = pos;
-            let byte_start = line.char_indices().nth(start).map(|(i, _)| i).unwrap_or(line.len());
+            let byte_start = line
+                .char_indices()
+                .nth(start)
+                .map(|(i, _)| i)
+                .unwrap_or(line.len());
 
             // Comment
             if chars[pos] == '#' {
@@ -1002,7 +1095,11 @@ impl HsabHelper {
                 if pos < len {
                     pos += 1; // closing quote
                 }
-                let byte_end = line.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(line.len());
+                let byte_end = line
+                    .char_indices()
+                    .nth(pos)
+                    .map(|(i, _)| i)
+                    .unwrap_or(line.len());
                 tokens.push(HighlightToken {
                     text: &line[byte_start..byte_end],
                     start: byte_start,
@@ -1024,7 +1121,11 @@ impl HsabHelper {
                     }
                     pos += 1;
                 }
-                let byte_end = line.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(line.len());
+                let byte_end = line
+                    .char_indices()
+                    .nth(pos)
+                    .map(|(i, _)| i)
+                    .unwrap_or(line.len());
                 tokens.push(HighlightToken {
                     text: &line[byte_start..byte_end],
                     start: byte_start,
@@ -1037,10 +1138,19 @@ impl HsabHelper {
             // Variable
             if chars[pos] == '$' {
                 pos += 1;
-                while pos < len && (chars[pos].is_alphanumeric() || chars[pos] == '_' || chars[pos] == '{' || chars[pos] == '}') {
+                while pos < len
+                    && (chars[pos].is_alphanumeric()
+                        || chars[pos] == '_'
+                        || chars[pos] == '{'
+                        || chars[pos] == '}')
+                {
                     pos += 1;
                 }
-                let byte_end = line.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(line.len());
+                let byte_end = line
+                    .char_indices()
+                    .nth(pos)
+                    .map(|(i, _)| i)
+                    .unwrap_or(line.len());
                 tokens.push(HighlightToken {
                     text: &line[byte_start..byte_end],
                     start: byte_start,
@@ -1057,7 +1167,11 @@ impl HsabHelper {
                 if pos < len && matches!(chars[pos], '>' | '&' | '|') {
                     pos += 1;
                 }
-                let byte_end = line.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(line.len());
+                let byte_end = line
+                    .char_indices()
+                    .nth(pos)
+                    .map(|(i, _)| i)
+                    .unwrap_or(line.len());
                 tokens.push(HighlightToken {
                     text: &line[byte_start..byte_end],
                     start: byte_start,
@@ -1068,10 +1182,20 @@ impl HsabHelper {
             }
 
             // Word (command, number, or identifier)
-            while pos < len && !chars[pos].is_whitespace() && !matches!(chars[pos], '[' | ']' | '|' | '>' | '<' | '@' | '&' | ';' | '#') {
+            while pos < len
+                && !chars[pos].is_whitespace()
+                && !matches!(
+                    chars[pos],
+                    '[' | ']' | '|' | '>' | '<' | '@' | '&' | ';' | '#'
+                )
+            {
                 pos += 1;
             }
-            let byte_end = line.char_indices().nth(pos).map(|(i, _)| i).unwrap_or(line.len());
+            let byte_end = line
+                .char_indices()
+                .nth(pos)
+                .map(|(i, _)| i)
+                .unwrap_or(line.len());
             let word = &line[byte_start..byte_end];
 
             // Determine token kind
@@ -1089,7 +1213,12 @@ impl HsabHelper {
             } else if std::path::Path::new(word).exists() {
                 // Existing files are normal (literal values)
                 TokenKind::Normal
-            } else if self.resolver.lock().map(|mut r| r.is_executable(word)).unwrap_or(false) {
+            } else if self
+                .resolver
+                .lock()
+                .map(|mut r| r.is_executable(word))
+                .unwrap_or(false)
+            {
                 // External executable found in PATH
                 TokenKind::Builtin
             } else if Self::is_dynamic_pattern(word) {
@@ -1265,7 +1394,10 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
 
     // Show banner only if HSAB_BANNER is set
     if std::env::var("HSAB_BANNER").is_ok() {
-        println!("hsab-{}£ Hash Backwards - stack-based postfix shell", VERSION);
+        println!(
+            "hsab-{}£ Hash Backwards - stack-based postfix shell",
+            VERSION
+        );
         println!("  Type 'exit' or Ctrl-D to quit, '.help' for usage");
     }
 
@@ -1323,20 +1455,18 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
         // Determine which prompt to use
         let prompt: String = if !multiline_buffer.is_empty() {
             // Multiline: try PS2, fallback to default
-            eval_prompt_definition(&mut eval, "PS2")
-                .unwrap_or_else(|| fallback_multiline.clone())
+            eval_prompt_definition(&mut eval, "PS2").unwrap_or_else(|| fallback_multiline.clone())
         } else {
             // Normal: try PS1, fallback to default
-            eval_prompt_definition(&mut eval, "PS1")
-                .unwrap_or_else(|| {
-                    // Use fallback with pound/cent based on stack
-                    let has_stack = eval.stack().iter().any(|v| v.as_arg().is_some());
-                    if !prefill.is_empty() || has_stack {
-                        fallback_stack.clone()
-                    } else {
-                        fallback_normal.clone()
-                    }
-                })
+            eval_prompt_definition(&mut eval, "PS1").unwrap_or_else(|| {
+                // Use fallback with pound/cent based on stack
+                let has_stack = eval.stack().iter().any(|v| v.as_arg().is_some());
+                if !prefill.is_empty() || has_stack {
+                    fallback_stack.clone()
+                } else {
+                    fallback_normal.clone()
+                }
+            })
         };
 
         // Use readline_with_initial if we have prefill from .use command
@@ -1495,7 +1625,10 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                         // Toggle type annotations in hint
                         let mut state = lock_or_recover(&shared_state);
                         state.show_types = !state.show_types;
-                        println!("Type annotations: {}", if state.show_types { "ON" } else { "OFF" });
+                        println!(
+                            "Type annotations: {}",
+                            if state.show_types { "ON" } else { "OFF" }
+                        );
                         continue;
                     }
                     ".hint" => {
@@ -1509,7 +1642,10 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                         // Toggle syntax highlighting
                         let mut state = lock_or_recover(&shared_state);
                         state.highlight_enabled = !state.highlight_enabled;
-                        println!("Syntax highlighting: {}", if state.highlight_enabled { "ON" } else { "OFF" });
+                        println!(
+                            "Syntax highlighting: {}",
+                            if state.highlight_enabled { "ON" } else { "OFF" }
+                        );
                         continue;
                     }
                     // === Debugger commands ===
@@ -1558,7 +1694,8 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                     }
                     _ if trimmed.starts_with(".break ") || trimmed.starts_with(".b ") => {
                         // Add a breakpoint
-                        let pattern = trimmed.strip_prefix(".break ")
+                        let pattern = trimmed
+                            .strip_prefix(".break ")
                             .or_else(|| trimmed.strip_prefix(".b "))
                             .unwrap_or("")
                             .to_string();
@@ -1578,7 +1715,8 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                     }
                     _ if trimmed.starts_with(".delbreak ") || trimmed.starts_with(".db ") => {
                         // Remove a breakpoint
-                        let pattern = trimmed.strip_prefix(".delbreak ")
+                        let pattern = trimmed
+                            .strip_prefix(".delbreak ")
                             .or_else(|| trimmed.strip_prefix(".db "))
                             .unwrap_or("");
                         if eval.remove_breakpoint(pattern) {
@@ -1590,7 +1728,8 @@ pub(crate) fn run_repl_with_login(is_login: bool, trace: bool) -> RlResult<()> {
                     }
                     _ if trimmed.starts_with(".use=") || trimmed.starts_with(".u=") => {
                         // Move N stack items to input
-                        let n_str = trimmed.strip_prefix(".use=")
+                        let n_str = trimmed
+                            .strip_prefix(".use=")
                             .or_else(|| trimmed.strip_prefix(".u="))
                             .unwrap_or("");
                         match n_str.parse::<usize>() {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -7,12 +7,36 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::Path;
+use std::sync::OnceLock;
 
 /// Stack operations for argument manipulation
 pub const STACK_OPS: &[&str] = &["dup", "swap", "drop", "over", "rot", "apply", "exec", "peek", "peek-all"];
 
 /// Path operations for filename manipulation
 pub const PATH_OPS: &[&str] = &["path-join", "suffix", "dirname", "basename", "reext", "path-resolve"];
+
+/// Language constructs that the parser turns into dedicated `Expr` variants
+/// (see `src/parser.rs` `word_to_expr`). These never dispatch through
+/// `try_builtin`/`try_structured_builtin`, so they are not part of
+/// `default_builtins()`, but the REPL completer/highlighter offers them.
+pub const LANGUAGE_KEYWORDS: &[&str] = &[
+    // Stack ops (aliases beyond STACK_OPS)
+    "dupe", "depth",
+    // String ops
+    "split1", "rsplit1",
+    // List operations
+    "marker", "spread", "each", "collect", "keep", "map", "filter",
+    // Control flow
+    "if", "elseif", "else", "times", "while", "until", "break",
+    // Parallel execution
+    "parallel", "fork",
+    // Process substitution
+    "subst", "fifo",
+    // JSON / structured data
+    "json", "unjson",
+    // Resource limits / pipeline status / modules
+    "timeout", "pipestatus", ".import",
+];
 
 /// Resolves whether a word is an executable command
 pub struct ExecutableResolver {
@@ -40,7 +64,7 @@ impl ExecutableResolver {
             .collect();
 
         ExecutableResolver {
-            builtins: Self::default_builtins(),
+            builtins: default_builtins().clone(),
             path_cache: HashMap::new(),
             path_dirs,
         }
@@ -50,7 +74,7 @@ impl ExecutableResolver {
     #[cfg(test)]
     pub fn with_path(path_dirs: Vec<String>) -> Self {
         ExecutableResolver {
-            builtins: Self::default_builtins(),
+            builtins: default_builtins().clone(),
             path_cache: HashMap::new(),
             path_dirs,
         }
@@ -58,13 +82,15 @@ impl ExecutableResolver {
 
     /// Check if a word is an hsab builtin (stack/path op or structured data op)
     /// Uses default_builtins() as the single source of truth for all builtins.
+    /// The builtin set is cached in a `OnceLock`, so this does not rebuild it
+    /// per call.
     pub fn is_hsab_builtin(word: &str) -> bool {
         // Check constant arrays for language constructs (parsed as Expr variants)
         if STACK_OPS.contains(&word) || PATH_OPS.contains(&word) {
             return true;
         }
         // Check if it's in the shell builtins set
-        Self::default_builtins().contains(word)
+        default_builtins().contains(word)
     }
 
     /// Check if a word is a stack operation
@@ -195,14 +221,62 @@ impl ExecutableResolver {
         self.find_in_path(name)
     }
 
-    /// Default set of common shell commands
-    /// This is the SINGLE SOURCE OF TRUTH for all hsab builtins.
-    /// Builtins are dispatched in two ways:
-    /// - Shell builtins: string-matching in try_builtin() (cd, pwd, echo, etc.)
-    /// - Language constructs: Expr enum variants in eval_expr() (dup, swap, if, etc.)
-    fn default_builtins() -> HashSet<&'static str> {
-        // Only include hsab's own shell builtins - these are implemented in try_builtin
-        // and should always be recognized as executables regardless of PATH.
+    /// Add custom commands to the builtin set (for testing or extension)
+    #[allow(dead_code)]
+    pub fn add_builtin(&mut self, cmd: &'static str) {
+        self.builtins.insert(cmd);
+    }
+
+    /// Clear the PATH cache
+    pub fn clear_cache(&mut self) {
+        self.path_cache.clear();
+    }
+
+    /// Force resolve a command and cache it (for hash builtin)
+    pub fn resolve_and_cache(&mut self, name: &str) {
+        // If already cached, skip
+        if self.path_cache.contains_key(name) {
+            return;
+        }
+
+        // Look up in PATH and cache result
+        let exists = self.check_path(name);
+        self.path_cache.insert(name.to_string(), exists);
+    }
+
+    /// Get all cached entries with their resolved paths (for hash builtin)
+    pub fn get_cache_entries(&self) -> Vec<(String, String)> {
+        let mut entries = Vec::new();
+        for (cmd, &exists) in &self.path_cache {
+            if exists {
+                // Find the actual path
+                if let Some(path) = self.find_in_path(cmd) {
+                    entries.push((cmd.clone(), path));
+                }
+            }
+        }
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+}
+
+/// Default set of hsab builtin command names.
+/// This is the SINGLE SOURCE OF TRUTH for all hsab builtins.
+/// Builtins are dispatched in two ways:
+/// - Shell builtins: string-matching in try_builtin() (cd, pwd, echo, etc.)
+/// - Stack-native builtins: string-matching in try_structured_builtin()
+///
+/// Language constructs (dup, swap, if, each, etc.) are parsed into `Expr`
+/// variants and live in `STACK_OPS`/`PATH_OPS`/`LANGUAGE_KEYWORDS` instead.
+///
+/// The set is built once and cached (`OnceLock`), so callers such as
+/// `is_hsab_builtin` and the REPL completer never rebuild it.
+pub fn default_builtins() -> &'static HashSet<&'static str> {
+    static BUILTINS: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    BUILTINS.get_or_init(|| {
+        // Only include hsab's own shell builtins - these are implemented in
+        // try_builtin/try_structured_builtin and should always be recognized
+        // as executables regardless of PATH.
         // All other commands are discovered via PATH lookup.
         // Note: "." is NOT included here - it's handled specially in eval.rs
         // so that "." alone is treated as current directory literal, but
@@ -307,45 +381,7 @@ impl ExecutableResolver {
             "cp", "mv", "rm", "rm-r", "ln", "realpath",
             "which", "extname", "glob", "ls",
         ].into_iter().collect()
-    }
-
-    /// Add custom commands to the builtin set (for testing or extension)
-    #[allow(dead_code)]
-    pub fn add_builtin(&mut self, cmd: &'static str) {
-        self.builtins.insert(cmd);
-    }
-
-    /// Clear the PATH cache
-    pub fn clear_cache(&mut self) {
-        self.path_cache.clear();
-    }
-
-    /// Force resolve a command and cache it (for hash builtin)
-    pub fn resolve_and_cache(&mut self, name: &str) {
-        // If already cached, skip
-        if self.path_cache.contains_key(name) {
-            return;
-        }
-
-        // Look up in PATH and cache result
-        let exists = self.check_path(name);
-        self.path_cache.insert(name.to_string(), exists);
-    }
-
-    /// Get all cached entries with their resolved paths (for hash builtin)
-    pub fn get_cache_entries(&self) -> Vec<(String, String)> {
-        let mut entries = Vec::new();
-        for (cmd, &exists) in &self.path_cache {
-            if exists {
-                // Find the actual path
-                if let Some(path) = self.find_in_path(cmd) {
-                    entries.push((cmd.clone(), path));
-                }
-            }
-        }
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
-        entries
-    }
+    })
 }
 
 #[cfg(test)]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -10,10 +10,19 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 /// Stack operations for argument manipulation
-pub const STACK_OPS: &[&str] = &["dup", "swap", "drop", "over", "rot", "apply", "exec", "peek", "peek-all"];
+pub const STACK_OPS: &[&str] = &[
+    "dup", "swap", "drop", "over", "rot", "apply", "exec", "peek", "peek-all",
+];
 
 /// Path operations for filename manipulation
-pub const PATH_OPS: &[&str] = &["path-join", "suffix", "dirname", "basename", "reext", "path-resolve"];
+pub const PATH_OPS: &[&str] = &[
+    "path-join",
+    "suffix",
+    "dirname",
+    "basename",
+    "reext",
+    "path-resolve",
+];
 
 /// Language constructs that the parser turns into dedicated `Expr` variants
 /// (see `src/parser.rs` `word_to_expr`). These never dispatch through
@@ -21,21 +30,40 @@ pub const PATH_OPS: &[&str] = &["path-join", "suffix", "dirname", "basename", "r
 /// `default_builtins()`, but the REPL completer/highlighter offers them.
 pub const LANGUAGE_KEYWORDS: &[&str] = &[
     // Stack ops (aliases beyond STACK_OPS)
-    "dupe", "depth",
+    "dupe",
+    "depth",
     // String ops
-    "split1", "rsplit1",
+    "split1",
+    "rsplit1",
     // List operations
-    "marker", "spread", "each", "collect", "keep", "map", "filter",
+    "marker",
+    "spread",
+    "each",
+    "collect",
+    "keep",
+    "map",
+    "filter",
     // Control flow
-    "if", "elseif", "else", "times", "while", "until", "break",
+    "if",
+    "elseif",
+    "else",
+    "times",
+    "while",
+    "until",
+    "break",
     // Parallel execution
-    "parallel", "fork",
+    "parallel",
+    "fork",
     // Process substitution
-    "subst", "fifo",
+    "subst",
+    "fifo",
     // JSON / structured data
-    "json", "unjson",
+    "json",
+    "unjson",
     // Resource limits / pipeline status / modules
-    "timeout", "pipestatus", ".import",
+    "timeout",
+    "pipestatus",
+    ".import",
 ];
 
 /// Resolves whether a word is an executable command
@@ -284,103 +312,330 @@ pub fn default_builtins() -> &'static HashSet<&'static str> {
         [
             // Borderline builtins: both formats (POSIX compat + dot-convention)
             // Non-dot format is an alias for convenience
-            "cd", ".cd", "pwd", ".pwd", "echo", ".echo",
-            "test", ".test", "true", ".true", "false", ".false", "[",
-            "read", ".read", "printf", ".printf", "wait", ".wait", "kill", ".kill",
-            "pushd", ".pushd", "popd", ".popd", "dirs", ".dirs",
-            "local", ".local", "return", ".return",
+            "cd",
+            ".cd",
+            "pwd",
+            ".pwd",
+            "echo",
+            ".echo",
+            "test",
+            ".test",
+            "true",
+            ".true",
+            "false",
+            ".false",
+            "[",
+            "read",
+            ".read",
+            "printf",
+            ".printf",
+            "wait",
+            ".wait",
+            "kill",
+            ".kill",
+            "pushd",
+            ".pushd",
+            "popd",
+            ".popd",
+            "dirs",
+            ".dirs",
+            "local",
+            ".local",
+            "return",
+            ".return",
             // Meta commands: dot-only (shell state manipulation)
-            ".export", ".unset", ".env", ".jobs", ".fg", ".bg",
-            ".tty", ".source",
-            ".exit", ".hash", ".type", ".which", ".alias", ".unalias", ".trap",
+            ".export",
+            ".unset",
+            ".env",
+            ".jobs",
+            ".fg",
+            ".bg",
+            ".tty",
+            ".source",
+            ".exit",
+            ".hash",
+            ".type",
+            ".which",
+            ".alias",
+            ".unalias",
+            ".trap",
             // Stack-native predicates
-            "file?", "dir?", "exists?", "empty?",
-            "eq?", "ne?", "=?", "!=?",
-            "lt?", "gt?", "le?", "ge?",
-            "nil?", "error?", "has?",
-            "number?", "string?", "array?", "function?",
-            "contains?", "starts?", "ends?",
+            "file?",
+            "dir?",
+            "exists?",
+            "empty?",
+            "eq?",
+            "ne?",
+            "=?",
+            "!=?",
+            "lt?",
+            "gt?",
+            "le?",
+            "ge?",
+            "nil?",
+            "error?",
+            "has?",
+            "number?",
+            "string?",
+            "array?",
+            "function?",
+            "contains?",
+            "starts?",
+            "ends?",
             // Logical operators
-            "not", "xor", "nand", "nor",
+            "not",
+            "xor",
+            "nand",
+            "nor",
             // Arithmetic primitives (word and symbol forms)
-            "plus", "minus", "mul", "div", "mod",
-            "+", "-", "*", "/", "%", "**", "++", "--",
+            "plus",
+            "minus",
+            "mul",
+            "div",
+            "mod",
+            "+",
+            "-",
+            "*",
+            "/",
+            "%",
+            "**",
+            "++",
+            "--",
             // String primitives
-            "len", "slice", "indexof", "str-replace", "format",
+            "len",
+            "slice",
+            "indexof",
+            "str-replace",
+            "format",
             // Path operations (also in PATH_OPS constant for parser)
             "reext",
             // Phase 0: Type introspection
             "typeof",
             // Phase 1: Record operations
-            "record", "get", "set", "del", "has?", "keys", "values", "merge",
+            "record",
+            "get",
+            "set",
+            "del",
+            "has?",
+            "keys",
+            "values",
+            "merge",
             // Phase 2: Table operations
-            "table", "where", "sort-by", "select", "first", "last", "nth",
+            "table",
+            "where",
+            "sort-by",
+            "select",
+            "first",
+            "last",
+            "nth",
             // Phase 3: Error handling
-            "try", "error?", "throw",
+            "try",
+            "error?",
+            "throw",
             // Phase 4: Serialization bridge
             // into-X = serialize (structured -> text), from-X = parse (text -> structured)
-            "into-json", "into-csv", "into-lines", "into-kv", "into-tsv", "into-delimited",
-            "to-json", "to-csv", "to-lines", "to-kv", "to-tsv", "to-delimited",
-            "from-json", "from-csv", "from-lines", "from-kv", "from-tsv", "from-delimited",
+            "into-json",
+            "into-csv",
+            "into-lines",
+            "into-kv",
+            "into-tsv",
+            "into-delimited",
+            "to-json",
+            "to-csv",
+            "to-lines",
+            "to-kv",
+            "to-tsv",
+            "to-delimited",
+            "from-json",
+            "from-csv",
+            "from-lines",
+            "from-kv",
+            "from-tsv",
+            "from-delimited",
             // Phase 5: Stack utilities
-            "tap", "dip", "dig", "bury", "pick", "roll",
+            "tap",
+            "dip",
+            "dig",
+            "bury",
+            "pick",
+            "roll",
             // Phase 6: Aggregations
-            "sum", "avg", "min", "max", "count", "reduce", "fold", "bend",
+            "sum",
+            "avg",
+            "min",
+            "max",
+            "count",
+            "reduce",
+            "fold",
+            "bend",
             // Statistical functions
-            "product", "median", "mode", "modes", "variance", "sample-variance",
-            "stdev", "sample-stdev", "percentile", "five-num",
+            "product",
+            "median",
+            "mode",
+            "modes",
+            "variance",
+            "sample-variance",
+            "stdev",
+            "sample-stdev",
+            "percentile",
+            "five-num",
             // Phase 8: Extended table/list ops
-            "group-by", "unique", "reverse", "flatten", "reject", "reject-where", "duplicates",
+            "group-by",
+            "unique",
+            "reverse",
+            "flatten",
+            "reject",
+            "reject-where",
+            "duplicates",
             // Extended spread operations
-            "fields", "fields-keys", "spread-head", "spread-tail", "spread-n", "spread-to",
+            "fields",
+            "fields-keys",
+            "spread-head",
+            "spread-tail",
+            "spread-n",
+            "spread-to",
             // Phase 9: Vector operations (for embeddings)
-            "dot-product", "magnitude", "normalize", "cosine-similarity", "euclidean-distance",
+            "dot-product",
+            "magnitude",
+            "normalize",
+            "cosine-similarity",
+            "euclidean-distance",
             // Phase 10: Combinators (fanout, zip, cross, retry, compose)
-            "fanout", "zip", "cross", "retry", "compose",
+            "fanout",
+            "zip",
+            "cross",
+            "retry",
+            "compose",
             // Plugin management
-            ".plugin-load", ".plugin-unload", ".plugin-reload", ".plugins", ".plugin-info",
+            ".plugin-load",
+            ".plugin-unload",
+            ".plugin-reload",
+            ".plugins",
+            ".plugin-info",
             // Structured builtins
-            "ls-table", "open", "save",
+            "ls-table",
+            "open",
+            "save",
             // Media / Image operations
-            "image-load", "image-show", "image-info", "to-base64", "from-base64",
+            "image-load",
+            "image-show",
+            "image-info",
+            "to-base64",
+            "from-base64",
             // Link operations (OSC 8)
-            "link", "link-info",
+            "link",
+            "link-info",
             // Clipboard operations (OSC 52)
-            ".copy", ".cut", ".paste",
+            ".copy",
+            ".cut",
+            ".paste",
             // Encoding operations
-            "to-hex", "from-hex", "as-bytes", "to-bytes", "to-string", "read-bytes",
+            "to-hex",
+            "from-hex",
+            "as-bytes",
+            "to-bytes",
+            "to-string",
+            "read-bytes",
             // Hash functions (SHA-2)
-            "sha256", "sha384", "sha512",
+            "sha256",
+            "sha384",
+            "sha512",
             // Hash functions (SHA-3)
-            "sha3-256", "sha3-384", "sha3-512",
+            "sha3-256",
+            "sha3-384",
+            "sha3-512",
             // File hash functions
-            "sha256-file", "sha3-256-file",
+            "sha256-file",
+            "sha3-256-file",
             // BigInt operations
-            "to-bigint", "big-add", "big-sub", "big-mul", "big-div", "big-mod",
-            "big-xor", "big-and", "big-or", "big-eq?", "big-lt?", "big-gt?",
-            "big-shl", "big-shr", "big-pow",
+            "to-bigint",
+            "big-add",
+            "big-sub",
+            "big-mul",
+            "big-div",
+            "big-mod",
+            "big-xor",
+            "big-and",
+            "big-or",
+            "big-eq?",
+            "big-lt?",
+            "big-gt?",
+            "big-shl",
+            "big-shr",
+            "big-pow",
             // Math primitives (for stats support)
-            "pow", "sqrt", "floor", "ceil", "round", "idiv", "sort-nums", "log-base",
+            "pow",
+            "sqrt",
+            "floor",
+            "ceil",
+            "round",
+            "idiv",
+            "sort-nums",
+            "log-base",
             // Macro-generated builtins
-            "abs", "negate", "max-of", "min-of",
+            "abs",
+            "negate",
+            "max-of",
+            "min-of",
             // Unicode operator aliases
-            "Σ", "Π", "÷", "⋅", "√", "∅", "≠", "≤", "≥", "μ",
+            "Σ",
+            "Π",
+            "÷",
+            "⋅",
+            "√",
+            "∅",
+            "≠",
+            "≤",
+            "≥",
+            "μ",
             // Stack snapshots
-            "snapshot", "snapshot-restore", "snapshot-list", "snapshot-delete", "snapshot-clear",
+            "snapshot",
+            "snapshot-restore",
+            "snapshot-list",
+            "snapshot-delete",
+            "snapshot-clear",
             // Async / concurrent operations
-            "async", "await", "future-status", "future-result", "future-cancel",
-            "delay", "delay-async", "future-map", "future-await-n",
-            "parallel-n", "parallel-map", "race", "await-all", "future-race", "futures-list",
+            "async",
+            "await",
+            "future-status",
+            "future-result",
+            "future-cancel",
+            "delay",
+            "delay-async",
+            "future-map",
+            "future-await-n",
+            "parallel-n",
+            "parallel-map",
+            "race",
+            "await-all",
+            "future-race",
+            "futures-list",
             "retry-delay",
             // HTTP client operations
-            "fetch", "fetch-status", "fetch-headers",
+            "fetch",
+            "fetch-status",
+            "fetch-headers",
             // Watch mode
             "watch",
             // Stack-native shell operations
-            "touch", "mkdir", "mkdir-p", "mktemp", "mktemp-d",
-            "cp", "mv", "rm", "rm-r", "ln", "realpath",
-            "which", "extname", "glob", "ls",
-        ].into_iter().collect()
+            "touch",
+            "mkdir",
+            "mkdir-p",
+            "mktemp",
+            "mktemp-d",
+            "cp",
+            "mv",
+            "rm",
+            "rm-r",
+            "ln",
+            "realpath",
+            "which",
+            "extname",
+            "glob",
+            "ls",
+        ]
+        .into_iter()
+        .collect()
     })
 }
 
@@ -430,10 +685,24 @@ mod tests {
     #[test]
     fn test_executable_paths() {
         let mut resolver = ExecutableResolver::new();
-        // Executable paths are now detected
-        assert!(resolver.is_executable("/bin/ls"));
+
+        // Hermetic (issue #34): create our own executable file instead of
+        // relying on /bin/ls, which does not exist on e.g. NixOS.
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let exe = tmp.path().join("myprog");
+        std::fs::write(&exe, "#!/bin/sh\n").expect("write test executable");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod +x");
+        }
+        assert!(resolver.is_executable(exe.to_str().expect("utf8 path")));
+
         // Non-executable files are not
-        assert!(!resolver.is_executable("src/main.rs")); // Not +x
+        let plain = tmp.path().join("notes.txt");
+        std::fs::write(&plain, "hello").expect("write plain file");
+        assert!(!resolver.is_executable(plain.to_str().expect("utf8 path")));
         assert!(!resolver.is_executable("/nonexistent/path")); // Doesn't exist
     }
 

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -87,8 +87,7 @@ pub fn check_sigchld() -> bool {
 #[cfg(unix)]
 pub fn stop_process(pid: u32) -> Result<(), String> {
     let pid = Pid::from_raw(pid as i32);
-    kill(pid, Signal::SIGSTOP)
-        .map_err(|e| format!("Failed to stop process {}: {}", pid, e))
+    kill(pid, Signal::SIGSTOP).map_err(|e| format!("Failed to stop process {}: {}", pid, e))
 }
 
 #[cfg(not(unix))]
@@ -100,8 +99,7 @@ pub fn stop_process(_pid: u32) -> Result<(), String> {
 #[cfg(unix)]
 pub fn continue_process(pid: u32) -> Result<(), String> {
     let pid = Pid::from_raw(pid as i32);
-    kill(pid, Signal::SIGCONT)
-        .map_err(|e| format!("Failed to continue process {}: {}", pid, e))
+    kill(pid, Signal::SIGCONT).map_err(|e| format!("Failed to continue process {}: {}", pid, e))
 }
 
 #[cfg(not(unix))]
@@ -113,8 +111,7 @@ pub fn continue_process(_pid: u32) -> Result<(), String> {
 #[cfg(unix)]
 pub fn terminate_process(pid: u32) -> Result<(), String> {
     let pid = Pid::from_raw(pid as i32);
-    kill(pid, Signal::SIGTERM)
-        .map_err(|e| format!("Failed to terminate process {}: {}", pid, e))
+    kill(pid, Signal::SIGTERM).map_err(|e| format!("Failed to terminate process {}: {}", pid, e))
 }
 
 #[cfg(not(unix))]

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,9 +1,15 @@
 //! Signal handling for hsab shell
 //!
-//! Provides signal handling infrastructure for job control:
-//! - SIGTSTP (Ctrl+Z): Suspend foreground job
-//! - SIGCONT: Resume suspended job
-//! - SIGCHLD: Reap child processes
+//! Signals actually registered (see `setup_signal_handlers`):
+//! - SIGTSTP (Ctrl+Z): handler sets `SIGTSTP_RECEIVED`; the shell suspends
+//!   the foreground job from normal code paths
+//! - SIGCHLD: handler sets `SIGCHLD_RECEIVED`; the REPL loop and the
+//!   `.jobs`/`wait` builtins then reap finished background jobs with a
+//!   non-blocking wait (issue #30)
+//!
+//! SIGCONT is *sent* (by `.fg`/`.bg` via `continue_process`), not handled.
+//! Handlers are async-signal-safe: they only flip an atomic flag; all
+//! reaping happens in normal code.
 
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
@@ -18,6 +24,10 @@ pub static FOREGROUND_PID: AtomicI32 = AtomicI32::new(-1);
 /// Flag indicating SIGTSTP was received (set by signal handler)
 pub static SIGTSTP_RECEIVED: AtomicBool = AtomicBool::new(false);
 
+/// Flag indicating SIGCHLD was received (set by signal handler); the REPL
+/// loop checks this to reap finished background jobs (issue #30)
+pub static SIGCHLD_RECEIVED: AtomicBool = AtomicBool::new(false);
+
 /// Set up signal handlers for the shell
 #[cfg(unix)]
 pub fn setup_signal_handlers() {
@@ -27,6 +37,14 @@ pub fn setup_signal_handlers() {
     unsafe {
         let _ = low_level::register(signal_hook::consts::SIGTSTP, || {
             SIGTSTP_RECEIVED.store(true, Ordering::SeqCst);
+        });
+    }
+
+    // Register SIGCHLD handler that sets the flag; reaping happens in the
+    // REPL loop / job builtins, never inside the handler (issue #30)
+    unsafe {
+        let _ = low_level::register(signal_hook::consts::SIGCHLD, || {
+            SIGCHLD_RECEIVED.store(true, Ordering::SeqCst);
         });
     }
 }
@@ -58,6 +76,11 @@ pub fn get_foreground_pid() -> Option<i32> {
 /// Check if SIGTSTP was received and clear the flag
 pub fn check_sigtstp() -> bool {
     SIGTSTP_RECEIVED.swap(false, Ordering::SeqCst)
+}
+
+/// Check if SIGCHLD was received and clear the flag
+pub fn check_sigchld() -> bool {
+    SIGCHLD_RECEIVED.swap(false, Ordering::SeqCst)
 }
 
 /// Send SIGSTOP to a process

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,7 +1,11 @@
 use hsab::{display, lex, parse, Evaluator, Value};
 
 /// Execute a single line of hsab code
-pub(crate) fn execute_line(eval: &mut Evaluator, input: &str, print_output: bool) -> Result<i32, String> {
+pub(crate) fn execute_line(
+    eval: &mut Evaluator,
+    input: &str,
+    print_output: bool,
+) -> Result<i32, String> {
     execute_line_with_options(eval, input, print_output, true)
 }
 
@@ -48,7 +52,13 @@ pub(crate) fn execute_line_with_options(
 pub(crate) fn is_structured(val: &Value) -> bool {
     matches!(
         val,
-        Value::Table { .. } | Value::Map(_) | Value::Error { .. } | Value::Media { .. } | Value::Link { .. } | Value::Bytes(_) | Value::BigInt(_)
+        Value::Table { .. }
+            | Value::Map(_)
+            | Value::Error { .. }
+            | Value::Media { .. }
+            | Value::Link { .. }
+            | Value::Bytes(_)
+            | Value::BigInt(_)
     )
 }
 
@@ -68,7 +78,7 @@ pub(crate) fn is_triple_quotes_balanced(input: &str) -> bool {
 
     while i < chars.len() {
         if i + 2 < chars.len() {
-            let triple: String = chars[i..i+3].iter().collect();
+            let triple: String = chars[i..i + 3].iter().collect();
             if triple == "\"\"\"" && !in_triple_single {
                 in_triple_double = !in_triple_double;
                 i += 3;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,15 @@
+//! Small shared utilities.
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// Lock a mutex, recovering the data if the mutex was poisoned (issue #31).
+///
+/// A panic while a lock is held poisons the mutex, and every subsequent
+/// `.lock().unwrap()` then panics too — for a long-lived REPL that turns one
+/// bug in a key handler or future thread into a full shell crash. The state
+/// guarded by these mutexes (REPL mirror stack, future results) carries no
+/// cross-field invariants, so recovering the possibly partially-updated data
+/// is strictly better than dying.
+pub fn lock_or_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,6 +3,7 @@
 pub use hsab::{lex, parse, Evaluator};
 
 /// Helper to evaluate hsab input and return output
+#[allow(dead_code)] // not every test target uses every helper
 pub fn eval(input: &str) -> Result<String, String> {
     let tokens = lex(input).map_err(|e| e.to_string())?;
     if tokens.is_empty() {
@@ -17,12 +18,14 @@ pub fn eval(input: &str) -> Result<String, String> {
 /// Helper to evaluate and get exit code
 #[allow(dead_code)]
 pub fn eval_exit_code(input: &str) -> i32 {
-    let tokens = lex(input).unwrap();
+    let tokens = lex(input).unwrap_or_else(|e| panic!("lex failed for {:?}: {}", input, e));
     if tokens.is_empty() {
         return 0;
     }
-    let program = parse(tokens).unwrap();
+    let program = parse(tokens).unwrap_or_else(|e| panic!("parse failed for {:?}: {}", input, e));
     let mut evaluator = Evaluator::new();
-    let result = evaluator.eval(&program).unwrap();
+    let result = evaluator
+        .eval(&program)
+        .unwrap_or_else(|e| panic!("eval failed for {:?}: {}", input, e));
     result.exit_code
 }

--- a/tests/test_apply_peek.rs
+++ b/tests/test_apply_peek.rs
@@ -36,5 +36,8 @@ fn test_peek_all() {
 fn test_at_is_now_a_literal() {
     // @ is no longer a special operator, it's just a word character
     let result = eval("#[\"hello\" echo] @");
-    assert!(result.is_ok(), "@ should be treated as a literal word, not an error");
+    assert!(
+        result.is_ok(),
+        "@ should be treated as a literal word, not an error"
+    );
 }

--- a/tests/test_arithmetic.rs
+++ b/tests/test_arithmetic.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_plus() {
@@ -80,7 +80,7 @@ fn test_sqrt_perfect_square() {
 fn test_sqrt_non_perfect() {
     let output = eval(r#"2 sqrt"#).unwrap();
     let val: f64 = output.trim().parse().unwrap();
-    assert!((val - 1.4142135).abs() < 0.0001);
+    assert!((val - std::f64::consts::SQRT_2).abs() < 0.0001);
 }
 
 #[test]
@@ -174,4 +174,3 @@ fn test_unicode_ge() {
     let exit_code = eval_exit_code("10 5 ≥");
     assert_eq!(exit_code, 0);
 }
-

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 // === delay tests ===
 
@@ -423,8 +423,12 @@ fn test_poisoned_future_value_still_serializable() {
 fn test_futures_list_counts_spawned_futures() {
     let output = eval("#[1 delay] async #[1 delay] async futures-list count").unwrap();
     // The two Future values remain on the stack above the count
-    assert_eq!(output.trim().lines().last(), Some("2"),
-               "futures-list should enumerate both futures: {}", output);
+    assert_eq!(
+        output.trim().lines().last(),
+        Some("2"),
+        "futures-list should enumerate both futures: {}",
+        output
+    );
 }
 
 #[test]
@@ -437,21 +441,34 @@ fn test_futures_list_empty_initially() {
 fn test_futures_list_status_transitions_after_await() {
     // Spawn, await, then list: status must be terminal (completed), not pending
     let output = eval("#[1 delay] async await futures-list").unwrap();
-    assert!(output.contains("completed"),
-            "awaited future should be listed as completed: {}", output);
-    assert!(!output.contains("pending"),
-            "no future should still be pending after await: {}", output);
+    assert!(
+        output.contains("completed"),
+        "awaited future should be listed as completed: {}",
+        output
+    );
+    assert!(
+        !output.contains("pending"),
+        "no future should still be pending after await: {}",
+        output
+    );
 }
 
 #[test]
 fn test_futures_list_shows_cancelled() {
     let output = eval("#[500 delay] async dup future-cancel drop futures-list").unwrap();
-    assert!(output.contains("cancelled"),
-            "cancelled future should be listed as cancelled: {}", output);
+    assert!(
+        output.contains("cancelled"),
+        "cancelled future should be listed as cancelled: {}",
+        output
+    );
 }
 
 #[test]
 fn test_futures_list_contains_ids() {
     let output = eval("#[1 delay] async await futures-list").unwrap();
-    assert!(output.contains("id"), "records should carry an id field: {}", output);
+    assert!(
+        output.contains("id"),
+        "records should carry an id field: {}",
+        output
+    );
 }

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -361,3 +361,56 @@ fn test_parallel_map_with_json_list() {
     let output = eval(r#"'[1,2,3]' from-json #[2 mul] 2 parallel-map to-json"#).unwrap();
     assert_eq!(output.trim(), "[2.0,4.0,6.0]");
 }
+
+// ============================================
+// Issue #31: mutex-poison hardening
+// ============================================
+
+#[test]
+fn test_poisoned_future_mutex_recovers() {
+    use hsab::FutureState;
+    use std::sync::{Arc, Mutex};
+
+    let state = Arc::new(Mutex::new(FutureState::Pending));
+
+    // Poison the mutex: panic in another thread while holding the lock.
+    let poisoner = Arc::clone(&state);
+    let result = std::thread::spawn(move || {
+        let _guard = poisoner.lock().unwrap();
+        panic!("deliberately poison the future mutex");
+    })
+    .join();
+    assert!(result.is_err(), "poisoning thread should have panicked");
+    assert!(state.lock().is_err(), "mutex should now be poisoned");
+
+    // The recovery helper must still hand back the data instead of panicking.
+    let guard = hsab::util::lock_or_recover(&state);
+    assert!(matches!(&*guard, FutureState::Pending));
+}
+
+#[test]
+fn test_poisoned_future_value_still_serializable() {
+    use hsab::ast::value_to_json;
+    use hsab::{FutureState, Value};
+    use std::sync::{Arc, Mutex};
+
+    let state = Arc::new(Mutex::new(FutureState::Completed(Box::new(Value::Number(
+        42.0,
+    )))));
+
+    // Poison it.
+    let poisoner = Arc::clone(&state);
+    let _ = std::thread::spawn(move || {
+        let _guard = poisoner.lock().unwrap();
+        panic!("poison");
+    })
+    .join();
+
+    // The REPL-side readers (value_to_json / display) must not panic.
+    let future = Value::Future {
+        id: "f1".into(),
+        state,
+    };
+    let json = value_to_json(&future);
+    assert_eq!(json["status"], "completed");
+}

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -414,3 +414,44 @@ fn test_poisoned_future_value_still_serializable() {
     let json = value_to_json(&future);
     assert_eq!(json["status"], "completed");
 }
+
+// ============================================
+// Issue #29: futures registry / futures-list
+// ============================================
+
+#[test]
+fn test_futures_list_counts_spawned_futures() {
+    let output = eval("#[1 delay] async #[1 delay] async futures-list count").unwrap();
+    // The two Future values remain on the stack above the count
+    assert_eq!(output.trim().lines().last(), Some("2"),
+               "futures-list should enumerate both futures: {}", output);
+}
+
+#[test]
+fn test_futures_list_empty_initially() {
+    let output = eval("futures-list count").unwrap();
+    assert_eq!(output.trim(), "0", "no futures spawned yet");
+}
+
+#[test]
+fn test_futures_list_status_transitions_after_await() {
+    // Spawn, await, then list: status must be terminal (completed), not pending
+    let output = eval("#[1 delay] async await futures-list").unwrap();
+    assert!(output.contains("completed"),
+            "awaited future should be listed as completed: {}", output);
+    assert!(!output.contains("pending"),
+            "no future should still be pending after await: {}", output);
+}
+
+#[test]
+fn test_futures_list_shows_cancelled() {
+    let output = eval("#[500 delay] async dup future-cancel drop futures-list").unwrap();
+    assert!(output.contains("cancelled"),
+            "cancelled future should be listed as cancelled: {}", output);
+}
+
+#[test]
+fn test_futures_list_contains_ids() {
+    let output = eval("#[1 delay] async await futures-list").unwrap();
+    assert!(output.contains("id"), "records should carry an id field: {}", output);
+}

--- a/tests/test_bigint.rs
+++ b/tests/test_bigint.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_bytes_to_bigint() {
@@ -16,14 +16,20 @@ fn test_bytes_to_bigint() {
 fn test_bigint_to_hex() {
     // BigInt should convert back to same hex as original hash
     let output = eval(r#""hello" sha256 to-bigint to-hex"#).unwrap();
-    assert_eq!(output.trim(), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    assert_eq!(
+        output.trim(),
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
 }
 
 #[test]
 fn test_bigint_to_bytes() {
     // BigInt should convert back to Bytes
     let output = eval(r#""hello" sha256 to-bigint to-bytes to-hex"#).unwrap();
-    assert_eq!(output.trim(), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    assert_eq!(
+        output.trim(),
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
 }
 
 #[test]
@@ -60,7 +66,8 @@ fn test_bigint_sub() {
 
 #[test]
 fn test_bigint_mul() {
-    let output = eval(r#""12345678901234567890" to-bigint "2" to-bigint big-mul to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "2" to-bigint big-mul to-string"#).unwrap();
     assert_eq!(output.trim(), "24691357802469135780");
 }
 
@@ -79,7 +86,8 @@ fn test_bigint_mod() {
 #[test]
 fn test_bigint_xor() {
     // XOR two hashes
-    let output = eval(r#""hello" sha256 to-bigint "world" sha256 to-bigint big-xor to-hex"#).unwrap();
+    let output =
+        eval(r#""hello" sha256 to-bigint "world" sha256 to-bigint big-xor to-hex"#).unwrap();
     // Result should be different from both inputs
     assert!(!output.contains("2cf24dba"));
     assert_eq!(output.trim().len(), 64); // Still 256 bits
@@ -141,7 +149,6 @@ fn test_bigint_pow() {
     assert_eq!(output.trim(), "1024");
 }
 
-
 // === Recovered tests ===
 
 #[test]
@@ -165,14 +172,16 @@ fn test_bigint_one() {
 #[test]
 fn test_bigint_add_zero() {
     // Adding zero should return the same number
-    let output = eval(r#""12345678901234567890" to-bigint "0" to-bigint big-add to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "0" to-bigint big-add to-string"#).unwrap();
     assert_eq!(output.trim(), "12345678901234567890");
 }
 
 #[test]
 fn test_bigint_sub_zero() {
     // Subtracting zero should return the same number
-    let output = eval(r#""12345678901234567890" to-bigint "0" to-bigint big-sub to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "0" to-bigint big-sub to-string"#).unwrap();
     assert_eq!(output.trim(), "12345678901234567890");
 }
 
@@ -186,35 +195,42 @@ fn test_bigint_sub_equal() {
 #[test]
 fn test_bigint_mul_zero() {
     // Multiplying by zero should return zero
-    let output = eval(r#""12345678901234567890" to-bigint "0" to-bigint big-mul to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "0" to-bigint big-mul to-string"#).unwrap();
     assert_eq!(output.trim(), "0");
 }
 
 #[test]
 fn test_bigint_mul_one() {
     // Multiplying by one should return the same number
-    let output = eval(r#""12345678901234567890" to-bigint "1" to-bigint big-mul to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "1" to-bigint big-mul to-string"#).unwrap();
     assert_eq!(output.trim(), "12345678901234567890");
 }
 
 #[test]
 fn test_bigint_div_one() {
     // Dividing by one should return the same number
-    let output = eval(r#""12345678901234567890" to-bigint "1" to-bigint big-div to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "1" to-bigint big-div to-string"#).unwrap();
     assert_eq!(output.trim(), "12345678901234567890");
 }
 
 #[test]
 fn test_bigint_div_self() {
     // Dividing a number by itself should return one
-    let output = eval(r#""12345678901234567890" to-bigint "12345678901234567890" to-bigint big-div to-string"#).unwrap();
+    let output = eval(
+        r#""12345678901234567890" to-bigint "12345678901234567890" to-bigint big-div to-string"#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "1");
 }
 
 #[test]
 fn test_bigint_mod_one() {
     // Any number mod 1 should be zero
-    let output = eval(r#""12345678901234567890" to-bigint "1" to-bigint big-mod to-string"#).unwrap();
+    let output =
+        eval(r#""12345678901234567890" to-bigint "1" to-bigint big-mod to-string"#).unwrap();
     assert_eq!(output.trim(), "0");
 }
 
@@ -236,27 +252,39 @@ fn test_bigint_zero_mod_number() {
 fn test_bigint_very_large_number() {
     // 2^256 - 1 (max 256-bit unsigned int, common in crypto)
     let output = eval(r#""115792089237316195423570985008687907853269984665640564039457584007913129639935" to-bigint to-string"#).unwrap();
-    assert_eq!(output.trim(), "115792089237316195423570985008687907853269984665640564039457584007913129639935");
+    assert_eq!(
+        output.trim(),
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    );
 }
 
 #[test]
 fn test_bigint_large_add() {
     // Add two very large numbers
-    let output = eval(r#""99999999999999999999999999999999999999" to-bigint "1" to-bigint big-add to-string"#).unwrap();
+    let output = eval(
+        r#""99999999999999999999999999999999999999" to-bigint "1" to-bigint big-add to-string"#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "100000000000000000000000000000000000000");
 }
 
 #[test]
 fn test_bigint_large_sub() {
     // Subtract from a very large number
-    let output = eval(r#""100000000000000000000000000000000000000" to-bigint "1" to-bigint big-sub to-string"#).unwrap();
+    let output = eval(
+        r#""100000000000000000000000000000000000000" to-bigint "1" to-bigint big-sub to-string"#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "99999999999999999999999999999999999999");
 }
 
 #[test]
 fn test_bigint_large_mul() {
     // Multiply two large numbers
-    let output = eval(r#""99999999999999999999" to-bigint "99999999999999999999" to-bigint big-mul to-string"#).unwrap();
+    let output = eval(
+        r#""99999999999999999999" to-bigint "99999999999999999999" to-bigint big-mul to-string"#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "9999999999999999999800000000000000000001");
 }
 
@@ -325,7 +353,9 @@ fn test_bigint_gt_false() {
 #[test]
 fn test_bigint_compare_large_numbers() {
     // Compare two very large numbers
-    let exit_code = eval_exit_code(r#""99999999999999999999999999999999999998" to-bigint "99999999999999999999999999999999999999" to-bigint big-lt?"#);
+    let exit_code = eval_exit_code(
+        r#""99999999999999999999999999999999999998" to-bigint "99999999999999999999999999999999999999" to-bigint big-lt?"#,
+    );
     assert_eq!(exit_code, 0);
 }
 
@@ -374,14 +404,18 @@ fn test_bigint_or_self() {
 #[test]
 fn test_bigint_bitwise_large() {
     // Bitwise operations on large numbers
-    let output = eval(r#""0xffffffffffffffff" to-bigint "0xf0f0f0f0f0f0f0f0" to-bigint big-and to-hex"#).unwrap();
+    let output =
+        eval(r#""0xffffffffffffffff" to-bigint "0xf0f0f0f0f0f0f0f0" to-bigint big-and to-hex"#)
+            .unwrap();
     assert_eq!(output.trim(), "f0f0f0f0f0f0f0f0");
 }
 
 #[test]
 fn test_bigint_xor_large() {
     // XOR on large numbers
-    let output = eval(r#""0xffffffffffffffff" to-bigint "0xf0f0f0f0f0f0f0f0" to-bigint big-xor to-hex"#).unwrap();
+    let output =
+        eval(r#""0xffffffffffffffff" to-bigint "0xf0f0f0f0f0f0f0f0" to-bigint big-xor to-hex"#)
+            .unwrap();
     assert_eq!(output.trim(), "f0f0f0f0f0f0f0f");
 }
 
@@ -404,7 +438,10 @@ fn test_bigint_shl_large() {
     // Shift left by large amount
     let output = eval(r#""1" to-bigint 256 big-shl to-string"#).unwrap();
     // 2^256
-    assert_eq!(output.trim(), "115792089237316195423570985008687907853269984665640564039457584007913129639936");
+    assert_eq!(
+        output.trim(),
+        "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+    );
 }
 
 #[test]
@@ -504,7 +541,10 @@ fn test_bigint_hex_leading_zeros() {
 fn test_bigint_hex_large() {
     // 64-character hex (256-bit number)
     let output = eval(r#""0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" to-bigint to-string"#).unwrap();
-    assert_eq!(output.trim(), "115792089237316195423570985008687907853269984665640564039457584007913129639935");
+    assert_eq!(
+        output.trim(),
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    );
 }
 
 #[test]
@@ -531,14 +571,17 @@ fn test_bigint_idempotent() {
 #[test]
 fn test_bigint_chained_add() {
     // (100 + 200) + 300 = 600
-    let output = eval(r#""100" to-bigint "200" to-bigint big-add "300" to-bigint big-add to-string"#).unwrap();
+    let output =
+        eval(r#""100" to-bigint "200" to-bigint big-add "300" to-bigint big-add to-string"#)
+            .unwrap();
     assert_eq!(output.trim(), "600");
 }
 
 #[test]
 fn test_bigint_chained_mul() {
     // (2 * 3) * 4 = 24
-    let output = eval(r#""2" to-bigint "3" to-bigint big-mul "4" to-bigint big-mul to-string"#).unwrap();
+    let output =
+        eval(r#""2" to-bigint "3" to-bigint big-mul "4" to-bigint big-mul to-string"#).unwrap();
     assert_eq!(output.trim(), "24");
 }
 
@@ -609,8 +652,15 @@ fn test_bigint_invalid_hex_error() {
 fn test_bigint_256bit_arithmetic() {
     // Testing operations at 256-bit scale (common in blockchain/crypto)
     let max_256 = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
-    let output = eval(&format!(r#""{}" to-bigint "1" to-bigint big-sub to-string"#, max_256)).unwrap();
-    assert_eq!(output.trim(), "115792089237316195423570985008687907853269984665640564039457584007913129639934");
+    let output = eval(&format!(
+        r#""{}" to-bigint "1" to-bigint big-sub to-string"#,
+        max_256
+    ))
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "115792089237316195423570985008687907853269984665640564039457584007913129639934"
+    );
 }
 
 #[test]
@@ -624,7 +674,8 @@ fn test_bigint_hash_xor_identity() {
 fn test_bigint_modular_arithmetic() {
     // Simple modular exponentiation concept: (a * b) mod n
     // (7 * 11) mod 13 = 77 mod 13 = 12
-    let output = eval(r#""7" to-bigint "11" to-bigint big-mul "13" to-bigint big-mod to-string"#).unwrap();
+    let output =
+        eval(r#""7" to-bigint "11" to-bigint big-mul "13" to-bigint big-mod to-string"#).unwrap();
     assert_eq!(output.trim(), "12");
 }
 
@@ -655,4 +706,3 @@ fn test_bigint_mod_smaller_than_divisor() {
     let output = eval(r#""5" to-bigint "10" to-bigint big-mod to-string"#).unwrap();
     assert_eq!(output.trim(), "5");
 }
-

--- a/tests/test_block_syntax.rs
+++ b/tests/test_block_syntax.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 // === #[...] block syntax (required by task) ===
 
@@ -29,7 +29,11 @@ fn test_hash_block_times() {
 #[test]
 fn test_hash_block_if() {
     let output = eval(r#"#["no" echo] #["yes" echo] true if"#).unwrap();
-    assert!(output.contains("yes"), "if with true condition should run then-branch: {}", output);
+    assert!(
+        output.contains("yes"),
+        "if with true condition should run then-branch: {}",
+        output
+    );
 }
 
 #[test]

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1,0 +1,204 @@
+//! CLI integration tests (issue #34): drive the hsab binary with assert_cmd.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn hsab() -> Command {
+    // cargo_bin is deprecated in favor of a macro that requires newer
+    // assert_cmd; it works fine for the standard target dir used in CI.
+    #[allow(deprecated)]
+    Command::cargo_bin("hsab").expect("hsab binary should build")
+}
+
+// === hsab -c '<program>' ===
+
+#[test]
+fn test_dash_c_arithmetic() {
+    hsab()
+        .args(["-c", "5 3 plus"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("8"));
+}
+
+#[test]
+fn test_dash_c_echo() {
+    hsab()
+        .args(["-c", "hello echo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"));
+}
+
+#[test]
+fn test_dash_c_error_exit_code() {
+    // A type error must produce a failure exit code and an error message
+    hsab()
+        .args(["-c", "\"not-a-record\" \"key\" get"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error"));
+}
+
+// === --version / --help ===
+
+#[test]
+fn test_version_flag() {
+    hsab()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hsab-"));
+}
+
+#[test]
+fn test_help_flag() {
+    hsab()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("USAGE"))
+        .stdout(predicate::str::contains("hsab -c <command>"));
+}
+
+// === script files ===
+
+#[test]
+fn test_script_file_basic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("test.hsab");
+    std::fs::write(&script, "hello echo\n").expect("write script");
+
+    hsab()
+        .arg(script.to_str().expect("utf8 path"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"));
+}
+
+#[test]
+fn test_script_skips_comments_but_runs_blocks() {
+    // `#` starts a comment line, but `#[` is block syntax and must execute
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("test.hsab");
+    std::fs::write(
+        &script,
+        "# this is a comment\nhello echo\n#[world echo] apply\n",
+    )
+    .expect("write script");
+
+    hsab()
+        .arg(script.to_str().expect("utf8 path"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"))
+        .stdout(predicate::str::contains("world"))
+        .stdout(predicate::str::contains("comment").not());
+}
+
+#[test]
+fn test_script_is_line_oriented_multiline_blocks_error() {
+    // Scripts execute line by line: a block spanning lines is a lex error
+    // reported with the line number, not silently skipped.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("test.hsab");
+    std::fs::write(&script, "#[\nmultiline echo\n] apply\n").expect("write script");
+
+    hsab()
+        .arg(script.to_str().expect("utf8 path"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("line 1"));
+}
+
+#[test]
+fn test_script_missing_file() {
+    hsab()
+        .arg("/nonexistent/script.hsab")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error reading"));
+}
+
+#[test]
+fn test_script_stops_on_failing_line() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("test.hsab");
+    // Line 2 raises a type error; line 3 must not run
+    std::fs::write(&script, "one echo\n\"x\" \"k\" get\nnever echo\n").expect("write script");
+
+    hsab()
+        .arg(script.to_str().expect("utf8 path"))
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("one"))
+        .stdout(predicate::str::contains("never").not())
+        .stderr(predicate::str::contains("line 2"));
+}
+
+// === hsab init ===
+
+#[test]
+fn test_init_installs_stdlib_into_home() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    hsab()
+        .env("HOME", home.path())
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Installed stdlib"));
+
+    let stdlib = home.path().join(".hsab/lib/stdlib.hsabrc");
+    assert!(stdlib.is_file(), "init should write {}", stdlib.display());
+    let content = std::fs::read_to_string(&stdlib).expect("read stdlib");
+    assert!(!content.is_empty(), "stdlib should not be empty");
+}
+
+#[test]
+fn test_init_refuses_to_overwrite() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let lib_dir = home.path().join(".hsab/lib");
+    std::fs::create_dir_all(&lib_dir).expect("mkdir");
+    let stdlib = lib_dir.join("stdlib.hsabrc");
+    std::fs::write(&stdlib, "# my customized stdlib\n").expect("write");
+
+    hsab()
+        .env("HOME", home.path())
+        .arg("init")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already installed"));
+
+    let content = std::fs::read_to_string(&stdlib).expect("read stdlib");
+    assert_eq!(
+        content, "# my customized stdlib\n",
+        "init must not overwrite an existing stdlib"
+    );
+}
+
+// === REPL smoke tests (piped stdin) ===
+
+#[test]
+fn test_repl_smoke_echo_and_exit() {
+    hsab()
+        .write_stdin("hello echo\n.exit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"));
+}
+
+#[test]
+fn test_repl_smoke_stack_and_clear() {
+    hsab()
+        .write_stdin("5 3 plus peek\n.clear\n.exit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("8"));
+}
+
+#[test]
+fn test_repl_smoke_eof_exits_cleanly() {
+    // Ctrl-D / EOF on stdin should exit without error
+    hsab().write_stdin("hello echo\n").assert().success();
+}

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_fanout_basic() {
@@ -11,7 +11,11 @@ fn test_fanout_basic() {
     let output = eval(r#""hello" #[len] #["!" suffix] fanout"#).unwrap();
     // Stack should have: 5, "hello!"
     assert!(output.contains("5"), "Should have length: {}", output);
-    assert!(output.contains("hello!"), "Should have suffixed: {}", output);
+    assert!(
+        output.contains("hello!"),
+        "Should have suffixed: {}",
+        output
+    );
 }
 
 #[test]
@@ -183,7 +187,6 @@ fn test_compose_empty_blocks() {
     assert!(result.is_ok() || result.is_err());
 }
 
-
 // === Recovered tests ===
 
 #[test]
@@ -217,8 +220,8 @@ fn test_fanout_preserves_stack_order() {
     let output = eval(r#"5 #[1 plus] #[2 plus] fanout"#).unwrap();
     let lines: Vec<&str> = output.lines().collect();
     assert_eq!(lines.len(), 2);
-    assert_eq!(lines[0].trim(), "6");  // First block result
-    assert_eq!(lines[1].trim(), "7");  // Second block result
+    assert_eq!(lines[0].trim(), "6"); // First block result
+    assert_eq!(lines[1].trim(), "7"); // Second block result
 }
 
 #[test]
@@ -286,7 +289,10 @@ fn test_zip_type_error_first_not_list() {
 #[test]
 fn test_zip_type_error_second_not_list() {
     let result = eval(r#"'[1,2]' json "notalist" zip"#);
-    assert!(result.is_err(), "Should error when second arg is not a list");
+    assert!(
+        result.is_err(),
+        "Should error when second arg is not a list"
+    );
 }
 
 #[test]
@@ -374,7 +380,10 @@ fn test_cross_type_error_first_not_list() {
 #[test]
 fn test_cross_type_error_second_not_list() {
     let result = eval(r#"'[1,2]' json "notalist" cross"#);
-    assert!(result.is_err(), "Should error when second arg is not a list");
+    assert!(
+        result.is_err(),
+        "Should error when second arg is not a list"
+    );
 }
 
 #[test]
@@ -397,14 +406,19 @@ fn test_retry_success_second_attempt() {
     // We can simulate this with a simple block that always succeeds
     let output = eval(r#"2 #[true] retry"#).unwrap();
     // Should succeed (no error)
-    assert!(output.is_empty() || output.len() >= 0);
+    // Smoke assertion: reaching here without panicking is the test.
+    let _ = output;
 }
 
 #[test]
 fn test_retry_with_string_count() {
     // retry count can be a string that parses to number
     let output = eval(r#""3" #["ok" echo] retry"#).unwrap();
-    assert!(output.contains("ok"), "Should succeed with string count: {}", output);
+    assert!(
+        output.contains("ok"),
+        "Should succeed with string count: {}",
+        output
+    );
 }
 
 #[test]
@@ -426,7 +440,11 @@ fn test_retry_non_numeric_string() {
 fn test_retry_one_attempt() {
     // Single attempt that succeeds
     let output = eval(r#"1 #["single" echo] retry"#).unwrap();
-    assert!(output.contains("single"), "Should succeed on single attempt: {}", output);
+    assert!(
+        output.contains("single"),
+        "Should succeed on single attempt: {}",
+        output
+    );
 }
 
 #[test]
@@ -447,7 +465,10 @@ fn test_retry_many_attempts_all_fail() {
 fn test_retry_type_error_not_block() {
     // Second argument must be a block
     let result = eval(r#"3 "notablock" retry"#);
-    assert!(result.is_err(), "Should error when second arg is not a block");
+    assert!(
+        result.is_err(),
+        "Should error when second arg is not a block"
+    );
 }
 
 #[test]
@@ -473,7 +494,11 @@ fn test_retry_block_produces_output() {
 fn test_retry_preserves_stack() {
     // After retry succeeds, result should be on stack
     let output = eval(r#"2 #[100] retry"#).unwrap();
-    assert!(output.contains("100"), "Should have 100 on stack: {}", output);
+    assert!(
+        output.contains("100"),
+        "Should have 100 on stack: {}",
+        output
+    );
 }
 
 #[test]
@@ -481,7 +506,8 @@ fn test_retry_large_count() {
     // Large retry count with immediate success
     let output = eval(r#"100 #[true] retry"#).unwrap();
     // Should succeed immediately without waiting
-    assert!(output.is_empty() || output.len() >= 0);
+    // Smoke assertion: reaching here without panicking is the test.
+    let _ = output;
 }
 
 #[test]
@@ -512,7 +538,8 @@ fn test_compose_nested_blocks() {
 #[test]
 fn test_compose_five_blocks() {
     // Compose many blocks
-    let output = eval(r#"1 #[1 plus] #[2 plus] #[3 plus] #[4 plus] #[5 plus] compose apply"#).unwrap();
+    let output =
+        eval(r#"1 #[1 plus] #[2 plus] #[3 plus] #[4 plus] #[5 plus] compose apply"#).unwrap();
     // 1+1+2+3+4+5 = 16
     assert_eq!(output.trim(), "16");
 }
@@ -534,14 +561,14 @@ fn test_compose_stack_underflow() {
 fn test_compose_preserves_block() {
     // Composed result is a block that can be stored
     let output = eval(r#"#[len] #[2 mul] compose :my-func "test" my-func"#).unwrap();
-    assert_eq!(output.trim(), "8");  // len("test") * 2 = 8
+    assert_eq!(output.trim(), "8"); // len("test") * 2 = 8
 }
 
 #[test]
 fn test_compose_block_can_be_reused() {
     // Store composed block and use multiple times
     let output = eval(r#"#[1 plus] #[2 mul] compose :f 5 f 10 f"#).unwrap();
-    let lines: Vec<&str> = output.lines().collect();
+    let _lines: Vec<&str> = output.lines().collect();
     // f(5) = (5+1)*2 = 12, f(10) = (10+1)*2 = 22
     assert!(output.contains("12"), "Should have 12: {}", output);
     assert!(output.contains("22"), "Should have 22: {}", output);
@@ -598,7 +625,11 @@ fn test_cross_with_nil_in_list() {
 fn test_fanout_error_message_no_blocks() {
     let result = eval(r#""value" fanout"#);
     match result {
-        Err(e) => assert!(e.contains("fanout") || e.contains("block"), "Error should mention fanout: {}", e),
+        Err(e) => assert!(
+            e.contains("fanout") || e.contains("block"),
+            "Error should mention fanout: {}",
+            e
+        ),
         Ok(_) => panic!("Should have failed"),
     }
 }
@@ -607,7 +638,11 @@ fn test_fanout_error_message_no_blocks() {
 fn test_zip_error_message_type() {
     let result = eval(r#""notalist" '[1]' json zip"#);
     match result {
-        Err(e) => assert!(e.contains("List") || e.contains("list") || e.contains("type"), "Error should mention type: {}", e),
+        Err(e) => assert!(
+            e.contains("List") || e.contains("list") || e.contains("type"),
+            "Error should mention type: {}",
+            e
+        ),
         Ok(_) => panic!("Should have failed"),
     }
 }
@@ -616,7 +651,11 @@ fn test_zip_error_message_type() {
 fn test_cross_error_message_type() {
     let result = eval(r#"'[1]' json "notalist" cross"#);
     match result {
-        Err(e) => assert!(e.contains("List") || e.contains("list") || e.contains("type"), "Error should mention type: {}", e),
+        Err(e) => assert!(
+            e.contains("List") || e.contains("list") || e.contains("type"),
+            "Error should mention type: {}",
+            e
+        ),
         Ok(_) => panic!("Should have failed"),
     }
 }
@@ -625,7 +664,11 @@ fn test_cross_error_message_type() {
 fn test_retry_error_message_zero() {
     let result = eval(r#"0 #[true] retry"#);
     match result {
-        Err(e) => assert!(e.contains("retry") || e.contains("0") || e.contains("count"), "Error should mention retry: {}", e),
+        Err(e) => assert!(
+            e.contains("retry") || e.contains("0") || e.contains("count"),
+            "Error should mention retry: {}",
+            e
+        ),
         Ok(_) => panic!("Should have failed"),
     }
 }
@@ -634,7 +677,14 @@ fn test_retry_error_message_zero() {
 fn test_compose_error_message_type() {
     let result = eval(r#"42 compose"#);
     match result {
-        Err(e) => assert!(e.contains("Block") || e.contains("block") || e.contains("type") || e.contains("compose"), "Error should mention type: {}", e),
+        Err(e) => assert!(
+            e.contains("Block")
+                || e.contains("block")
+                || e.contains("type")
+                || e.contains("compose"),
+            "Error should mention type: {}",
+            e
+        ),
         Ok(_) => panic!("Should have failed"),
     }
 }
@@ -651,7 +701,8 @@ fn test_retry_success_immediate() {
     // Use a simple block that always succeeds
     let output = eval(r#"2 #[true] retry"#).unwrap();
     // Should succeed (no error)
-    assert!(output.is_empty() || output.len() >= 0);
+    // Smoke assertion: reaching here without panicking is the test.
+    let _ = output;
 }
 
 #[test]

--- a/tests/test_control.rs
+++ b/tests/test_control.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_block_pushes() {
@@ -36,7 +36,12 @@ fn test_job_status_stopped() {
     // (Implicitly tested through .jobs builtin)
     let output = eval(".jobs").unwrap();
     // Should not error, output may be empty
-    assert!(output.is_empty() || output.contains("Running") || output.contains("Stopped") || output.contains("Done"));
+    assert!(
+        output.is_empty()
+            || output.contains("Running")
+            || output.contains("Stopped")
+            || output.contains("Done")
+    );
 }
 
 #[test]
@@ -53,8 +58,8 @@ fn test_bg_no_stopped_job_error() {
 
 #[test]
 fn test_fifo_creates_named_pipe() {
-    use std::path::Path;
     use std::fs;
+    use std::path::Path;
 
     // #[hello echo] fifo should create a named pipe and push its path
     // Note: hsab uses postfix notation, so "hello echo" means echo hello
@@ -63,7 +68,11 @@ fn test_fifo_creates_named_pipe() {
 
     // The path should exist and be a named pipe (or at least exist)
     let path = Path::new(pipe_path);
-    assert!(path.exists() || pipe_path.contains("hsab_fifo"), "fifo should create a pipe at: {}", pipe_path);
+    assert!(
+        path.exists() || pipe_path.contains("hsab_fifo"),
+        "fifo should create a pipe at: {}",
+        pipe_path
+    );
 
     // Clean up
     fs::remove_file(pipe_path).ok();
@@ -77,8 +86,11 @@ fn test_fifo_path_is_in_tmp() {
     let output = eval("#[test echo] fifo").unwrap();
     let pipe_path = output.trim();
 
-    assert!(pipe_path.starts_with("/tmp/") || pipe_path.contains("hsab_fifo"),
-            "fifo path should be in /tmp: {}", pipe_path);
+    assert!(
+        pipe_path.starts_with("/tmp/") || pipe_path.contains("hsab_fifo"),
+        "fifo path should be in /tmp: {}",
+        pipe_path
+    );
 
     fs::remove_file(pipe_path).ok();
 }
@@ -89,7 +101,11 @@ fn test_fifo_can_be_read() {
     // #[hello echo] fifo cat should produce "hello"
     // Note: postfix notation - "hello echo" means echo hello
     let output = eval("#[hello echo] fifo cat").unwrap();
-    assert!(output.contains("hello"), "should be able to cat from fifo: {}", output);
+    assert!(
+        output.contains("hello"),
+        "should be able to cat from fifo: {}",
+        output
+    );
 }
 
 #[test]
@@ -97,7 +113,11 @@ fn test_if_true_branch() {
     // New order: [else] [then] condition if
     // true condition -> runs then-branch
     let output = eval(r#"#["no" echo] #["yes" echo] true if"#).unwrap();
-    assert!(output.contains("yes"), "if with true condition should run then-branch: {}", output);
+    assert!(
+        output.contains("yes"),
+        "if with true condition should run then-branch: {}",
+        output
+    );
 }
 
 #[test]
@@ -105,7 +125,11 @@ fn test_if_false_branch() {
     // New order: [else] [then] condition if
     // false condition -> runs else-branch
     let output = eval(r#"#["no" echo] #["yes" echo] false if"#).unwrap();
-    assert!(output.contains("no"), "if with false condition should run else-branch: {}", output);
+    assert!(
+        output.contains("no"),
+        "if with false condition should run else-branch: {}",
+        output
+    );
 }
 
 #[test]
@@ -113,7 +137,11 @@ fn test_if_with_test_condition() {
     // New order: [else] [then] condition if
     // 1 1 eq? pushes Bool(true) -> then runs
     let output = eval(r#"#["not-equal" echo] #["equal" echo] 1 1 eq? if"#).unwrap();
-    assert!(output.contains("equal"), "if with passing test should run then-branch: {}", output);
+    assert!(
+        output.contains("equal"),
+        "if with passing test should run then-branch: {}",
+        output
+    );
 }
 
 #[test]
@@ -127,14 +155,21 @@ fn test_times_loop() {
 #[test]
 fn test_times_zero() {
     let output = eval("#[x echo] 0 times").unwrap();
-    assert!(output.is_empty() || !output.contains("x"), "times 0 should not execute block");
+    assert!(
+        output.is_empty() || !output.contains("x"),
+        "times 0 should not execute block"
+    );
 }
 
 #[test]
 fn test_while_false_condition() {
     // #[false] #[] while should execute zero times since false returns exit code 1
     let output = eval("#[false] #[] while done echo").unwrap();
-    assert!(output.contains("done"), "while with false condition should exit immediately: {}", output);
+    assert!(
+        output.contains("done"),
+        "while with false condition should exit immediately: {}",
+        output
+    );
 }
 
 #[test]

--- a/tests/test_dynamic_patterns.rs
+++ b/tests/test_dynamic_patterns.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_dynamic_plus() {

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_hash_builtin_no_args() {
@@ -37,7 +37,10 @@ fn test_sha256_returns_bytes() {
 fn test_sha256_to_hex() {
     let output = eval(r#""hello" sha256 to-hex"#).unwrap();
     // SHA-256 of "hello" is known
-    assert_eq!(output.trim(), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    assert_eq!(
+        output.trim(),
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
 }
 
 #[test]
@@ -58,7 +61,10 @@ fn test_sha512_to_hex() {
 fn test_sha3_256_to_hex() {
     let output = eval(r#""hello" sha3-256 to-hex"#).unwrap();
     // SHA3-256 of "hello"
-    assert_eq!(output.trim(), "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392");
+    assert_eq!(
+        output.trim(),
+        "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392"
+    );
 }
 
 #[test]
@@ -79,7 +85,10 @@ fn test_sha3_512_to_hex() {
 fn test_sha256_to_base64() {
     let output = eval(r#""hello" sha256 to-base64"#).unwrap();
     // Base64 of SHA-256 of "hello"
-    assert_eq!(output.trim(), "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=");
+    assert_eq!(
+        output.trim(),
+        "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
+    );
 }
 
 #[test]
@@ -94,11 +103,14 @@ fn test_sha256_file() {
     use std::fs;
     let temp = tempfile::NamedTempFile::new().unwrap();
     fs::write(temp.path(), "hello").unwrap();
-    
+
     let input = format!(r#""{}" sha256-file to-hex"#, temp.path().display());
     let output = eval(&input).unwrap();
     // Same as sha256 of "hello"
-    assert_eq!(output.trim(), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    assert_eq!(
+        output.trim(),
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
 }
 
 #[test]
@@ -106,10 +118,13 @@ fn test_sha3_256_file() {
     use std::fs;
     let temp = tempfile::NamedTempFile::new().unwrap();
     fs::write(temp.path(), "hello").unwrap();
-    
+
     let input = format!(r#""{}" sha3-256-file to-hex"#, temp.path().display());
     let output = eval(&input).unwrap();
-    assert_eq!(output.trim(), "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392");
+    assert_eq!(
+        output.trim(),
+        "3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392"
+    );
 }
 
 #[test]
@@ -183,9 +198,11 @@ fn test_cross_encoding_hex_to_base64() {
 fn test_empty_string_sha256() {
     let output = eval(r#""" sha256 to-hex"#).unwrap();
     // SHA-256 of empty string
-    assert_eq!(output.trim(), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert_eq!(
+        output.trim(),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
 }
-
 
 // === Recovered tests ===
 
@@ -237,7 +254,10 @@ fn test_empty_string_sha512() {
 fn test_empty_string_sha3_256() {
     let output = eval(r#""" sha3-256 to-hex"#).unwrap();
     // SHA3-256 of empty string (known value)
-    assert_eq!(output.trim(), "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a");
+    assert_eq!(
+        output.trim(),
+        "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
+    );
 }
 
 #[test]
@@ -389,7 +409,10 @@ fn test_invalid_base64_error() {
 fn test_invalid_utf8_to_string_error() {
     // Create bytes that are not valid UTF-8
     let result = eval(r#""ff" from-hex to-string"#);
-    assert!(result.is_err(), "Invalid UTF-8 bytes should error on to-string");
+    assert!(
+        result.is_err(),
+        "Invalid UTF-8 bytes should error on to-string"
+    );
 }
 
 #[test]
@@ -411,7 +434,10 @@ fn test_long_string_sha256() {
     let input = format!(r#""{}" sha256 to-hex"#, long_input);
     let output = eval(&input).unwrap();
     // SHA-256 of 1000 'a's (known value)
-    assert_eq!(output.trim(), "41edece42d63e8d9bf515a9ba6932e1c20cbc9f5a5d134645adb5db1b9737ea3");
+    assert_eq!(
+        output.trim(),
+        "41edece42d63e8d9bf515a9ba6932e1c20cbc9f5a5d134645adb5db1b9737ea3"
+    );
 }
 
 #[test]
@@ -441,7 +467,10 @@ fn test_sha256_empty_file() {
     let input = format!(r#""{}" sha256-file to-hex"#, temp.path().display());
     let output = eval(&input).unwrap();
     // SHA-256 of empty file (same as empty string)
-    assert_eq!(output.trim(), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    assert_eq!(
+        output.trim(),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
 }
 
 #[test]
@@ -453,7 +482,10 @@ fn test_sha3_256_empty_file() {
     let input = format!(r#""{}" sha3-256-file to-hex"#, temp.path().display());
     let output = eval(&input).unwrap();
     // SHA3-256 of empty file
-    assert_eq!(output.trim(), "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a");
+    assert_eq!(
+        output.trim(),
+        "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
+    );
 }
 
 #[test]
@@ -461,7 +493,7 @@ fn test_sha256_binary_file() {
     use std::fs;
     let temp = tempfile::NamedTempFile::new().unwrap();
     // Write binary data (not valid UTF-8)
-    fs::write(temp.path(), &[0xff, 0x00, 0xfe, 0x01]).unwrap();
+    fs::write(temp.path(), [0xff, 0x00, 0xfe, 0x01]).unwrap();
 
     let input = format!(r#""{}" sha256-file to-hex"#, temp.path().display());
     let output = eval(&input).unwrap();
@@ -550,7 +582,10 @@ fn test_sha3_512_equality() {
 #[test]
 fn test_different_hash_algorithms_not_equal() {
     let exit_code = eval_exit_code(r#""hello" sha256 "hello" sha3-256 eq?"#);
-    assert_eq!(exit_code, 1, "SHA-256 and SHA3-256 of same input should not be equal");
+    assert_eq!(
+        exit_code, 1,
+        "SHA-256 and SHA3-256 of same input should not be equal"
+    );
 }
 
 #[test]
@@ -689,7 +724,8 @@ fn test_chained_hash_operations() {
 #[test]
 fn test_chained_encode_decode() {
     // Multiple encode/decode cycles
-    let output = eval(r#""test" as-bytes to-base64 from-base64 to-hex from-hex to-string"#).unwrap();
+    let output =
+        eval(r#""test" as-bytes to-base64 from-base64 to-hex from-hex to-string"#).unwrap();
     assert_eq!(output.trim(), "test");
 }
 
@@ -697,7 +733,11 @@ fn test_chained_encode_decode() {
 fn test_hash_of_hash_deterministic() {
     let hash1 = eval(r#""hello" sha256 sha256 to-hex"#).unwrap();
     let hash2 = eval(r#""hello" sha256 sha256 to-hex"#).unwrap();
-    assert_eq!(hash1.trim(), hash2.trim(), "Hash of hash should be deterministic");
+    assert_eq!(
+        hash1.trim(),
+        hash2.trim(),
+        "Hash of hash should be deterministic"
+    );
 }
 
 #[test]
@@ -894,4 +934,3 @@ fn test_read_bytes_zero() {
     let output = eval(r#""/dev/urandom" 0 read-bytes len"#).unwrap();
     assert_eq!(output.trim(), "0");
 }
-

--- a/tests/test_functional.rs
+++ b/tests/test_functional.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 // === reduce tests ===
 
@@ -58,31 +58,49 @@ fn test_fold_empty_list() {
 #[test]
 fn test_bend_generate_sequence() {
     let output = eval("1 #[dup 5 le?] #[dup 1 plus] bend").unwrap();
-    assert!(output.contains("1") && output.contains("2") && output.contains("3")
-            && output.contains("4") && output.contains("5"),
-            "bend should generate sequence 1..5: {}", output);
+    assert!(
+        output.contains("1")
+            && output.contains("2")
+            && output.contains("3")
+            && output.contains("4")
+            && output.contains("5"),
+        "bend should generate sequence 1..5: {}",
+        output
+    );
 }
 
 #[test]
 fn test_bend_powers_of_two() {
     let output = eval("1 #[dup 16 le?] #[dup 2 mul] bend").unwrap();
-    assert!(output.contains("1") && output.contains("2") && output.contains("4")
-            && output.contains("8") && output.contains("16"),
-            "bend should generate powers of 2 up to 16: {}", output);
+    assert!(
+        output.contains("1")
+            && output.contains("2")
+            && output.contains("4")
+            && output.contains("8")
+            && output.contains("16"),
+        "bend should generate powers of 2 up to 16: {}",
+        output
+    );
 }
 
 #[test]
 fn test_bend_immediate_false() {
     let output = eval("10 #[dup 5 le?] #[dup 1 plus] bend").unwrap();
-    assert!(!output.contains("10"),
-            "bend with immediately false predicate should not emit seed: {}", output);
+    assert!(
+        !output.contains("10"),
+        "bend with immediately false predicate should not emit seed: {}",
+        output
+    );
 }
 
 #[test]
 fn test_bend_single_element() {
     let output = eval("1 #[dup 1 le?] #[dup 1 plus] bend").unwrap();
-    assert!(output.contains("1"),
-            "bend should generate at least the seed when predicate passes once: {}", output);
+    assert!(
+        output.contains("1"),
+        "bend should generate at least the seed when predicate passes once: {}",
+        output
+    );
 }
 
 // === roundtrip: bend then reduce ===

--- a/tests/test_http.rs
+++ b/tests/test_http.rs
@@ -7,7 +7,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 // === Error handling tests (no network required) ===
 
@@ -102,14 +102,17 @@ fn test_fetch_explicit_get() {
 #[ignore] // Requires network
 fn test_fetch_post() {
     // POST request with JSON body
-    let output = eval(r#""{\"test\":123}" "https://httpbin.org/post" "POST" fetch "json" get "test" get"#).unwrap();
+    let output =
+        eval(r#""{\"test\":123}" "https://httpbin.org/post" "POST" fetch "json" get "test" get"#)
+            .unwrap();
     assert_eq!(output.trim(), "123");
 }
 
 #[test]
 #[ignore] // Requires network
 fn test_fetch_put() {
-    let output = eval(r#""{\"key\":\"value\"}" "https://httpbin.org/put" "PUT" fetch "json" get"#).unwrap();
+    let output =
+        eval(r#""{\"key\":\"value\"}" "https://httpbin.org/put" "PUT" fetch "json" get"#).unwrap();
     assert!(output.contains("key"));
 }
 
@@ -123,7 +126,9 @@ fn test_fetch_delete() {
 #[test]
 #[ignore] // Requires network
 fn test_fetch_patch() {
-    let output = eval(r#""{\"update\":true}" "https://httpbin.org/patch" "PATCH" fetch "json" get"#).unwrap();
+    let output =
+        eval(r#""{\"update\":true}" "https://httpbin.org/patch" "PATCH" fetch "json" get"#)
+            .unwrap();
     assert!(output.contains("update"));
 }
 
@@ -133,7 +138,8 @@ fn test_fetch_patch() {
 #[ignore] // Requires network
 fn test_fetch_body_infers_post() {
     // When body is provided and URL is second, should infer POST
-    let output = eval(r#""{\"auto\":\"post\"}" "https://httpbin.org/post" fetch "json" get"#).unwrap();
+    let output =
+        eval(r#""{\"auto\":\"post\"}" "https://httpbin.org/post" fetch "json" get"#).unwrap();
     assert!(output.contains("auto"));
 }
 

--- a/tests/test_image.rs
+++ b/tests/test_image.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 use std::fs;
 use tempfile::NamedTempFile;
@@ -40,19 +40,13 @@ const MINIMAL_GIF: &[u8] = &[
 ];
 
 fn create_temp_png() -> NamedTempFile {
-    let temp = tempfile::Builder::new()
-        .suffix(".png")
-        .tempfile()
-        .unwrap();
+    let temp = tempfile::Builder::new().suffix(".png").tempfile().unwrap();
     fs::write(temp.path(), MINIMAL_PNG).unwrap();
     temp
 }
 
 fn create_temp_gif() -> NamedTempFile {
-    let temp = tempfile::Builder::new()
-        .suffix(".gif")
-        .tempfile()
-        .unwrap();
+    let temp = tempfile::Builder::new().suffix(".gif").tempfile().unwrap();
     fs::write(temp.path(), MINIMAL_GIF).unwrap();
     temp
 }
@@ -104,7 +98,11 @@ fn test_image_info_returns_record() {
 fn test_image_info_has_mime_type() {
     let temp = create_temp_png();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/png");
 }
 
@@ -112,7 +110,11 @@ fn test_image_info_has_mime_type() {
 fn test_image_info_gif_mime_type() {
     let temp = create_temp_gif();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/gif");
 }
 
@@ -155,8 +157,12 @@ fn test_image_info_gif_dimensions() {
 fn test_image_info_has_source() {
     let temp = create_temp_png();
     let path_str = temp.path().to_string_lossy().to_string();
-    let output = eval(&format!(r#""{}" image-load image-info "source" get"#, path_str)).unwrap();
-    assert!(output.contains(&path_str) || output.trim().len() > 0);
+    let output = eval(&format!(
+        r#""{}" image-load image-info "source" get"#,
+        path_str
+    ))
+    .unwrap();
+    assert!(output.contains(&path_str) || !output.trim().is_empty());
 }
 
 // === image-show tests ===
@@ -183,7 +189,11 @@ fn test_mime_type_detection_png() {
     let temp = NamedTempFile::with_suffix(".png").unwrap();
     fs::write(temp.path(), MINIMAL_PNG).unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/png");
 }
 
@@ -192,7 +202,11 @@ fn test_mime_type_detection_gif() {
     let temp = NamedTempFile::with_suffix(".gif").unwrap();
     fs::write(temp.path(), MINIMAL_GIF).unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/gif");
 }
 
@@ -203,7 +217,11 @@ fn test_mime_type_detection_jpg() {
     let temp = NamedTempFile::with_suffix(".jpg").unwrap();
     fs::write(temp.path(), b"not a real jpeg").unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/jpeg");
 }
 
@@ -212,7 +230,11 @@ fn test_mime_type_detection_jpeg() {
     let temp = NamedTempFile::with_suffix(".jpeg").unwrap();
     fs::write(temp.path(), b"not a real jpeg").unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/jpeg");
 }
 
@@ -221,7 +243,11 @@ fn test_mime_type_detection_webp() {
     let temp = NamedTempFile::with_suffix(".webp").unwrap();
     fs::write(temp.path(), b"test").unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/webp");
 }
 
@@ -230,7 +256,11 @@ fn test_mime_type_detection_svg() {
     let temp = NamedTempFile::with_suffix(".svg").unwrap();
     fs::write(temp.path(), b"<svg></svg>").unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/svg+xml");
 }
 
@@ -239,7 +269,11 @@ fn test_mime_type_detection_bmp() {
     let temp = NamedTempFile::with_suffix(".bmp").unwrap();
     fs::write(temp.path(), b"test").unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "image/bmp");
 }
 
@@ -248,7 +282,11 @@ fn test_mime_type_detection_unknown() {
     let temp = NamedTempFile::with_suffix(".xyz").unwrap();
     fs::write(temp.path(), b"test").unwrap();
     let path = temp.path().display();
-    let output = eval(&format!(r#""{}" image-load image-info "mime_type" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info "mime_type" get"#,
+        path
+    ))
+    .unwrap();
     assert_eq!(output.trim(), "application/octet-stream");
 }
 
@@ -294,6 +332,10 @@ fn test_image_chain_operations() {
     let temp = create_temp_png();
     let path = temp.path().display();
     // Load -> info -> get multiple fields
-    let output = eval(&format!(r#""{}" image-load image-info dup "mime_type" get swap "width" get"#, path)).unwrap();
+    let output = eval(&format!(
+        r#""{}" image-load image-info dup "mime_type" get swap "width" get"#,
+        path
+    ))
+    .unwrap();
     assert!(output.contains("image/png") || output.contains("1"));
 }

--- a/tests/test_jobs.rs
+++ b/tests/test_jobs.rs
@@ -1,0 +1,155 @@
+//! Integration tests for background jobs and SIGCHLD reaping (issue #30)
+
+#[path = "common/mod.rs"]
+mod common;
+#[allow(unused_imports)]
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
+
+use std::time::Duration;
+
+/// Run a line on a persistent evaluator and return the output.
+fn run(evaluator: &mut Evaluator, input: &str) -> String {
+    let tokens = lex(input).unwrap();
+    let program = parse(tokens).unwrap();
+    let result = evaluator.eval(&program).unwrap();
+    evaluator.clear_stack();
+    result.output
+}
+
+/// Extract the pid (second tab-separated field) from a `.jobs` output line.
+fn first_job_pid(jobs_output: &str) -> Option<u32> {
+    jobs_output
+        .lines()
+        .next()?
+        .split('\t')
+        .nth(1)?
+        .trim()
+        .parse()
+        .ok()
+}
+
+#[test]
+fn test_background_job_transitions_to_done() {
+    let mut evaluator = Evaluator::new();
+    run(&mut evaluator, "#[0.1 sleep] &");
+
+    // Right after spawn, the job should be listed as Running
+    let out = run(&mut evaluator, ".jobs");
+    assert!(
+        out.contains("Running"),
+        "job should be Running right after spawn: {}",
+        out
+    );
+
+    // After the child exits, .jobs must reflect Done without manual help
+    std::thread::sleep(Duration::from_millis(400));
+    let out = run(&mut evaluator, ".jobs");
+    assert!(
+        out.contains("Done"),
+        "job should transition to Done after exit: {}",
+        out
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_background_job_is_reaped_no_zombie() {
+    let mut evaluator = Evaluator::new();
+    run(&mut evaluator, "#[0.05 sleep] &");
+    let out = run(&mut evaluator, ".jobs");
+    let pid = first_job_pid(&out).expect("jobs output should contain a pid");
+
+    std::thread::sleep(Duration::from_millis(300));
+    // .jobs triggers the reaper
+    let out = run(&mut evaluator, ".jobs");
+    assert!(out.contains("Done"), "job should be Done: {}", out);
+
+    // The child must be fully reaped: /proc/<pid> gone or not in Z state
+    if let Ok(stat) = std::fs::read_to_string(format!("/proc/{}/stat", pid)) {
+        // stat: "pid (comm) state ..." — state is first char after ") "
+        let state = stat
+            .rsplit(") ")
+            .next()
+            .and_then(|rest| rest.chars().next())
+            .unwrap_or('?');
+        assert_ne!(state, 'Z', "child {} is a zombie: {}", pid, stat);
+    }
+}
+
+#[test]
+fn test_wait_blocks_until_job_finishes() {
+    let mut evaluator = Evaluator::new();
+    run(&mut evaluator, "#[0.2 sleep] &");
+
+    let start = std::time::Instant::now();
+    let output = run(&mut evaluator, "wait");
+    let elapsed = start.elapsed();
+    let _ = output;
+
+    assert!(
+        elapsed >= Duration::from_millis(150),
+        "wait should block until the job completes (took {:?})",
+        elapsed
+    );
+
+    let out = run(&mut evaluator, ".jobs");
+    assert!(
+        out.contains("Done"),
+        "job should be Done after wait: {}",
+        out
+    );
+}
+
+#[test]
+fn test_wait_yields_exit_code() {
+    let mut evaluator = Evaluator::new();
+    run(&mut evaluator, "#[0.05 sleep] &");
+    let tokens = lex("wait").unwrap();
+    let program = parse(tokens).unwrap();
+    let result = evaluator.eval(&program).unwrap();
+    assert_eq!(result.exit_code, 0, "wait should yield the job's exit code");
+}
+
+#[test]
+#[cfg(unix)]
+fn test_sigchld_flag_set_on_child_exit() {
+    hsab::signals::setup_signal_handlers();
+    // Clear any pending flag from other tests' children
+    let _ = hsab::signals::check_sigchld();
+
+    let status = std::process::Command::new("sh")
+        .args(["-c", "exit 0"])
+        .status()
+        .expect("spawn sh");
+    assert!(status.success());
+
+    // Signal delivery is asynchronous; give it a moment
+    let mut flagged = false;
+    for _ in 0..50 {
+        if hsab::signals::check_sigchld() {
+            flagged = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(flagged, "SIGCHLD handler should set the flag when a child exits");
+}
+
+#[test]
+fn test_reap_jobs_reports_finished_jobs() {
+    let mut evaluator = Evaluator::new();
+    run(&mut evaluator, "#[0.05 sleep] &");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let notices = evaluator.reap_jobs();
+    assert_eq!(notices.len(), 1, "one job should have been reaped: {:?}", notices);
+    assert!(
+        notices[0].contains("Done"),
+        "notice should report Done: {}",
+        notices[0]
+    );
+
+    // Second reap: nothing new
+    let notices = evaluator.reap_jobs();
+    assert!(notices.is_empty(), "already-reaped job reported again: {:?}", notices);
+}

--- a/tests/test_jobs.rs
+++ b/tests/test_jobs.rs
@@ -132,7 +132,10 @@ fn test_sigchld_flag_set_on_child_exit() {
         }
         std::thread::sleep(Duration::from_millis(10));
     }
-    assert!(flagged, "SIGCHLD handler should set the flag when a child exits");
+    assert!(
+        flagged,
+        "SIGCHLD handler should set the flag when a child exits"
+    );
 }
 
 #[test]
@@ -142,7 +145,12 @@ fn test_reap_jobs_reports_finished_jobs() {
     std::thread::sleep(Duration::from_millis(300));
 
     let notices = evaluator.reap_jobs();
-    assert_eq!(notices.len(), 1, "one job should have been reaped: {:?}", notices);
+    assert_eq!(
+        notices.len(),
+        1,
+        "one job should have been reaped: {:?}",
+        notices
+    );
     assert!(
         notices[0].contains("Done"),
         "notice should report Done: {}",
@@ -151,5 +159,9 @@ fn test_reap_jobs_reports_finished_jobs() {
 
     // Second reap: nothing new
     let notices = evaluator.reap_jobs();
-    assert!(notices.is_empty(), "already-reaped job reported again: {:?}", notices);
+    assert!(
+        notices.is_empty(),
+        "already-reaped job reported again: {:?}",
+        notices
+    );
 }

--- a/tests/test_local.rs
+++ b/tests/test_local.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_variable_passthrough() {
@@ -62,7 +62,12 @@ fn test_practical_join_path() {
 fn test_semicolon_basic_assignment() {
     // ABC=5; $ABC echo should print 5
     let output = eval("ABC=5; $ABC echo").unwrap();
-    assert_eq!(output.trim(), "5", "basic assignment should work: {}", output);
+    assert_eq!(
+        output.trim(),
+        "5",
+        "basic assignment should work: {}",
+        output
+    );
 }
 
 #[test]
@@ -71,8 +76,12 @@ fn test_semicolon_multiple_assignments() {
     // Note: In postfix stack semantics, $A pushes "hello", $B pushes "world"
     // echo pops in LIFO order: world then hello -> "world hello"
     let output = eval("A=hello B=world; $A $B echo").unwrap();
-    assert_eq!(output.trim(), "world hello",
-            "multiple assignments with LIFO order: {}", output);
+    assert_eq!(
+        output.trim(),
+        "world hello",
+        "multiple assignments with LIFO order: {}",
+        output
+    );
 }
 
 #[test]
@@ -82,10 +91,18 @@ fn test_semicolon_shadowing() {
     std::env::set_var("HSAB_TEST_VAR", "original");
     let output = eval("HSAB_TEST_VAR=shadowed; $HSAB_TEST_VAR echo").unwrap();
     // Output should be exactly "shadowed", not "HSAB_TEST_VAR=shadowed"
-    assert_eq!(output.trim(), "shadowed", "shadowed value should be used: {}", output);
+    assert_eq!(
+        output.trim(),
+        "shadowed",
+        "shadowed value should be used: {}",
+        output
+    );
     // After the scoped expression, original should be restored
-    assert_eq!(std::env::var("HSAB_TEST_VAR").unwrap(), "original",
-               "original value should be restored after scope");
+    assert_eq!(
+        std::env::var("HSAB_TEST_VAR").unwrap(),
+        "original",
+        "original value should be restored after scope"
+    );
     std::env::remove_var("HSAB_TEST_VAR");
 }
 
@@ -95,16 +112,28 @@ fn test_semicolon_unset_after_scope() {
     std::env::remove_var("HSAB_NEW_VAR");
     let output = eval("HSAB_NEW_VAR=temporary; $HSAB_NEW_VAR echo").unwrap();
     // Output should be exactly "temporary"
-    assert_eq!(output.trim(), "temporary", "new var should work: {}", output);
-    assert!(std::env::var("HSAB_NEW_VAR").is_err(),
-            "new var should be unset after scope");
+    assert_eq!(
+        output.trim(),
+        "temporary",
+        "new var should work: {}",
+        output
+    );
+    assert!(
+        std::env::var("HSAB_NEW_VAR").is_err(),
+        "new var should be unset after scope"
+    );
 }
 
 #[test]
 fn test_without_semicolon_is_literal() {
     // Without semicolon, ABC=5 should be treated as a literal
     let output = eval("ABC=5 echo").unwrap();
-    assert_eq!(output.trim(), "ABC=5", "without semicolon should be literal: {}", output);
+    assert_eq!(
+        output.trim(),
+        "ABC=5",
+        "without semicolon should be literal: {}",
+        output
+    );
 }
 
 #[test]
@@ -112,14 +141,21 @@ fn test_flags_still_work() {
     // Flags should not be affected by assignment parsing
     let output = eval("-la ls").unwrap();
     // Just check it doesn't error - output depends on directory
-    assert!(output.len() > 0 || output.is_empty(), "flags should still work");
+    assert!(
+        !output.is_empty() || output.is_empty(),
+        "flags should still work"
+    );
 }
 
 #[test]
 fn test_assignment_with_special_chars_in_value() {
     // Values can contain special characters
     let output = eval("PATH=/usr/bin:/bin; $PATH echo").unwrap();
-    assert!(output.contains("/usr/bin:/bin"), "special chars in value: {}", output);
+    assert!(
+        output.contains("/usr/bin:/bin"),
+        "special chars in value: {}",
+        output
+    );
 }
 
 #[test]
@@ -127,7 +163,11 @@ fn test_empty_value_assignment() {
     // Empty value assignment
     let output = eval("EMPTY=; $EMPTY echo").unwrap();
     // Empty value means $EMPTY expands to empty string
-    assert!(output.trim().is_empty() || output == "\n", "empty value should work: '{}'", output);
+    assert!(
+        output.trim().is_empty() || output == "\n",
+        "empty value should work: '{}'",
+        output
+    );
 }
 
 #[test]
@@ -151,52 +191,71 @@ fn test_escape_dollar() {
     assert!(output.contains("$HOME"));
 }
 
-
 // === Recovered tests ===
 
 #[test]
 fn test_local_structured_map_get() {
     // Test that local Map can use get to access fields
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '{"name":"bob","score":95}' from-json _DATA local
             $_DATA "score" get
         ] :get_map_field
         get_map_field
-    "#).unwrap();
-    assert_eq!(output.trim(), "95", "local Map should support get: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "95",
+        "local Map should support get: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_structured_table() {
     // Test that local preserves Table values
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             marker "name" "alice" record "name" "bob" record table _TBL local
             $_TBL typeof
         ] :table_local
         table_local
-    "#).unwrap();
-    assert_eq!(output.trim(), "table", "local should preserve Table structure: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "table",
+        "local should preserve Table structure: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_number() {
     // Test local with Number value (should use env vars for primitives)
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             42 _NUM local
             $_NUM 8 plus
         ] :num_local
         num_local
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "50", "local Number should work: {}", output);
 }
 
 #[test]
 fn test_local_nested_function_scopes() {
     // Test that nested function calls have independent local scopes
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[10,20,30]' from-json _INNER_LIST local
             $_INNER_LIST sum
@@ -210,15 +269,23 @@ fn test_local_nested_function_scopes() {
         ] :outer_func
 
         outer_func
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // inner_func returns 60, outer sum is 6, total is 66
-    assert_eq!(output.trim(), "66", "nested scopes should be independent: {}", output);
+    assert_eq!(
+        output.trim(),
+        "66",
+        "nested scopes should be independent: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_variable_shadowing() {
     // Test that inner scope shadows outer scope variables
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             100 _SHADOW local
             $_SHADOW
@@ -230,15 +297,23 @@ fn test_local_variable_shadowing() {
         ] :outer_shadow
 
         outer_shadow
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // inner_shadow shadows _SHADOW with 100, should return 100
-    assert_eq!(output.trim(), "100", "inner scope should shadow outer: {}", output);
+    assert_eq!(
+        output.trim(),
+        "100",
+        "inner scope should shadow outer: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_variable_shadowing_structured() {
     // Test shadowing with structured types (List)
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[100,200]' from-json _DATA local
             $_DATA sum
@@ -252,25 +327,42 @@ fn test_local_variable_shadowing_structured() {
         ] :outer_struct
 
         outer_struct
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // inner returns 300, outer sum is 3, total is 303
-    assert_eq!(output.trim(), "303", "structured shadowing should work: {}", output);
+    assert_eq!(
+        output.trim(),
+        "303",
+        "structured shadowing should work: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_restoration_after_function_exit() {
     // Test that env vars are restored after function exits
     std::env::set_var("HSAB_RESTORE_TEST", "original_value");
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             modified HSAB_RESTORE_TEST local
             $HSAB_RESTORE_TEST echo
         ] :modify_var
         modify_var
-    "#).unwrap();
-    assert!(output.contains("modified"), "local should use new value inside: {}", output);
-    assert_eq!(std::env::var("HSAB_RESTORE_TEST").unwrap(), "original_value",
-               "original value should be restored after function exits");
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("modified"),
+        "local should use new value inside: {}",
+        output
+    );
+    assert_eq!(
+        std::env::var("HSAB_RESTORE_TEST").unwrap(),
+        "original_value",
+        "original value should be restored after function exits"
+    );
     std::env::remove_var("HSAB_RESTORE_TEST");
 }
 
@@ -278,22 +370,32 @@ fn test_local_restoration_after_function_exit() {
 fn test_local_restoration_unset_var() {
     // Test that previously unset vars are removed after function exits
     std::env::remove_var("HSAB_UNSET_TEST");
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             newvalue HSAB_UNSET_TEST local
             $HSAB_UNSET_TEST echo
         ] :set_new_var
         set_new_var
-    "#).unwrap();
-    assert!(output.contains("newvalue"), "local should set new value: {}", output);
-    assert!(std::env::var("HSAB_UNSET_TEST").is_err(),
-            "previously unset var should be unset after function exits");
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("newvalue"),
+        "local should set new value: {}",
+        output
+    );
+    assert!(
+        std::env::var("HSAB_UNSET_TEST").is_err(),
+        "previously unset var should be unset after function exits"
+    );
 }
 
 #[test]
 fn test_local_deeply_nested_scopes() {
     // Test 3-level deep nesting
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             1000 _LEVEL local
             $_LEVEL
@@ -310,15 +412,23 @@ fn test_local_deeply_nested_scopes() {
         ] :level1
 
         level1
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // level3 returns 1000, level2 returns 1000+100=1100, level1 returns 1100+10=1110
-    assert_eq!(output.trim(), "1110", "deeply nested scopes should work: {}", output);
+    assert_eq!(
+        output.trim(),
+        "1110",
+        "deeply nested scopes should work: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_list_operations_in_nested_scope() {
     // Test that List operations work correctly in nested scopes
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[5,6,7,8]' from-json _NUMS local
             $_NUMS count $_NUMS sum plus
@@ -332,17 +442,25 @@ fn test_local_list_operations_in_nested_scope() {
         ] :outer_list_ops
 
         outer_list_ops
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // inner: count=4, sum=26, inner_total=30
     // outer: count=3, sum=6, outer_total=9
     // final: 30+9=39
-    assert_eq!(output.trim(), "39", "list operations in nested scopes: {}", output);
+    assert_eq!(
+        output.trim(),
+        "39",
+        "list operations in nested scopes: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_map_in_nested_scope() {
     // Test Map operations in nested scopes
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '{"value":100}' from-json _OBJ local
             $_OBJ "value" get
@@ -356,7 +474,9 @@ fn test_local_map_in_nested_scope() {
         ] :get_outer_value
 
         get_outer_value
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // inner returns 100, outer returns 10, total is 110
     assert_eq!(output.trim(), "110", "map in nested scopes: {}", output);
 }
@@ -364,20 +484,24 @@ fn test_local_map_in_nested_scope() {
 #[test]
 fn test_local_table_count_in_scope() {
     // Test Table operations with local variables
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             marker "id" 1 record "id" 2 record "id" 3 record table _TBL local
             $_TBL count
         ] :count_table
         count_table
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "3", "table count in local scope: {}", output);
 }
 
 #[test]
 fn test_local_multiple_vars_same_scope() {
     // Test multiple local variables in the same function scope
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             10 _A local
             20 _B local
@@ -385,8 +509,15 @@ fn test_local_multiple_vars_same_scope() {
             $_A $_B plus $_C plus
         ] :multi_local
         multi_local
-    "#).unwrap();
-    assert_eq!(output.trim(), "60", "multiple local vars should work: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "60",
+        "multiple local vars should work: {}",
+        output
+    );
 }
 
 #[test]
@@ -395,41 +526,61 @@ fn test_local_error_outside_function() {
     let result = eval("42 _VAR local");
     assert!(result.is_err(), "local should fail outside function");
     let err = result.unwrap_err();
-    assert!(err.contains("inside a function"), "error should mention function: {}", err);
+    assert!(
+        err.contains("inside a function"),
+        "error should mention function: {}",
+        err
+    );
 }
 
 #[test]
 fn test_local_scope_isolation_between_calls() {
     // Test that separate function calls have isolated scopes
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[1,2,3]' from-json _ISOLATED local
             $_ISOLATED sum
         ] :isolated_func
 
         isolated_func isolated_func plus
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Each call returns 6, total is 12
-    assert_eq!(output.trim(), "12", "separate calls should have isolated scopes: {}", output);
+    assert_eq!(
+        output.trim(),
+        "12",
+        "separate calls should have isolated scopes: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_with_literal_string() {
     // Test local with a literal string value
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             "hello world" _MSG local
             $_MSG echo
         ] :string_local
         string_local
-    "#).unwrap();
-    assert!(output.contains("hello world"), "local should work with strings: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("hello world"),
+        "local should work with strings: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_preserves_list_after_operations() {
     // Test that operations on local List don't affect the stored value
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[1,2,3,4,5]' from-json _NUMS local
             $_NUMS sum drop
@@ -437,15 +588,23 @@ fn test_local_preserves_list_after_operations() {
             $_NUMS sum
         ] :preserve_list
         preserve_list
-    "#).unwrap();
-    assert_eq!(output.trim(), "15", "local List should be preserved after operations: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "15",
+        "local List should be preserved after operations: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_env_var_overwrite() {
     // Test that local correctly overwrites existing env var within scope
     std::env::set_var("HSAB_OVERWRITE_TEST", "outer");
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             inner1 HSAB_OVERWRITE_TEST local
             #[
@@ -456,10 +615,23 @@ fn test_local_env_var_overwrite() {
             $HSAB_OVERWRITE_TEST echo
         ] :outer_overwrite
         outer_overwrite
-    "#).unwrap();
-    assert!(output.contains("inner2"), "nested should see inner2: {}", output);
-    assert!(output.contains("inner1"), "outer should see inner1: {}", output);
-    assert_eq!(std::env::var("HSAB_OVERWRITE_TEST").unwrap(), "outer",
-               "original should be restored");
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("inner2"),
+        "nested should see inner2: {}",
+        output
+    );
+    assert!(
+        output.contains("inner1"),
+        "outer should see inner1: {}",
+        output
+    );
+    assert_eq!(
+        std::env::var("HSAB_OVERWRITE_TEST").unwrap(),
+        "outer",
+        "original should be restored"
+    );
     std::env::remove_var("HSAB_OVERWRITE_TEST");
 }

--- a/tests/test_macro_builtins.rs
+++ b/tests/test_macro_builtins.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_abs_positive() {

--- a/tests/test_modules.rs
+++ b/tests/test_modules.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_import_creates_namespaced_definitions() {
@@ -16,9 +16,16 @@ fn test_import_creates_namespaced_definitions() {
     drop(file);
 
     // Import and call the namespaced function (namespace = "mymodule")
-    let code = format!(r#""{}" .import file.txt mymodule::mybackup"#, module_path.display());
+    let code = format!(
+        r#""{}" .import file.txt mymodule::mybackup"#,
+        module_path.display()
+    );
     let output = eval(&code).unwrap();
-    assert!(output.contains("file.txt.bak"), "Expected namespaced function to work: {}", output);
+    assert!(
+        output.contains("file.txt.bak"),
+        "Expected namespaced function to work: {}",
+        output
+    );
 }
 
 #[test]
@@ -31,9 +38,16 @@ fn test_import_with_alias() {
     drop(file);
 
     // Import with explicit alias
-    let code = format!(r#""{}" utils .import file.txt utils::mybackup"#, module_path.display());
+    let code = format!(
+        r#""{}" utils .import file.txt utils::mybackup"#,
+        module_path.display()
+    );
     let output = eval(&code).unwrap();
-    assert!(output.contains("file.txt.bak"), "Expected aliased function to work: {}", output);
+    assert!(
+        output.contains("file.txt.bak"),
+        "Expected aliased function to work: {}",
+        output
+    );
 }
 
 #[test]
@@ -50,7 +64,11 @@ fn test_import_private_definitions_not_exported() {
     let code = format!(r#""{}" .import mymodule::_private"#, module_path.display());
     let output = eval(&code).unwrap();
     // _private should be treated as literal (not found as definition)
-    assert!(output.contains("mymodule::_private"), "Private definitions should not be exported: {}", output);
+    assert!(
+        output.contains("mymodule::_private"),
+        "Private definitions should not be exported: {}",
+        output
+    );
 }
 
 #[test]
@@ -65,11 +83,22 @@ fn test_import_skips_already_loaded() {
 
     // Import twice - should only add "loaded" once
     // depth should show 1 because only one import actually executed
-    let code = format!(r#""{0}" .import "{0}" .import depth"#, module_path.display());
+    let code = format!(
+        r#""{0}" .import "{0}" .import depth"#,
+        module_path.display()
+    );
     let output = eval(&code).unwrap();
     // Output will be "loaded\n1" - the literal and the depth
-    assert!(output.contains("1"), "Module should only be loaded once, depth should be 1: {}", output);
+    assert!(
+        output.contains("1"),
+        "Module should only be loaded once, depth should be 1: {}",
+        output
+    );
     // Make sure there's only ONE "loaded" in the output
-    assert_eq!(output.matches("loaded").count(), 1, "Module should only be loaded once: {}", output);
+    assert_eq!(
+        output.matches("loaded").count(),
+        1,
+        "Module should only be loaded once: {}",
+        output
+    );
 }
-

--- a/tests/test_predicates.rs
+++ b/tests/test_predicates.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_exists_predicate_cargo() {
@@ -47,45 +47,65 @@ fn test_nil_predicate_non_destructive() {
     // nil? should not consume the value (it stays on stack)
     // nil? also pushes a Bool result, so depth should be >= 2
     let output = eval(r#"/nonexistent/path/xyz cd nil?"#).unwrap();
-    assert!(output.contains("true"), "nil? on nil value should return true");
+    assert!(
+        output.contains("true"),
+        "nil? on nil value should return true"
+    );
 }
 
 // contains? predicate tests
 #[test]
 fn test_contains_predicate_match() {
     let exit_code = eval_exit_code(r#""hello world" "wor" contains?"#);
-    assert_eq!(exit_code, 0, "contains? should return 0 when substring found");
+    assert_eq!(
+        exit_code, 0,
+        "contains? should return 0 when substring found"
+    );
 }
 
 #[test]
 fn test_contains_predicate_no_match() {
     let exit_code = eval_exit_code(r#""hello world" "xyz" contains?"#);
-    assert_eq!(exit_code, 1, "contains? should return 1 when substring not found");
+    assert_eq!(
+        exit_code, 1,
+        "contains? should return 1 when substring not found"
+    );
 }
 
 // starts? predicate tests
 #[test]
 fn test_starts_predicate_match() {
     let exit_code = eval_exit_code(r#""hello world" "hello" starts?"#);
-    assert_eq!(exit_code, 0, "starts? should return 0 when string starts with prefix");
+    assert_eq!(
+        exit_code, 0,
+        "starts? should return 0 when string starts with prefix"
+    );
 }
 
 #[test]
 fn test_starts_predicate_no_match() {
     let exit_code = eval_exit_code(r#""hello world" "world" starts?"#);
-    assert_eq!(exit_code, 1, "starts? should return 1 when string doesn't start with prefix");
+    assert_eq!(
+        exit_code, 1,
+        "starts? should return 1 when string doesn't start with prefix"
+    );
 }
 
 // ends? predicate tests
 #[test]
 fn test_ends_predicate_match() {
     let exit_code = eval_exit_code(r#""hello.txt" ".txt" ends?"#);
-    assert_eq!(exit_code, 0, "ends? should return 0 when string ends with suffix");
+    assert_eq!(
+        exit_code, 0,
+        "ends? should return 0 when string ends with suffix"
+    );
 }
 
 #[test]
 fn test_ends_predicate_no_match() {
     let exit_code = eval_exit_code(r#""hello.txt" ".md" ends?"#);
-    assert_eq!(exit_code, 1, "ends? should return 1 when string doesn't end with suffix");
+    assert_eq!(
+        exit_code, 1,
+        "ends? should return 1 when string doesn't end with suffix"
+    );
 }
-

--- a/tests/test_serialization_naming.rs
+++ b/tests/test_serialization_naming.rs
@@ -12,44 +12,73 @@ use common::eval;
 fn test_into_json_serializes_record() {
     // into-json should serialize a value to JSON string (same as old to-json)
     let output = eval(r#""name" "Alice" "age" "30" record into-json"#).unwrap();
-    assert!(output.contains("Alice"), "into-json should serialize record to JSON: {}", output);
-    assert!(output.contains("name"), "into-json should contain field name: {}", output);
+    assert!(
+        output.contains("Alice"),
+        "into-json should serialize record to JSON: {}",
+        output
+    );
+    assert!(
+        output.contains("name"),
+        "into-json should contain field name: {}",
+        output
+    );
 }
 
 #[test]
 fn test_into_json_serializes_list() {
     // into-json on a list
     let output = eval(r#"'[1,2,3]' json into-json"#).unwrap();
-    assert!(output.contains("[") && output.contains("1") && output.contains("2") && output.contains("3"),
-        "into-json should serialize list: {}", output);
+    assert!(
+        output.contains("[")
+            && output.contains("1")
+            && output.contains("2")
+            && output.contains("3"),
+        "into-json should serialize list: {}",
+        output
+    );
 }
 
 #[test]
 fn test_to_json_still_works_as_alias() {
     // to-json should still work (alias for into-json serialize)
     let output = eval(r#""name" "test" record to-json"#).unwrap();
-    assert!(output.contains("name") && output.contains("test"),
-        "to-json should still work as alias: {}", output);
+    assert!(
+        output.contains("name") && output.contains("test"),
+        "to-json should still work as alias: {}",
+        output
+    );
 }
 
 #[test]
 fn test_from_json_parses_object() {
     // from-json should parse a JSON string into structured data
     let output = eval(r#"'{"a":1}' from-json keys"#).unwrap();
-    assert!(output.contains("a"), "from-json should parse JSON object: {}", output);
+    assert!(
+        output.contains("a"),
+        "from-json should parse JSON object: {}",
+        output
+    );
 }
 
 #[test]
 fn test_from_json_parses_array() {
     // from-json should parse a JSON array
     let output = eval(r#"'[1,2,3]' from-json typeof"#).unwrap();
-    assert_eq!(output.trim(), "list", "from-json should parse JSON array to list");
+    assert_eq!(
+        output.trim(),
+        "list",
+        "from-json should parse JSON array to list"
+    );
 }
 
 #[test]
 fn test_from_json_parses_number() {
     let output = eval(r#"'42' from-json typeof"#).unwrap();
-    assert_eq!(output.trim(), "number", "from-json should parse JSON number");
+    assert_eq!(
+        output.trim(),
+        "number",
+        "from-json should parse JSON number"
+    );
 }
 
 // === CSV ===
@@ -57,26 +86,41 @@ fn test_from_json_parses_number() {
 #[test]
 fn test_into_csv_serializes_table() {
     // into-csv should serialize table to CSV string (same as old to-csv)
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" "30" record
             "name" "bob" "age" "25" record
         table
         into-csv
-    "#).unwrap();
-    assert!(output.contains("name") && output.contains("age"),
-        "into-csv should have CSV headers: {}", output);
-    assert!(output.contains("alice") && output.contains("bob"),
-        "into-csv should have CSV data: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("name") && output.contains("age"),
+        "into-csv should have CSV headers: {}",
+        output
+    );
+    assert!(
+        output.contains("alice") && output.contains("bob"),
+        "into-csv should have CSV data: {}",
+        output
+    );
 }
 
 #[test]
 fn test_to_csv_still_works_as_alias() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker "name" "alice" record table to-csv
-    "#).unwrap();
-    assert!(output.contains("name") && output.contains("alice"),
-        "to-csv should still work: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("name") && output.contains("alice"),
+        "to-csv should still work: {}",
+        output
+    );
 }
 
 #[test]
@@ -89,7 +133,11 @@ fn test_from_csv_parses_csv_string() {
 #[test]
 fn test_from_csv_correct_data() {
     let output = eval(r#""name,age\nalice,30" from-csv 0 nth "name" get"#).unwrap();
-    assert_eq!(output.trim(), "alice", "from-csv should parse data correctly");
+    assert_eq!(
+        output.trim(),
+        "alice",
+        "from-csv should parse data correctly"
+    );
 }
 
 // === TSV ===
@@ -97,23 +145,40 @@ fn test_from_csv_correct_data() {
 #[test]
 fn test_into_tsv_serializes_table() {
     // into-tsv should serialize table to TSV string (same as old to-tsv)
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" "30" record
         table
         into-tsv
-    "#).unwrap();
-    assert!(output.contains("\t"), "into-tsv should produce tab-separated output: {}", output);
-    assert!(output.contains("alice"), "into-tsv should contain data: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("\t"),
+        "into-tsv should produce tab-separated output: {}",
+        output
+    );
+    assert!(
+        output.contains("alice"),
+        "into-tsv should contain data: {}",
+        output
+    );
 }
 
 #[test]
 fn test_to_tsv_still_works_as_alias() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker "name" "alice" record table to-tsv
-    "#).unwrap();
-    assert!(output.contains("\t") || output.contains("alice"),
-        "to-tsv should still work: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("\t") || output.contains("alice"),
+        "to-tsv should still work: {}",
+        output
+    );
 }
 
 #[test]
@@ -135,15 +200,26 @@ fn test_from_tsv_correct_data() {
 fn test_into_kv_serializes_record() {
     // into-kv should serialize record to key=value format (same as old to-kv)
     let output = eval(r#""name" "alice" "age" "30" record into-kv"#).unwrap();
-    assert!(output.contains("age=30"), "into-kv should produce key=value: {}", output);
-    assert!(output.contains("name=alice"), "into-kv should produce key=value: {}", output);
+    assert!(
+        output.contains("age=30"),
+        "into-kv should produce key=value: {}",
+        output
+    );
+    assert!(
+        output.contains("name=alice"),
+        "into-kv should produce key=value: {}",
+        output
+    );
 }
 
 #[test]
 fn test_to_kv_still_works_as_alias() {
     let output = eval(r#""name" "test" record to-kv"#).unwrap();
-    assert!(output.contains("name=test"),
-        "to-kv should still work: {}", output);
+    assert!(
+        output.contains("name=test"),
+        "to-kv should still work: {}",
+        output
+    );
 }
 
 #[test]
@@ -165,14 +241,22 @@ fn test_from_kv_correct_data() {
 fn test_into_lines_still_parses() {
     // into-lines should still work as before (parse: string -> list)
     let output = eval(r#""a\nb\nc" into-lines count"#).unwrap();
-    assert_eq!(output.trim(), "3", "into-lines should still split string into list");
+    assert_eq!(
+        output.trim(),
+        "3",
+        "into-lines should still split string into list"
+    );
 }
 
 #[test]
 fn test_from_lines_parses() {
     // from-lines should be an alias for into-lines (parse: string -> list)
     let output = eval(r#""a\nb\nc" from-lines count"#).unwrap();
-    assert_eq!(output.trim(), "3", "from-lines should split string into list");
+    assert_eq!(
+        output.trim(),
+        "3",
+        "from-lines should split string into list"
+    );
 }
 
 #[test]
@@ -189,22 +273,31 @@ fn test_to_lines_still_serializes() {
 fn test_json_roundtrip_from_into() {
     // from-json then into-json should roundtrip
     let output = eval(r#"'{"x":1}' from-json into-json"#).unwrap();
-    assert!(output.contains("x") && output.contains("1"),
-        "JSON roundtrip should preserve data: {}", output);
+    assert!(
+        output.contains("x") && output.contains("1"),
+        "JSON roundtrip should preserve data: {}",
+        output
+    );
 }
 
 #[test]
 fn test_csv_roundtrip_from_into() {
     // from-csv then into-csv should roundtrip
     let output = eval(r#""name,age\nalice,30" from-csv into-csv"#).unwrap();
-    assert!(output.contains("name") && output.contains("alice"),
-        "CSV roundtrip should preserve data: {}", output);
+    assert!(
+        output.contains("name") && output.contains("alice"),
+        "CSV roundtrip should preserve data: {}",
+        output
+    );
 }
 
 #[test]
 fn test_kv_roundtrip_from_into() {
     // from-kv then into-kv should roundtrip
     let output = eval(r#""name=alice" from-kv into-kv"#).unwrap();
-    assert!(output.contains("name=alice"),
-        "KV roundtrip should preserve data: {}", output);
+    assert!(
+        output.contains("name=alice"),
+        "KV roundtrip should preserve data: {}",
+        output
+    );
 }

--- a/tests/test_shell.rs
+++ b/tests/test_shell.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_pipe_basic() {
@@ -16,8 +16,8 @@ fn test_pipe_basic() {
 fn test_pipe_chained() {
     // Would need multiple pipes, but basic pipe works
     let output = eval("ls #[txt grep] |").unwrap();
-    // May or may not have .txt files
-    assert!(output.is_empty() || output.contains("txt") || true);
+    // May or may not have .txt files; not panicking is the test.
+    let _ = output;
 }
 
 #[test]
@@ -96,7 +96,10 @@ fn test_login_flag_recognized() {
     // Just check it doesn't fail with "unknown option"
     if let Ok(out) = output {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(!stderr.contains("Unknown option: -l"), "Login flag should be recognized");
+        assert!(
+            !stderr.contains("Unknown option: -l"),
+            "Login flag should be recognized"
+        );
     }
 }
 
@@ -113,14 +116,17 @@ fn test_login_long_flag() {
 
     if let Ok(out) = output {
         let stderr = String::from_utf8_lossy(&out.stderr);
-        assert!(!stderr.contains("Unknown option: --login"), "Login long flag should be recognized");
+        assert!(
+            !stderr.contains("Unknown option: --login"),
+            "Login long flag should be recognized"
+        );
     }
 }
 
 #[test]
 fn test_login_shell_sources_profile() {
-    use std::process::Command;
     use std::fs;
+    use std::process::Command;
 
     // Create temp directory with .hsab_profile
     let temp_dir = tempfile::tempdir().unwrap();
@@ -136,8 +142,10 @@ fn test_login_shell_sources_profile() {
 
     if let Ok(out) = output {
         // Should succeed (exit 0) because test_profile_loaded was defined
-        assert!(out.status.success() || out.status.code() == Some(0),
-            "Profile should be sourced in login mode");
+        assert!(
+            out.status.success() || out.status.code() == Some(0),
+            "Profile should be sourced in login mode"
+        );
     }
 }
 
@@ -165,7 +173,10 @@ fn test_source_executes_file() {
     let result = evaluator.eval(&program);
 
     // Should succeed because was_sourced should be defined
-    assert!(result.is_ok(), ".source should execute file and define words");
+    assert!(
+        result.is_ok(),
+        ".source should execute file and define words"
+    );
 }
 
 #[test]
@@ -219,8 +230,15 @@ fn test_stdin_redirect() {
     std::fs::write(temp_file.path(), "hello from file\n").unwrap();
 
     // #[cat] #[input.txt] < should feed file to cat's stdin
-    let output = eval(&format!("#[cat] #[{}] <", temp_file.path().to_str().unwrap())).unwrap();
-    assert!(output.contains("hello from file"), "stdin redirect should work");
+    let output = eval(&format!(
+        "#[cat] #[{}] <",
+        temp_file.path().to_str().unwrap()
+    ))
+    .unwrap();
+    assert!(
+        output.contains("hello from file"),
+        "stdin redirect should work"
+    );
     // temp_file auto-cleans up on drop
 }
 
@@ -230,7 +248,11 @@ fn test_stderr_to_stdout_redirect() {
     // Use bash -c to run a command that outputs to stderr
     let output = eval(r#"#["echo error >&2" -c bash] 2>&1"#).unwrap();
     // The error message should appear in output
-    assert!(output.contains("error"), "stderr should be redirected to stdout: got {}", output);
+    assert!(
+        output.contains("error"),
+        "stderr should be redirected to stdout: got {}",
+        output
+    );
 }
 
 #[test]
@@ -256,8 +278,11 @@ fn test_cd_home() {
     let output = eval("cd").unwrap();
     std::env::set_current_dir(&original_dir).unwrap();
     // Should contain a path string (not nil)
-    assert!(!output.trim().is_empty() && output.trim() != "nil",
-        "cd to home should push path, got: {}", output);
+    assert!(
+        !output.trim().is_empty() && output.trim() != "nil",
+        "cd to home should push path, got: {}",
+        output
+    );
 }
 
 #[test]
@@ -427,8 +452,8 @@ fn test_unalias_remove() {
 #[test]
 fn test_hash_command() {
     let output = eval(r#".hash"#).unwrap();
-    // hash should output cached paths or be empty
-    assert!(output.is_empty() || output.len() >= 0);
+    // hash should output cached paths or be empty; not panicking is the test.
+    let _ = output;
 }
 
 #[test]

--- a/tests/test_shell_native.rs
+++ b/tests/test_shell_native.rs
@@ -21,8 +21,10 @@ fn test_touch_returns_path() {
     let output = eval(&cmd).unwrap();
 
     // Should return the path
-    assert!(output.contains(&tmp.to_string_lossy().to_string()) ||
-            output.contains("hsab_test_touch.txt"));
+    assert!(
+        output.contains(&tmp.to_string_lossy().to_string())
+            || output.contains("hsab_test_touch.txt")
+    );
 
     // File should exist
     assert!(tmp.exists());

--- a/tests/test_stack.rs
+++ b/tests/test_stack.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_literals_push_to_stack() {
@@ -156,8 +156,11 @@ fn test_subst_creates_file() {
 
     let output = eval("#[hello echo] subst").unwrap();
     let path = output.trim();
-    assert!(Path::new(path).exists() || path.contains("hsab_subst"),
-            "subst should create a temp file: {}", path);
+    assert!(
+        Path::new(path).exists() || path.contains("hsab_subst"),
+        "subst should create a temp file: {}",
+        path
+    );
     // Clean up
     std::fs::remove_file(path).ok();
 }
@@ -165,7 +168,11 @@ fn test_subst_creates_file() {
 #[test]
 fn test_subst_content() {
     let output = eval("#[hello echo] subst cat").unwrap();
-    assert!(output.contains("hello"), "subst should capture command output: {}", output);
+    assert!(
+        output.contains("hello"),
+        "subst should capture command output: {}",
+        output
+    );
 }
 
 #[test]
@@ -175,9 +182,9 @@ fn test_read_pushes_to_stack() {
     // and that it integrates with the stack model
     let tokens = hsab::lex("read").unwrap();
     let program = hsab::parse(tokens).unwrap();
-    let mut evaluator = Evaluator::new();
+    let _evaluator = Evaluator::new();
     // This will fail waiting for stdin in a test, but we can verify parsing works
-    assert!(program.expressions.len() > 0);
+    assert!(!program.expressions.is_empty());
 }
 
 #[test]
@@ -378,8 +385,11 @@ fn test_export_stack_value() {
     // value name .export - take value from stack
     std::env::remove_var("HSAB_STACK_TEST");
     let _output = eval("myvalue HSAB_STACK_TEST .export").unwrap();
-    assert_eq!(std::env::var("HSAB_STACK_TEST").unwrap(), "myvalue",
-               ".export should set env var from stack value");
+    assert_eq!(
+        std::env::var("HSAB_STACK_TEST").unwrap(),
+        "myvalue",
+        ".export should set env var from stack value"
+    );
     std::env::remove_var("HSAB_STACK_TEST");
 }
 
@@ -388,8 +398,11 @@ fn test_export_stack_value_with_spaces() {
     // Quoted value with spaces
     std::env::remove_var("HSAB_STACK_TEST2");
     let _output = eval("\"hello world\" HSAB_STACK_TEST2 .export").unwrap();
-    assert_eq!(std::env::var("HSAB_STACK_TEST2").unwrap(), "hello world",
-               ".export should handle values with spaces");
+    assert_eq!(
+        std::env::var("HSAB_STACK_TEST2").unwrap(),
+        "hello world",
+        ".export should handle values with spaces"
+    );
     std::env::remove_var("HSAB_STACK_TEST2");
 }
 
@@ -398,8 +411,11 @@ fn test_export_old_syntax_still_works() {
     // Old KEY=VALUE syntax should still work
     std::env::remove_var("HSAB_OLD_SYNTAX");
     let _output = eval("HSAB_OLD_SYNTAX=oldvalue .export").unwrap();
-    assert_eq!(std::env::var("HSAB_OLD_SYNTAX").unwrap(), "oldvalue",
-               "old KEY=VALUE .export syntax should still work");
+    assert_eq!(
+        std::env::var("HSAB_OLD_SYNTAX").unwrap(),
+        "oldvalue",
+        "old KEY=VALUE .export syntax should still work"
+    );
     std::env::remove_var("HSAB_OLD_SYNTAX");
 }
 
@@ -407,41 +423,67 @@ fn test_export_old_syntax_still_works() {
 fn test_local_stack_native_in_definition() {
     // value NAME local inside a definition
     std::env::set_var("HSAB_LOCAL_TEST", "original");
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[myvalue HSAB_LOCAL_TEST local $HSAB_LOCAL_TEST echo] :test_local
         test_local
-    "#).unwrap();
-    assert!(output.contains("myvalue"), "local should use stack value: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("myvalue"),
+        "local should use stack value: {}",
+        output
+    );
     // Original should be restored after definition exits
-    assert_eq!(std::env::var("HSAB_LOCAL_TEST").unwrap(), "original",
-               "original value should be restored after definition exits");
+    assert_eq!(
+        std::env::var("HSAB_LOCAL_TEST").unwrap(),
+        "original",
+        "original value should be restored after definition exits"
+    );
     std::env::remove_var("HSAB_LOCAL_TEST");
 }
 
 #[test]
 fn test_local_structured_list() {
     // Test that local preserves List values (not converting to string)
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[1,2,3,4,5]' from-json _MYLIST local
             $_MYLIST sum
         ] :sum_local_list
         sum_local_list
-    "#).unwrap();
-    assert_eq!(output.trim(), "15", "local should preserve List structure: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "15",
+        "local should preserve List structure: {}",
+        output
+    );
 }
 
 #[test]
 fn test_local_structured_list_count() {
     // Test that local Lists preserve structure and can use count
-    let output = eval(r#"
+    let output = eval(
+        r#"
         #[
             '[1,2,3,4]' from-json _NUMS local
             $_NUMS count
         ] :count_local
         count_local
-    "#).unwrap();
-    assert_eq!(output.trim(), "4", "local List should work with count: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.trim(),
+        "4",
+        "local List should work with count: {}",
+        output
+    );
 }
 
 #[test]
@@ -485,13 +527,18 @@ fn test_reject_basic() {
     // Keep items where predicate FAILS
     // Keep items that are NOT "b"
     let output = eval(r#"'["a","b","c"]' json #["b" eq?] reject to-json"#).unwrap();
-    assert!(output.contains("a") && output.contains("c"), "Should have a and c: {}", output);
+    assert!(
+        output.contains("a") && output.contains("c"),
+        "Should have a and c: {}",
+        output
+    );
     assert!(!output.contains(r#""b""#), "Should not have b: {}", output);
 }
 
 #[test]
 fn test_reject_where_table() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" 30 record
             "name" "bob" "age" 25 record
@@ -499,7 +546,9 @@ fn test_reject_where_table() {
         table
         #["age" get 30 ge?] reject-where
         count
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Only bob (age 25) should remain
     assert_eq!(output.trim(), "1");
 }

--- a/tests/test_stats.rs
+++ b/tests/test_stats.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_product_basic() {
@@ -77,7 +77,11 @@ fn test_variance_basic() {
     // [2, 4, 4, 4, 5, 5, 7, 9] -> mean=5, variance=4
     let output = eval("'[2,4,4,4,5,5,7,9]' from-json variance").unwrap();
     let val: f64 = output.trim().parse().unwrap();
-    assert!((val - 4.0).abs() < 0.0001, "Expected variance ~4.0, got {}", val);
+    assert!(
+        (val - 4.0).abs() < 0.0001,
+        "Expected variance ~4.0, got {}",
+        val
+    );
 }
 
 #[test]
@@ -85,7 +89,11 @@ fn test_sample_variance_basic() {
     // Same data, sample variance = 4 * 8/7 = 4.571...
     let output = eval("'[2,4,4,4,5,5,7,9]' from-json sample-variance").unwrap();
     let val: f64 = output.trim().parse().unwrap();
-    assert!((val - 4.571428).abs() < 0.001, "Expected sample-variance ~4.571, got {}", val);
+    assert!(
+        (val - 4.571428).abs() < 0.001,
+        "Expected sample-variance ~4.571, got {}",
+        val
+    );
 }
 
 #[test]
@@ -93,14 +101,22 @@ fn test_stdev_basic() {
     // stdev = sqrt(4) = 2
     let output = eval("'[2,4,4,4,5,5,7,9]' from-json stdev").unwrap();
     let val: f64 = output.trim().parse().unwrap();
-    assert!((val - 2.0).abs() < 0.0001, "Expected stdev ~2.0, got {}", val);
+    assert!(
+        (val - 2.0).abs() < 0.0001,
+        "Expected stdev ~2.0, got {}",
+        val
+    );
 }
 
 #[test]
 fn test_sample_stdev_basic() {
     let output = eval("'[2,4,4,4,5,5,7,9]' from-json sample-stdev").unwrap();
     let val: f64 = output.trim().parse().unwrap();
-    assert!((val - 2.13809).abs() < 0.001, "Expected sample-stdev ~2.138, got {}", val);
+    assert!(
+        (val - 2.13809).abs() < 0.001,
+        "Expected sample-stdev ~2.138, got {}",
+        val
+    );
 }
 
 #[test]

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -3,22 +3,28 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_triple_single_quote() {
     // Triple single quotes should preserve the content
     let output = eval("'''hello world''' echo").unwrap();
-    assert!(output.contains("hello") && output.contains("world"),
-            "triple single quotes should work: {}", output);
+    assert!(
+        output.contains("hello") && output.contains("world"),
+        "triple single quotes should work: {}",
+        output
+    );
 }
 
 #[test]
 fn test_triple_double_quote() {
     // Triple double quotes should work too
     let output = eval(r#""""test string""" echo"#).unwrap();
-    assert!(output.contains("test") && output.contains("string"),
-            "triple double quotes should work: {}", output);
+    assert!(
+        output.contains("test") && output.contains("string"),
+        "triple double quotes should work: {}",
+        output
+    );
 }
 
 #[test]
@@ -124,7 +130,11 @@ fn test_recursion_limit_triggered() {
 
     assert!(result.is_err(), "Infinite recursion should trigger error");
     let err_msg = result.unwrap_err();
-    assert!(err_msg.contains("Recursion limit"), "Error should mention recursion limit: {}", err_msg);
+    assert!(
+        err_msg.contains("Recursion limit"),
+        "Error should mention recursion limit: {}",
+        err_msg
+    );
 }
 
 #[test]
@@ -133,16 +143,27 @@ fn test_safe_recursion_works() {
     // Define countdown: if n > 0, decrement and recurse, else push "done"
     // New if order: #[else] #[then] condition if
     // Pattern: dup 0 gt? #[else-block] #[then-block] condition if
-    let output = eval(r#"#[#[dup 0 gt?] #[drop "done" echo] #[1 minus countdown] if] :countdown 3 countdown"#).unwrap();
+    let output = eval(
+        r#"#[#[dup 0 gt?] #[drop "done" echo] #[1 minus countdown] if] :countdown 3 countdown"#,
+    )
+    .unwrap();
     // Should terminate successfully
-    assert!(output.contains("done"), "Safe recursion should complete: {}", output);
+    assert!(
+        output.contains("done"),
+        "Safe recursion should complete: {}",
+        output
+    );
 }
 
 #[test]
 fn test_interpolation_simple() {
     std::env::set_var("HSAB_INTERP_SIMPLE", "world");
     let output = eval(r#""hello $HSAB_INTERP_SIMPLE" echo"#).unwrap();
-    assert!(output.contains("hello world"), "Should interpolate variable: {}", output);
+    assert!(
+        output.contains("hello world"),
+        "Should interpolate variable: {}",
+        output
+    );
     std::env::remove_var("HSAB_INTERP_SIMPLE");
 }
 
@@ -150,14 +171,22 @@ fn test_interpolation_simple() {
 fn test_interpolation_braces() {
     std::env::set_var("HSAB_INTERP_BRACE", "foo");
     let output = eval(r#""${HSAB_INTERP_BRACE}bar" echo"#).unwrap();
-    assert!(output.contains("foobar"), "Should interpolate with braces: {}", output);
+    assert!(
+        output.contains("foobar"),
+        "Should interpolate with braces: {}",
+        output
+    );
     std::env::remove_var("HSAB_INTERP_BRACE");
 }
 
 #[test]
 fn test_interpolation_escaped() {
     let output = eval(r#""price is \$100" echo"#).unwrap();
-    assert!(output.contains("$100"), "Should escape dollar sign: {}", output);
+    assert!(
+        output.contains("$100"),
+        "Should escape dollar sign: {}",
+        output
+    );
 }
 
 #[test]
@@ -242,7 +271,6 @@ fn test_printf_number() {
     assert!(output.contains("answer: 42"));
 }
 
-
 // === Recovered tests ===
 
 #[test]
@@ -266,7 +294,7 @@ fn test_len_whitespace_only() {
 #[test]
 fn test_len_unicode_emoji() {
     // Emoji should count as one character
-    let output = eval(r#""hello world" len"#).unwrap();
+    let _output = eval(r#""hello world" len"#).unwrap();
     // The emoji is 2 chars in this context (surrogate pair handling may vary)
     // Let's test with a simple multi-byte char
     let output2 = eval(r#""cafe" len"#).unwrap();
@@ -735,4 +763,3 @@ fn test_str_replace_at_end() {
     let output = eval(r#""abc" "c" "X" str-replace"#).unwrap();
     assert_eq!(output.trim(), "abX");
 }
-

--- a/tests/test_structured.rs
+++ b/tests/test_structured.rs
@@ -3,30 +3,39 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_json_parse() {
     let output = eval(r#"'{"name":"test","value":42}' json"#).unwrap();
     // JSON parsed to structured data, then displayed
-    assert!(output.contains("name") || output.contains("test"),
-            "json should parse JSON string: {}", output);
+    assert!(
+        output.contains("name") || output.contains("test"),
+        "json should parse JSON string: {}",
+        output
+    );
 }
 
 #[test]
 fn test_unjson_stringify() {
     // Create a value and stringify it
     let output = eval(r#"'{"x":1}' json unjson"#).unwrap();
-    assert!(output.contains("x") && output.contains("1"),
-            "unjson should stringify back to JSON: {}", output);
+    assert!(
+        output.contains("x") && output.contains("1"),
+        "unjson should stringify back to JSON: {}",
+        output
+    );
 }
 
 #[test]
 fn test_spread() {
     // spread: take list and push each element
     let output = eval(r#"'["a","b","c"]' json spread"#).unwrap();
-    assert!(output.contains("a") && output.contains("b") && output.contains("c"),
-            "spread should push each list element: {}", output);
+    assert!(
+        output.contains("a") && output.contains("b") && output.contains("c"),
+        "spread should push each list element: {}",
+        output
+    );
 }
 
 #[test]
@@ -34,8 +43,11 @@ fn test_marker_and_collect() {
     // marker pushes a boundary, collect gathers everything back to marker
     let output = eval("marker a b c collect").unwrap();
     // collect should produce a list
-    assert!(output.contains("a") && output.contains("b") && output.contains("c"),
-            "collect should gather items after marker: {}", output);
+    assert!(
+        output.contains("a") && output.contains("b") && output.contains("c"),
+        "collect should gather items after marker: {}",
+        output
+    );
 }
 
 #[test]
@@ -113,7 +125,11 @@ fn test_record_get_missing_field() {
     // Should either error or return nil/empty
     match result {
         Err(_) => (), // Expected - error for missing field
-        Ok(s) => assert!(s.trim().is_empty() || s.contains("null"), "missing field should be empty or null: {}", s),
+        Ok(s) => assert!(
+            s.trim().is_empty() || s.contains("null"),
+            "missing field should be empty or null: {}",
+            s
+        ),
     }
 }
 
@@ -175,14 +191,16 @@ fn test_record_merge_overwrites() {
 #[test]
 fn test_table_construction() {
     // table from records
-    let output = eval("marker \"name\" \"alice\" record \"name\" \"bob\" record table typeof").unwrap();
+    let output =
+        eval("marker \"name\" \"alice\" record \"name\" \"bob\" record table typeof").unwrap();
     assert_eq!(output.trim(), "table");
 }
 
 #[test]
 fn test_table_where_filter() {
     // Filter rows where condition is true
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" 30 record
             "name" "bob" "age" 25 record
@@ -190,45 +208,61 @@ fn test_table_where_filter() {
         table
         #["age" get 30 gt?] where
         "name" get
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Should only have carol (age > 30)
-    assert!(output.contains("carol"), "where should filter to carol: {}", output);
+    assert!(
+        output.contains("carol"),
+        "where should filter to carol: {}",
+        output
+    );
     assert!(!output.contains("alice"), "alice should be filtered out");
     assert!(!output.contains("bob"), "bob should be filtered out");
 }
 
 #[test]
 fn test_table_sort_by() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "bob" "age" 25 record
             "name" "alice" "age" 30 record
         table
         "name" sort-by
         0 nth "name" get
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // First after sorting by name should be alice
     assert_eq!(output.trim(), "alice");
 }
 
 #[test]
 fn test_table_select_columns() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" 30 "city" "NYC" record
         table
         #["name" "age"] select
         0 nth keys
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Should only have name and age, not city
-    assert!(output.contains("name") && output.contains("age"), "should have name and age");
+    assert!(
+        output.contains("name") && output.contains("age"),
+        "should have name and age"
+    );
     assert!(!output.contains("city"), "city should be removed");
 }
 
 #[test]
 fn test_table_first() {
     // Simpler test: just check that first returns a table with correct row count
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "n" "a" record
             "n" "b" record
@@ -236,16 +270,22 @@ fn test_table_first() {
         table
         2 first
         0 nth "n" get
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // First 2 rows, get row 0's "n" field - should be first record's value
     // After reverse, first record is {n:a}
-    assert!(output.trim() == "a" || output.trim() == "b" || output.trim() == "c",
-        "Expected a, b, or c but got: {}", output.trim());
+    assert!(
+        output.trim() == "a" || output.trim() == "b" || output.trim() == "c",
+        "Expected a, b, or c but got: {}",
+        output.trim()
+    );
 }
 
 #[test]
 fn test_table_last() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "n" 1 record
             "n" 2 record
@@ -253,19 +293,24 @@ fn test_table_last() {
         table
         1 last
         0 nth "n" get
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "3");
 }
 
 #[test]
 fn test_table_nth_row() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "n" "first" record
             "n" "second" record
         table
         1 nth "n" get
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "second");
 }
 
@@ -273,14 +318,23 @@ fn test_table_nth_row() {
 fn test_try_success() {
     let output = eval("#[hello echo] try typeof").unwrap();
     // Should return the output, not an error
-    assert!(output.contains("hello") || output.contains("string"), "try should return result on success: {}", output);
+    assert!(
+        output.contains("hello") || output.contains("string"),
+        "try should return result on success: {}",
+        output
+    );
 }
 
 #[test]
 fn test_try_captures_error() {
     // Use a stack underflow which definitely causes EvalError
     let output = eval("#[dup] try typeof").unwrap();
-    assert_eq!(output.trim(), "error", "try should capture error: {}", output);
+    assert_eq!(
+        output.trim(),
+        "error",
+        "try should capture error: {}",
+        output
+    );
 }
 
 #[test]
@@ -293,7 +347,10 @@ fn test_error_predicate_true() {
 #[test]
 fn test_error_predicate_false() {
     let code = eval_exit_code("#[hello echo] try error?");
-    assert_eq!(code, 1, "error? should return 1 (false) for non-Error value");
+    assert_eq!(
+        code, 1,
+        "error? should return 1 (false) for non-Error value"
+    );
 }
 
 #[test]
@@ -305,7 +362,11 @@ fn test_throw_creates_error() {
 #[test]
 fn test_error_has_message() {
     let output = eval("\"my error message\" throw \"message\" get").unwrap();
-    assert!(output.contains("my error message"), "error should have message field: {}", output);
+    assert!(
+        output.contains("my error message"),
+        "error should have message field: {}",
+        output
+    );
 }
 
 #[test]
@@ -359,26 +420,46 @@ fn test_from_kv_content() {
 #[test]
 fn test_to_json_record() {
     let output = eval("\"name\" \"test\" record to-json").unwrap();
-    assert!(output.contains("name") && output.contains("test"), "to-json should serialize record: {}", output);
+    assert!(
+        output.contains("name") && output.contains("test"),
+        "to-json should serialize record: {}",
+        output
+    );
 }
 
 #[test]
 fn test_to_json_list() {
     let output = eval("'[1,2,3]' from-json to-json").unwrap();
-    assert!(output.contains("[") && output.contains("1") && output.contains("2") && output.contains("3"));
+    assert!(
+        output.contains("[")
+            && output.contains("1")
+            && output.contains("2")
+            && output.contains("3")
+    );
 }
 
 #[test]
 fn test_to_csv_table() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" "30" record
             "name" "bob" "age" "25" record
         table
         to-csv
-    "#).unwrap();
-    assert!(output.contains("name") && output.contains("age"), "to-csv should have headers: {}", output);
-    assert!(output.contains("alice") && output.contains("bob"), "to-csv should have data: {}", output);
+    "#,
+    )
+    .unwrap();
+    assert!(
+        output.contains("name") && output.contains("age"),
+        "to-csv should have headers: {}",
+        output
+    );
+    assert!(
+        output.contains("alice") && output.contains("bob"),
+        "to-csv should have data: {}",
+        output
+    );
 }
 
 #[test]
@@ -404,7 +485,11 @@ fn test_flat_record_auto_serializes_to_kv() {
     // When a flat record is passed to an external command via pipe,
     // it should auto-serialize to key=value format
     let output = eval("\"name\" \"test\" record #[cat] |").unwrap();
-    assert!(output.contains("name=test"), "Flat record should auto-serialize to key=value: {}", output);
+    assert!(
+        output.contains("name=test"),
+        "Flat record should auto-serialize to key=value: {}",
+        output
+    );
 }
 
 #[test]
@@ -412,7 +497,11 @@ fn test_nested_record_auto_serializes_to_json() {
     // When a nested record is passed to an external command via pipe,
     // it should auto-serialize to JSON format
     let output = eval("\"outer\" \"inner\" \"val\" record record #[cat] |").unwrap();
-    assert!(output.contains("{") && output.contains("}"), "Nested record should auto-serialize to JSON: {}", output);
+    assert!(
+        output.contains("{") && output.contains("}"),
+        "Nested record should auto-serialize to JSON: {}",
+        output
+    );
 }
 
 #[test]
@@ -447,20 +536,25 @@ fn test_count_list() {
 
 #[test]
 fn test_count_table() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" record
             "name" "bob" record
             "name" "charlie" record
         table
         count
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "3");
 }
 
 #[test]
 fn test_deep_get_nested() {
-    let output = eval(r#"'{"server":{"host":"localhost","port":8080}}' from-json "server.port" get"#).unwrap();
+    let output =
+        eval(r#"'{"server":{"host":"localhost","port":8080}}' from-json "server.port" get"#)
+            .unwrap();
     assert_eq!(output.trim(), "8080");
 }
 
@@ -478,7 +572,8 @@ fn test_deep_get_missing() {
 
 #[test]
 fn test_group_by() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "type" "fruit" "name" "apple" record
             "type" "veg" "name" "carrot" record
@@ -486,13 +581,16 @@ fn test_group_by() {
         table
         "type" group-by
         typeof
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "record");
 }
 
 #[test]
 fn test_group_by_access() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "type" "a" "val" "1" record
             "type" "b" "val" "2" record
@@ -501,7 +599,9 @@ fn test_group_by_access() {
         "type" group-by
         "a" get
         count
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert_eq!(output.trim(), "2");
 }
 
@@ -541,7 +641,11 @@ fn test_brace_expansion_comma() {
     // {a,b,c} should expand to three stack items
     let output = eval("{a,b,c} depth").unwrap();
     // depth returns 3 (three items: a, b, c), then all items are output
-    assert!(output.contains("3"), "depth should show 3 items on stack: {}", output);
+    assert!(
+        output.contains("3"),
+        "depth should show 3 items on stack: {}",
+        output
+    );
 }
 
 #[test]
@@ -568,51 +672,78 @@ fn test_brace_expansion_prefix_suffix() {
 #[test]
 fn test_sort_by_list_of_records() {
     // Parse JSON array and sort by field
-    let output = eval(r#"'[{"name":"bob"},{"name":"alice"}]' json "name" sort-by to-json"#).unwrap();
+    let output =
+        eval(r#"'[{"name":"bob"},{"name":"alice"}]' json "name" sort-by to-json"#).unwrap();
     // After sorting by "name", alice should come before bob
-    assert!(output.find("alice").unwrap() < output.find("bob").unwrap(),
-        "alice should come before bob after sort-by name: {}", output);
+    assert!(
+        output.find("alice").unwrap() < output.find("bob").unwrap(),
+        "alice should come before bob after sort-by name: {}",
+        output
+    );
 }
 
 #[test]
 fn test_sort_by_list_numeric() {
     // Sort by numeric field
-    let output = eval(r#"'[{"age":30},{"age":20},{"age":25}]' json "age" sort-by to-json"#).unwrap();
+    let output =
+        eval(r#"'[{"age":30},{"age":20},{"age":25}]' json "age" sort-by to-json"#).unwrap();
     // After sorting by "age", order should be 20, 25, 30
     let pos_20 = output.find("20").unwrap();
     let pos_25 = output.find("25").unwrap();
     let pos_30 = output.find("30").unwrap();
-    assert!(pos_20 < pos_25 && pos_25 < pos_30,
-        "Should be sorted by age ascending: {}", output);
+    assert!(
+        pos_20 < pos_25 && pos_25 < pos_30,
+        "Should be sorted by age ascending: {}",
+        output
+    );
 }
 
 #[test]
 fn test_sort_by_table_still_works() {
     // Ensure table sort-by still works
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
         "name" "Bob" record
         "name" "Alice" record
         table
         "name" sort-by
         to-json
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Alice should come before Bob
-    assert!(output.find("Alice").unwrap() < output.find("Bob").unwrap(),
-        "Table sort-by should still work: {}", output);
+    assert!(
+        output.find("Alice").unwrap() < output.find("Bob").unwrap(),
+        "Table sort-by should still work: {}",
+        output
+    );
 }
 
 #[test]
 fn test_deep_set_nested_value() {
-    let output = eval(r#"'{"server":{"host":"localhost"}}' json "server.port" 9090 set to-json"#).unwrap();
-    assert!(output.contains("9090"), "Should set nested value: {}", output);
-    assert!(output.contains("localhost"), "Should preserve existing values: {}", output);
+    let output =
+        eval(r#"'{"server":{"host":"localhost"}}' json "server.port" 9090 set to-json"#).unwrap();
+    assert!(
+        output.contains("9090"),
+        "Should set nested value: {}",
+        output
+    );
+    assert!(
+        output.contains("localhost"),
+        "Should preserve existing values: {}",
+        output
+    );
 }
 
 #[test]
 fn test_deep_set_creates_new_path() {
     let output = eval(r#"'{}' json "a.b.c" "deep" set to-json"#).unwrap();
-    assert!(output.contains("deep"), "Should create nested path: {}", output);
+    assert!(
+        output.contains("deep"),
+        "Should create nested path: {}",
+        output
+    );
 }
 
 #[test]
@@ -620,8 +751,11 @@ fn test_ls_table_returns_table() {
     // ls-table should return a table with name, type, size, modified columns
     let output = eval(r#"ls-table to-json"#).unwrap();
     // Should have column headers in the output
-    assert!(output.contains("name") || output.contains("type"),
-        "ls-table should produce a table: {}", output);
+    assert!(
+        output.contains("name") || output.contains("type"),
+        "ls-table should produce a table: {}",
+        output
+    );
 }
 
 #[test]
@@ -630,7 +764,11 @@ fn test_ls_table_with_path() {
     let output = eval(r#"/tmp ls-table count"#).unwrap();
     // Should return a count (number)
     let count: i32 = output.trim().parse().unwrap_or(-1);
-    assert!(count >= 0, "ls-table should produce countable table: {}", output);
+    assert!(
+        count >= 0,
+        "ls-table should produce countable table: {}",
+        output
+    );
 }
 
 #[test]
@@ -644,7 +782,11 @@ fn test_open_json_file() {
     writeln!(f, r#"{{"name":"test","value":42}}"#).unwrap();
 
     let output = eval(&format!(r#""{}" open "name" get"#, path)).unwrap();
-    assert!(output.contains("test"), "Should parse JSON file: {}", output);
+    assert!(
+        output.contains("test"),
+        "Should parse JSON file: {}",
+        output
+    );
 
     std::fs::remove_file(path).ok();
 }
@@ -661,36 +803,62 @@ fn test_open_csv_file() {
 
     let output = eval(&format!(r#""{}" open count"#, path)).unwrap();
     // Should have 2 rows
-    assert!(output.contains("2"), "Should parse CSV file with 2 rows: {}", output);
+    assert!(
+        output.contains("2"),
+        "Should parse CSV file with 2 rows: {}",
+        output
+    );
 
     std::fs::remove_file(path).ok();
 }
 
 #[test]
 fn test_to_tsv_basic() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" "age" "30" record
             "name" "bob" "age" "25" record
         table
         to-tsv
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Column order isn't guaranteed due to hash maps, so just check tabs and values
-    assert!(output.contains("\t"), "Should have tab separators: {}", output);
-    assert!(output.contains("name") && output.contains("age"), "Should have headers: {}", output);
-    assert!(output.contains("alice") && output.contains("bob"), "Should have data: {}", output);
+    assert!(
+        output.contains("\t"),
+        "Should have tab separators: {}",
+        output
+    );
+    assert!(
+        output.contains("name") && output.contains("age"),
+        "Should have headers: {}",
+        output
+    );
+    assert!(
+        output.contains("alice") && output.contains("bob"),
+        "Should have data: {}",
+        output
+    );
 }
 
 #[test]
 fn test_to_delimited_pipe() {
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "name" "alice" record
         table
         "|" to-delimited
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     // Column order isn't guaranteed due to hash maps, so just check it's pipe-delimited
-    assert!(output.contains("|") || output.contains("name"), "Should have pipe delimiter or column: {}", output);
+    assert!(
+        output.contains("|") || output.contains("name"),
+        "Should have pipe delimiter or column: {}",
+        output
+    );
     assert!(output.contains("alice"), "Should have data: {}", output);
 }
 
@@ -702,7 +870,11 @@ fn test_save_json() {
     let _ = eval(&format!(r#""name" "test" record "{}" save"#, path));
 
     let content = fs::read_to_string(path).unwrap();
-    assert!(content.contains("name") && content.contains("test"), "Should save JSON: {}", content);
+    assert!(
+        content.contains("name") && content.contains("test"),
+        "Should save JSON: {}",
+        content
+    );
 
     fs::remove_file(path).ok();
 }
@@ -712,15 +884,22 @@ fn test_save_csv() {
     use std::fs;
 
     let path = "/tmp/hsab_test_save.csv";
-    let _ = eval(&format!(r#"
+    let _ = eval(&format!(
+        r#"
         marker
             "name" "alice" "age" "30" record
         table
         "{}" save
-    "#, path));
+    "#,
+        path
+    ));
 
     let content = fs::read_to_string(path).unwrap();
-    assert!(content.contains("name") && content.contains("alice"), "Should save CSV: {}", content);
+    assert!(
+        content.contains("name") && content.contains("alice"),
+        "Should save CSV: {}",
+        content
+    );
 
     fs::remove_file(path).ok();
 }
@@ -760,8 +939,11 @@ fn test_reduce_concat() {
     let output = eval(r#"'["a","b","c"]' json "" #[suffix] reduce"#).unwrap();
     // The result depends on suffix order - just check all chars are present
     let trimmed = output.trim();
-    assert!(trimmed.contains("a") && trimmed.contains("b") && trimmed.contains("c"),
-            "Should contain a, b, c: {}", trimmed);
+    assert!(
+        trimmed.contains("a") && trimmed.contains("b") && trimmed.contains("c"),
+        "Should contain a, b, c: {}",
+        trimmed
+    );
     assert_eq!(trimmed.len(), 3, "Should be exactly 3 chars");
 }
 
@@ -777,7 +959,8 @@ fn test_get_missing_key() {
     // Get on missing key - behavior varies
     let exit_code = eval_exit_code(r#"record "missing" get"#);
     // May error or return nil, just verify it runs
-    assert!(exit_code == 0 || exit_code != 0);
+    // Smoke assertion: reaching here without panicking is the test.
+    let _ = exit_code;
 }
 
 #[test]
@@ -812,12 +995,15 @@ fn test_reverse_empty_list() {
 #[test]
 fn test_group_by_creates_record() {
     // group-by needs a table and produces a Record
-    let output = eval(r#"
+    let output = eval(
+        r#"
         marker
             "k" "a" "v" 1 record
             "k" "a" "v" 2 record
         table "k" group-by typeof
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
     assert!(output.contains("record"));
 }
 
@@ -977,18 +1163,27 @@ fn test_set_in_record() {
 fn test_type_error_uses_type_name_not_debug() {
     // `get` on a non-record: error message must say "string", not Literal("...")
     let err = eval(r#""not-a-record" "key" get"#).unwrap_err();
-    assert!(err.contains("got string"),
-            "TypeError should use hsab type name, got: {}", err);
-    assert!(!err.contains("Literal("),
-            "TypeError must not leak Rust Debug repr: {}", err);
+    assert!(
+        err.contains("got string"),
+        "TypeError should use hsab type name, got: {}",
+        err
+    );
+    assert!(
+        !err.contains("Literal("),
+        "TypeError must not leak Rust Debug repr: {}",
+        err
+    );
 }
 
 #[test]
 fn test_type_error_block_expected() {
     // `where` requires a block predicate; a number should report "number"
     let err = eval(r#"5 3 where"#).unwrap_err();
-    assert!(!err.contains("Number("),
-            "TypeError must not leak Rust Debug repr: {}", err);
+    assert!(
+        !err.contains("Number("),
+        "TypeError must not leak Rust Debug repr: {}",
+        err
+    );
 }
 
 #[test]

--- a/tests/test_structured.rs
+++ b/tests/test_structured.rs
@@ -968,3 +968,36 @@ fn test_set_in_record() {
     let output = eval(r#""a" 1 record "a" 999 set"#).unwrap();
     assert!(output.contains("999"));
 }
+
+// ============================================
+// Issue #33: human-readable type names in errors
+// ============================================
+
+#[test]
+fn test_type_error_uses_type_name_not_debug() {
+    // `get` on a non-record: error message must say "string", not Literal("...")
+    let err = eval(r#""not-a-record" "key" get"#).unwrap_err();
+    assert!(err.contains("got string"),
+            "TypeError should use hsab type name, got: {}", err);
+    assert!(!err.contains("Literal("),
+            "TypeError must not leak Rust Debug repr: {}", err);
+}
+
+#[test]
+fn test_type_error_block_expected() {
+    // `where` requires a block predicate; a number should report "number"
+    let err = eval(r#"5 3 where"#).unwrap_err();
+    assert!(!err.contains("Number("),
+            "TypeError must not leak Rust Debug repr: {}", err);
+}
+
+#[test]
+fn test_value_type_names() {
+    use hsab::Value;
+    assert_eq!(Value::Literal("x".into()).type_name(), "string");
+    assert_eq!(Value::Number(1.5).type_name(), "number");
+    assert_eq!(Value::Bool(true).type_name(), "boolean");
+    assert_eq!(Value::List(vec![]).type_name(), "list");
+    assert_eq!(Value::Nil.type_name(), "nil");
+    assert_eq!(Value::Bytes(vec![]).type_name(), "bytes");
+}

--- a/tests/test_type_logic.rs
+++ b/tests/test_type_logic.rs
@@ -3,16 +3,30 @@ mod common;
 use common::{eval, eval_exit_code};
 
 #[test]
-fn test_number_pred() { assert_eq!(eval_exit_code("42 number?"), 0); }
+fn test_number_pred() {
+    assert_eq!(eval_exit_code("42 number?"), 0);
+}
 #[test]
-fn test_string_pred() { assert_eq!(eval_exit_code("\"hi\" string?"), 0); }
+fn test_string_pred() {
+    assert_eq!(eval_exit_code("\"hi\" string?"), 0);
+}
 #[test]
-fn test_typeof_number() { assert_eq!(eval("42 typeof").unwrap().trim(), "number"); }
+fn test_typeof_number() {
+    assert_eq!(eval("42 typeof").unwrap().trim(), "number");
+}
 #[test]
-fn test_typeof_string() { assert_eq!(eval("\"hi\" typeof").unwrap().trim(), "string"); }
+fn test_typeof_string() {
+    assert_eq!(eval("\"hi\" typeof").unwrap().trim(), "string");
+}
 #[test]
-fn test_not_true() { assert_ne!(eval_exit_code("true not"), 0); }
+fn test_not_true() {
+    assert_ne!(eval_exit_code("true not"), 0);
+}
 #[test]
-fn test_not_false() { assert_eq!(eval_exit_code("false not"), 0); }
+fn test_not_false() {
+    assert_eq!(eval_exit_code("false not"), 0);
+}
 #[test]
-fn test_empty_string() { assert_eq!(eval_exit_code("\"\" empty?"), 0); }
+fn test_empty_string() {
+    assert_eq!(eval_exit_code("\"\" empty?"), 0);
+}

--- a/tests/test_unified_control.rs
+++ b/tests/test_unified_control.rs
@@ -28,7 +28,11 @@ fn test_if_two_arg_form_true() {
 fn test_if_two_arg_false_no_output() {
     // Two-arg if with false condition: nothing should happen
     let output = eval(r#"#["yes" echo] false if"#).unwrap();
-    assert!(output.trim().is_empty(), "false condition with no else should produce no output, got: {}", output);
+    assert!(
+        output.trim().is_empty(),
+        "false condition with no else should produce no output, got: {}",
+        output
+    );
 }
 
 // ===== New times order: #[block] N times =====
@@ -92,7 +96,8 @@ fn test_elseif_second_branch_taken() {
 #[test]
 fn test_else_after_all_false() {
     // All conditions false, else runs
-    let program = r#"#["first" echo] false if #["second" echo] false elseif #["fallback" echo] else"#;
+    let program =
+        r#"#["first" echo] false if #["second" echo] false elseif #["fallback" echo] else"#;
     let output = eval(program).unwrap();
     assert_eq!(output.trim(), "fallback");
 }

--- a/tests/test_vector.rs
+++ b/tests/test_vector.rs
@@ -3,7 +3,7 @@
 #[path = "common/mod.rs"]
 mod common;
 #[allow(unused_imports)]
-use common::{eval, eval_exit_code, Evaluator, lex, parse};
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
 
 #[test]
 fn test_dot_product() {
@@ -30,14 +30,22 @@ fn test_magnitude_3d() {
 fn test_normalize() {
     // normalize [3,4] = [0.6, 0.8]
     let output = eval(r#"'[3,4]' json normalize to-json"#).unwrap();
-    assert!(output.contains("0.6") && output.contains("0.8"), "Should be unit vector: {}", output);
+    assert!(
+        output.contains("0.6") && output.contains("0.8"),
+        "Should be unit vector: {}",
+        output
+    );
 }
 
 #[test]
 fn test_normalize_zero_vector() {
     // normalize [0,0] = [0,0]
     let output = eval(r#"'[0,0]' json normalize to-json"#).unwrap();
-    assert!(output.contains("0"), "Zero vector should stay zero: {}", output);
+    assert!(
+        output.contains("0"),
+        "Zero vector should stay zero: {}",
+        output
+    );
 }
 
 #[test]
@@ -81,4 +89,3 @@ fn test_vector_ops_length_mismatch() {
     let result = eval(r#"'[1,2,3]' json '[1,2]' json dot-product"#);
     assert!(result.is_err(), "Should error on length mismatch");
 }
-


### PR DESCRIPTION
Implements the robustness/infrastructure track in dependency order (one commit per issue):

- #23 `Value::Map` → IndexMap: records/keys/columns/JSON now deterministic, insertion-ordered
- #32 single source of truth for builtins: registry-backed REPL completion, OnceLock-cached set, ~60 dead dispatch arms removed, drift-guard tests
- #33 (partial, refs) `Value::type_name()` — no more `{:?}` Debug leaks in user-facing errors; source spans deferred
- #31 mutex-poison hardening (`lock_or_recover`, 38 sites) — a panic in a handler no longer kills the shell
- #29 futures registry — `futures-list` actually lists futures with statuses
- #35 prompt perf: one cached `git status --porcelain=v2` call instead of 3 subprocesses per prompt; unused `ctrlc` dep removed
- #30 SIGCHLD job reaping: no more zombies; `.jobs`/`wait`/`.fg` work as documented
- #34 hermetic tests (local test server replaces live httpbin), 15 CLI/REPL integration tests, CI (fmt/clippy -D warnings/test/no-default-features), ~40 clippy lints fixed

Also fixes a discovered bug: `execute_script` silently dropped any line starting with `#[block]` (treated as comment).

Suite: **1306 passed, 0 failed**; fmt + clippy clean; both feature builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)