### PR TITLE
Execute wave 2: structured model completion + v0.2.0 release prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "hsab"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hsab"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Hash Backwards - A postfix notation shell"
 license = "MIT"

--- a/Formula/hsab.rb
+++ b/Formula/hsab.rb
@@ -1,9 +1,8 @@
 class Hsab < Formula
   desc "Stack-based postfix shell with persistent state between commands"
   homepage "https://github.com/johnhenry/bash-backwards"
-  url "https://github.com/johnhenry/bash-backwards.git",
-      tag:      "v0.1.0",
-      revision: ""
+  url "https://github.com/johnhenry/bash-backwards/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "PLACEHOLDER_UPDATED_ON_RELEASE"
   license "MIT"
   head "https://github.com/johnhenry/bash-backwards.git", branch: "main"
 
@@ -18,7 +17,7 @@ class Hsab < Formula
   end
 
   test do
-    assert_match "hsab-0.1.0", shell_output("#{bin}/hsab --version")
+    assert_match "hsab-0.2.0", shell_output("#{bin}/hsab --version")
     assert_equal "hello", shell_output("#{bin}/hsab -c '\"hello\" echo'").strip
   end
 end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 John Henry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -307,7 +307,10 @@ test -f file            # or: file -f .test
 
 Run `hsab --help` for the complete builtin reference, including:
 
-- **Structured Data**: Records, tables, JSON parsing (`record`, `table`, `json`, `get`, `set`, `where`, `sort-by`, `select`)
+- **Structured Data**: Records, tables, JSON parsing (`record`, `table`, `json`, `get`, `set`, `where`, `sort-by`, `sort-by-desc`, `select`, `group-by`, `join-on`, `add-column`, `map-column`, `rename-column`, `transpose`, `first`, `last`, `nth`)
+- **Structured Builtins**: Everyday commands as tables/records (`ls-t`, `ps-t`, `env-t`, `which-t`, `history-t`) — see [Structured Data](docs/structured-data.md)
+- **Numbers**: First-class integers and floats with strict coercion (`2 3 plus typeof` → `int`; overflow promotes to `BigInt`)
+- **Command Boundary**: Failed external commands push a structured `Error` (stderr, exit code, argv); non-UTF-8 output is preserved as `Bytes`
 - **Serialization**: Convert between text and structured data (`into-csv`, `from-csv`, `into-tsv`, `from-tsv`, `into-json`, `from-json`, `into-kv`, `from-kv`)
 - **File I/O**: Auto-formatting read/write (`open`, `save` — format based on extension)
 - **Vector Ops**: For AI embeddings (`dot-product`, `magnitude`, `normalize`, `cosine-similarity`, `euclidean-distance`)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -242,7 +242,8 @@ hsab has the following value types (from `Value` enum):
 |------|-------------|---------|
 | `Literal` | A string value | `"hello"`, `file.txt` |
 | `Output` | Command output | Result of `ls` |
-| `Number` | Floating-point number | `42`, `3.14` |
+| `Int` | 64-bit integer | `42`, `-7` |
+| `Number` | Floating-point number | `3.14`, `2.5` |
 | `Bool` | Boolean | `true`, `false` |
 | `Nil` | Empty/null value | Empty output |
 | `List` | Ordered collection | `[1, 2, 3]` |
@@ -260,9 +261,10 @@ hsab has the following value types (from `Value` enum):
 ### Type Introspection
 
 ```hsab
-42 typeof               # "Number"
-"hello" typeof          # "Literal"
-[1, 2, 3] typeof        # "List"
+42 typeof               # "int"
+3.14 typeof             # "float"
+"hello" typeof          # "string"
+[1, 2, 3] typeof        # "list"
 ```
 
 ---
@@ -301,6 +303,22 @@ snapshot-clear              # Clear all snapshots
 ---
 
 ## Arithmetic
+
+### Numeric Types and Promotion
+
+Integer literals (e.g. `42`, `-7`) are first-class `Int` values (64-bit);
+literals with a decimal point (e.g. `3.14`) are floats. Arithmetic promotes:
+
+- `Int op Int` → `Int` (checked); on i64 overflow the result is promoted to
+  `BigInt` when non-negative, otherwise to a float
+- `Int op Float` (either order) → `Float`
+- `BigInt` operands stay `BigInt` where the result is non-negative,
+  otherwise fall back to floats
+- `div` on two Ints yields an `Int` only when the division is exact
+  (`6 2 div` → `3`, `5 2 div` → `2.5`)
+
+Arithmetic is **strict**: a non-numeric operand (e.g. `"abc" 3 plus`) is a
+type error, not a silent `0`.
 
 ### Basic Operations
 

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -430,7 +430,38 @@ Examples:
 
 Column order is deterministic (records preserve insertion order via IndexMap).
 
-## 7. Common Patterns
+## 7. Structured Core Builtins
+
+Structured variants of everyday commands return tables/records directly
+(issue #27). They are additive: the plain text builtins are unchanged.
+
+| Builtin | Result | Example |
+|---------|--------|---------|
+| `ls-t` | `Table{name, type, size, modified}` | `ls-t "size" get sum` |
+| `ps-t` | `Table{pid, name, cpu, mem, status}` | `ps-t #["mem" get 1000000 gt?] where` |
+| `env-t` | `Record` of environment variables | `env-t "PATH" get` |
+| `which-t` | `Record{name, path, type}` | `"sh" which-t "path" get` |
+| `history-t` | `Table{index, command}` | `history-t 10 last` |
+
+Notes:
+
+- `ls-t` types are `file`/`dir`/`symlink`/`other` (symlinks not followed);
+  `size` is bytes, `modified` is a Unix timestamp.
+- `ps-t` reads `/proc` on Linux and shells out to `ps` on macOS; `cpu` is
+  cumulative CPU seconds, `mem` is resident set size in bytes.
+- `history-t` reads the saved REPL history file (`~/.hsab_history`); the
+  current session's entries appear after they are flushed on exit.
+- Column order is deterministic (IndexMap insertion order).
+
+```hsab
+# Directories only
+ls-t #["type" get "dir" eq?] where "name" get
+
+# Total size of files in a directory
+ls-t #["type" get "file" eq?] where "size" get sum
+```
+
+## 8. Common Patterns
 
 ### Transforming Lists of Records
 

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -302,7 +302,37 @@ $_Z echo    # 30
 
 ---
 
-## 4. JSON Interop
+## 4. External Command Boundary
+
+External (non-builtin) commands return structured values (issue #25):
+
+- **Success, UTF-8 stdout** — pushed as `Output` (unchanged behavior).
+- **Success, empty stdout** — pushed as `Nil` (unchanged behavior).
+- **Success, non-UTF-8 stdout** — pushed as `Bytes`, preserving the exact
+  bytes (previously the output was lossily re-encoded).
+- **Non-zero exit** — pushes a structured `Error` value instead of output:
+
+```hsab
+/no/such/dir /bin/ls           # pushes Error{kind: "command", ...}
+dup error?                     # true
+"message" get                  # the command's stderr (trimmed)
+```
+
+The `Error` carries:
+
+| Field | Contents |
+|-------|----------|
+| `kind` | `"command"` |
+| `message` | captured stderr (trimmed), or `exited N` if stderr was empty |
+| `code` | the exit code |
+| `command` | the argv that was run |
+
+Errors are recoverable values: the REPL stays alive, `$?` still reflects the
+exit code, and you can branch with `dup error? #[...] #[...] if`. Stderr is
+still discarded on success (shell norms) unless you redirect it explicitly
+(`2>`, `&>`, `2>&1`).
+
+## 5. JSON Interop
 
 ### Parsing JSON
 
@@ -362,7 +392,7 @@ table "data.csv" save                          # Writes CSV
 
 ---
 
-## 5. Common Patterns
+## 6. Common Patterns
 
 ### Transforming Lists of Records
 

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -392,7 +392,45 @@ table "data.csv" save                          # Writes CSV
 
 ---
 
-## 6. Common Patterns
+## 6. Table Operations
+
+Tables support a full set of transformation operations (issue #26). All are
+immutable: they return a new table.
+
+| Operation | Stack Effect | Description |
+|-----------|--------------|-------------|
+| `where` | `Table #[pred] -- Table` | Keep rows where the predicate passes (row pushed as Record) |
+| `sort-by` | `Table "col" -- Table` | Sort ascending by column (numeric-aware) |
+| `sort-by-desc` | `Table "col" -- Table` | Sort descending by column |
+| `select` | `Table [cols] -- Table` | Keep only the named columns |
+| `first` | `Table N -- Table` | First N rows |
+| `last` | `Table N -- Table` | Last N rows |
+| `nth` | `Table N -- Record` | Row N as a Record |
+| `group-by` | `Table "col" -- Record` | Record mapping each distinct value of `col` to a sub-Table |
+| `join-on` | `Left Right "lkey" "rkey" -- Table` | Inner join; right key column dropped, colliding right columns suffixed `_right` |
+| `add-column` | `Table #[block] "name" -- Table` | New column computed per row (row pushed as Record; block result is the cell) |
+| `map-column` | `Table "col" #[block] -- Table` | Transform `col` in place (cell pushed; block result replaces it) |
+| `rename-column` | `Table "old" "new" -- Table` | Rename a column |
+| `transpose` | `Table -- Table` | Swap rows/columns: result has a `column` column plus one column per original row (`0`, `1`, ...) |
+
+Examples:
+
+```hsab
+# Group and inspect
+"t,n\na,1\na,2\nb,3" from-csv "t" group-by keys        # a b
+"t,n\na,1\na,2\nb,3" from-csv "t" group-by "a" get     # sub-table with 2 rows
+
+# Join users to orders
+"id,name\n1,alice" from-csv "uid,item\n1,book" from-csv "id" "uid" join-on
+
+# Computed columns
+"n\n1\n2" from-csv #["n" get 10 mul] "n10" add-column
+"n\n1\n2" from-csv "n" #[2 mul] map-column
+```
+
+Column order is deterministic (records preserve insertion order via IndexMap).
+
+## 7. Common Patterns
 
 ### Transforming Lists of Records
 

--- a/issues/000-structured-object-model.md
+++ b/issues/000-structured-object-model.md
@@ -7,6 +7,53 @@
 
 ---
 
+
+## Status (as of reconciliation — wave 2, 2026-07)
+
+This draft was written as if the structured object model were greenfield.
+**Most of it is now implemented.** The sections below are kept as design
+prose/prior art; treat the "Implementation Plan" as historical. What exists:
+
+- **Value variants** — `src/ast.rs` (`Value` enum): `Literal`, `Output`,
+  `Block`, `Nil`, `Marker`, `List`, `Map` (Record, backed by `IndexMap` —
+  #23, landed wave 1), `Number` (float), `Int` (first-class integer — #24),
+  `Bool`, `Table{columns, rows}`, `Error{kind, message, code, source,
+  command}`, `Media`, `Link`, `Bytes`, `BigInt`, `Future`.
+- **Record/table ops** — `src/eval/structured.rs`: `record`, `table`,
+  polymorphic `get` (record field / table column / list index / error
+  field, dot-paths), `set`, `del`, `has?`, `keys`, `values`, `merge`,
+  `where`, `sort-by`, `sort-by-desc`, `select`, `first`, `last`, `nth`,
+  `group-by`, `join-on`, `add-column`, `map-column`, `rename-column`,
+  `transpose` (#26).
+- **Format-on-display** — `src/display.rs`, invoked only at the terminal
+  boundary (`src/terminal.rs`); stack values are never mutated by display.
+- **Serialization** — `src/eval/serialization.rs`: `into-/from-` csv, tsv,
+  json, kv, lines, delimited.
+- **External-command boundary** — `src/eval/command.rs` (#25): non-zero
+  exit pushes `Value::Error{kind:"command"}` with captured stderr;
+  non-UTF-8 stdout is preserved as `Bytes`; success path unchanged.
+- **Typed pipelines** — `collect`/`keep`/`spread` preserve value types;
+  `spread` on a Table pushes row Records (#28).
+- **Integers** — integer literals, JSON integers, and arithmetic are
+  Int-typed with overflow promotion to BigInt (#24); strict numeric
+  coercion (no silent `0`).
+- **Structured core builtins** — `ls-t`, `ps-t`, `env-t`, `which-t`,
+  `history-t` (#27, additive; text builtins unchanged).
+
+Remaining / deliberately not done:
+- Default-structured `ls`/`ps` with a `raw` escape hatch (003) — the
+  additive `-t` convention was chosen instead.
+- `Nothing`/`get?` optional-value semantics — `get` pushes `Nil` on
+  missing keys instead of erroring, which covers the main use case.
+- Brace-literal record syntax (`{name: "x"}`) — records are built from
+  stack pairs (`"k" v record`) or parsed from JSON/CSV.
+
+Follow-up issues that carried the deltas: #23 (IndexMap), #24 (Int), #25
+(command boundary), #26 (table ops), #27 (structured builtins), #28
+(collect/keep), #33 (error positions). See also #22 (this reconciliation).
+
+---
+
 ## Summary
 
 Add a structured data model to hsab so that values on the stack can be **records** (key-value maps), **tables** (lists of records), and **lists** (ordered sequences of typed values) — not just strings and blocks. This transforms hsab from "bash with a stack" into "a stack-based shell with native structured data," a combination no other shell offers.

--- a/issues/001-record-and-table-types.md
+++ b/issues/001-record-and-table-types.md
@@ -7,6 +7,22 @@
 
 ---
 
+
+## Status (as of reconciliation — wave 2, 2026-07)
+
+**Implemented.** `Value::Map(IndexMap<String, Value>)` and
+`Value::List(Vec<Value>)` exist (`src/ast.rs`); a separate
+`Value::Table{columns, rows}` variant was added as well (contrary to the
+"no separate Table type" suggestion below — tables display and serialize
+columnar data more efficiently, and `spread` converts rows back to
+Records). `record`, `list`, polymorphic `get` (field/column/dot-path),
+`set` (immutable), `keys`, `values`, `count` are all in
+`src/eval/structured.rs` and registered in `src/resolver.rs`
+(`default_builtins`). `get` pushes `Nil` on missing keys (no separate
+`get?`). Insertion order is preserved (#23, IndexMap).
+
+---
+
 ## Summary
 
 Implement `Record` (ordered key-value map) and `List` (ordered sequence) as first-class `Value` variants. A table is a `List<Record>` where all records share the same keys — no separate Table type needed.

--- a/issues/002-format-on-display.md
+++ b/issues/002-format-on-display.md
@@ -6,6 +6,20 @@
 
 ---
 
+
+## Status (as of reconciliation — wave 2, 2026-07)
+
+**Implemented.** Format-on-display lives in `src/display.rs` (~1000
+lines: box-drawing tables, aligned records, terminal-width handling) and
+is invoked only at the terminal boundary in `src/terminal.rs`
+(`execute_line_with_options`, gated by `is_structured`). Stack values are
+never modified by rendering. The REPL prompt shows type-annotated
+previews of stack items (`src/repl.rs`). Explicit serializers
+(`into-json`, `into-csv`, `into-tsv`, ...) produce text values
+(`src/eval/serialization.rs`), distinct from display formatting.
+
+---
+
 ## Summary
 
 Structured data flows through the pipeline as rich typed values. Only at the terminal — when a value would be printed — does the display formatter render it. Intermediate pipeline stages never see rendered text. This is PowerShell's most important design insight.

--- a/issues/003-external-command-interop.md
+++ b/issues/003-external-command-interop.md
@@ -6,6 +6,29 @@
 
 ---
 
+
+## Status (as of reconciliation — wave 2, 2026-07)
+
+**Largely implemented**, with one deliberate deviation:
+
+- **Outbound auto-serialization** — `Value::as_arg()` (`src/ast.rs`):
+  tables serialize to TSV with a header row, lists join with newlines,
+  records to `key=value` lines (nested records to JSON), numbers/strings
+  as expected. Exactly the table below.
+- **Inbound explicit parse** — external output enters as `Output`
+  (text); `from-json`/`from-csv`/`from-tsv`/`json` upgrade it explicitly
+  (`src/eval/serialization.rs`). No auto-parsing heuristics.
+- **Byte fidelity + structured failure (#25)** — non-UTF-8 stdout is
+  preserved as `Value::Bytes`; a non-zero exit pushes
+  `Value::Error{kind:"command", message:<stderr>, code, command}`
+  (`src/eval/command.rs`).
+- **Deviation:** the `raw` escape hatch was not built. Instead of making
+  `ls`/`ps` structured-by-default, structured variants are additive
+  (`ls-t`, `ps-t`, `env-t`, `which-t`, `history-t` — #27), so text-mode
+  scripts never need an escape hatch.
+
+---
+
 ## Summary
 
 Define how structured data crosses the boundary to external commands and how external command output enters the structured world. This is the make-or-break decision for usability.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -19,6 +19,7 @@ pub fn value_to_json(v: &Value) -> JsonValue {
         Value::Number(n) => serde_json::Number::from_f64(*n)
             .map(JsonValue::Number)
             .unwrap_or(JsonValue::Null),
+        Value::Int(i) => JsonValue::Number((*i).into()),
         Value::Bool(b) => JsonValue::Bool(*b),
         Value::Nil => JsonValue::Null,
         Value::List(items) => JsonValue::Array(items.iter().map(value_to_json).collect()),
@@ -138,7 +139,14 @@ pub fn json_to_value(json: JsonValue) -> Value {
     match json {
         JsonValue::Null => Value::Nil,
         JsonValue::Bool(b) => Value::Bool(b),
-        JsonValue::Number(n) => Value::Number(n.as_f64().unwrap_or(0.0)),
+        JsonValue::Number(n) => {
+            // JSON integers become Int (exact); everything else is a float
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else {
+                Value::Number(n.as_f64().unwrap_or(0.0))
+            }
+        }
         JsonValue::String(s) => Value::Literal(s),
         JsonValue::Array(arr) => Value::List(arr.into_iter().map(json_to_value).collect()),
         JsonValue::Object(obj) => {
@@ -168,8 +176,10 @@ pub enum Value {
     List(Vec<Value>),
     /// A map/object of key-value pairs (for structured data)
     Map(IndexMap<String, Value>),
-    /// A numeric value
+    /// A floating-point numeric value
     Number(f64),
+    /// A first-class integer value (exact within i64 range)
+    Int(i64),
     /// A boolean value
     Bool(bool),
     /// A table: list of records with consistent columns
@@ -244,6 +254,9 @@ impl PartialEq for Value {
             (Value::List(a), Value::List(b)) => a == b,
             (Value::Map(a), Value::Map(b)) => a == b,
             (Value::Number(a), Value::Number(b)) => a == b,
+            // Int equality is by variant: Int(2) == Number(2.0) is false.
+            // Numeric *operators* treat them compatibly (see eval/math.rs).
+            (Value::Int(a), Value::Int(b)) => a == b,
             (Value::Bool(a), Value::Bool(b)) => a == b,
             (
                 Value::Table {
@@ -304,6 +317,29 @@ impl PartialEq for Value {
 }
 
 impl Value {
+    /// Convert a bare word to a stack value, recognizing numeric literals
+    /// (issue #24).
+    ///
+    /// Integer literals (round-trip exact, within i64 range) become `Int`;
+    /// float literals containing `.` (round-trip exact) become `Number`.
+    /// Everything else stays a `Literal` string. The round-trip guard keeps
+    /// shell-significant spellings like `007`, `+5`, or `1.20` as strings so
+    /// they pass through to external commands unchanged.
+    pub fn from_literal_word(s: &str) -> Value {
+        if let Ok(i) = s.parse::<i64>() {
+            if i.to_string() == s {
+                return Value::Int(i);
+            }
+        } else if s.contains('.') {
+            if let Ok(f) = s.parse::<f64>() {
+                if f.is_finite() && f.to_string() == s {
+                    return Value::Number(f);
+                }
+            }
+        }
+        Value::Literal(s.to_string())
+    }
+
     /// Human-readable hsab-level type name (issue #33).
     ///
     /// Used for user-facing error messages (`TypeError.got`) and `typeof`,
@@ -311,7 +347,8 @@ impl Value {
     pub fn type_name(&self) -> &'static str {
         match self {
             Value::Literal(_) | Value::Output(_) => "string",
-            Value::Number(_) => "number",
+            Value::Number(_) => "float",
+            Value::Int(_) => "int",
             Value::Bool(_) => "boolean",
             Value::List(_) => "list",
             Value::Map(_) => "record",
@@ -342,14 +379,14 @@ impl Value {
             Value::Block(_) => None, // Blocks can't be args directly
             Value::Nil => None,
             Value::Marker => None, // Markers can't be args
-            Value::Number(n) => {
-                // Format nicely - no trailing .0 for integers
-                if n.fract() == 0.0 && n.abs() < i64::MAX as f64 {
-                    Some(format!("{}", *n as i64))
-                } else {
-                    Some(n.to_string())
-                }
-            }
+            // f64 Display already drops a trailing ".0" (3.0 -> "3");
+            // normalize -0.0 to "0"
+            Value::Number(n) => Some(if *n == 0.0 {
+                "0".to_string()
+            } else {
+                n.to_string()
+            }),
+            Value::Int(i) => Some(i.to_string()),
             Value::Bool(b) => Some(b.to_string()),
             Value::List(items) => {
                 // Join list items with newlines for shell compatibility
@@ -368,6 +405,7 @@ impl Value {
                         Value::Literal(_)
                             | Value::Output(_)
                             | Value::Number(_)
+                            | Value::Int(_)
                             | Value::Bool(_)
                             | Value::Nil
                     )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,6 +178,11 @@ JSON / STRUCTURED DATA:
     json                    Parse JSON string to structured data
     unjson                  Convert structured data to JSON string
     ls-table                List directory as table: ls-table or /path ls-table
+    ls-t                    Structured ls: Table{{name,type,size,modified}}
+    ps-t                    Structured ps: Table{{pid,name,cpu,mem,status}}
+    env-t                   Environment as Record: env-t "PATH" get
+    which-t                 Structured which: Record{{name,path,type}}
+    history-t               REPL history as Table{{index,command}}
 
 STRUCTURED DATA OPS:
     Record Operations:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,9 +195,15 @@ STRUCTURED DATA OPS:
       where                 Filter: table #[predicate] where
       reject-where          Inverse of where: keep rows that DON'T match
       sort-by               Sort: table "column" sort-by
+      sort-by-desc          Sort descending: table "column" sort-by-desc
       select                Columns: table "col1" "col2" select
       first/last/nth        Row access: table 5 first
       group-by              Group: table "column" group-by
+      join-on               Inner join: left right "lkey" "rkey" join-on
+      add-column            Computed column: table #[block] "name" add-column
+      map-column            Transform column: table "col" #[block] map-column
+      rename-column         Rename: table "old" "new" rename-column
+      transpose             Swap rows/columns: table transpose
       unique/reverse        List transforms
       duplicates            Return items appearing more than once
       flatten               Flatten nested: list flatten

--- a/src/display.rs
+++ b/src/display.rs
@@ -495,6 +495,7 @@ fn format_value_compact(val: &Value, mode: CompactMode) -> String {
             }
         }
         Value::Number(n) => format_number_compact(*n, mode),
+        Value::Int(i) => color(mode, "35", &i.to_string()),
         Value::Bool(b) => color(mode, "34", &b.to_string()),
         Value::Nil => color(mode, "90", "nil"),
         Value::List(items) => match mode {

--- a/src/eval/aggregation.rs
+++ b/src/eval/aggregation.rs
@@ -13,6 +13,7 @@ impl Evaluator {
                 .iter()
                 .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
+                    Value::Int(i) => Some(*i as f64),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
                 })
@@ -42,6 +43,7 @@ impl Evaluator {
                     .iter()
                     .filter_map(|v| match v {
                         Value::Number(n) => Some(*n),
+                        Value::Int(i) => Some(*i as f64),
                         Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                         _ => None,
                     })
@@ -73,6 +75,7 @@ impl Evaluator {
                 .iter()
                 .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
+                    Value::Int(i) => Some(*i as f64),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
                 })
@@ -105,6 +108,7 @@ impl Evaluator {
                 .iter()
                 .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
+                    Value::Int(i) => Some(*i as f64),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
                 })
@@ -140,7 +144,7 @@ impl Evaluator {
             _ => 1,
         };
 
-        self.stack.push(Value::Number(n as f64));
+        self.stack.push(Value::Int(n as i64));
         self.last_exit_code = 0;
         Ok(())
     }

--- a/src/eval/async_ops.rs
+++ b/src/eval/async_ops.rs
@@ -311,6 +311,7 @@ impl Evaluator {
 
         let limit: usize = match n_val {
             Value::Number(n) => n as usize,
+            Value::Int(i) => i as usize,
             Value::Literal(s) => s.parse().map_err(|_| EvalError::TypeError {
                 expected: "integer".into(),
                 got: s,
@@ -689,6 +690,7 @@ impl Evaluator {
 
         let n: usize = match n_val {
             Value::Number(num) => num as usize,
+            Value::Int(i) => i as usize,
             Value::Literal(s) | Value::Output(s) => {
                 s.parse().map_err(|_| EvalError::TypeError {
                     expected: "integer".into(),

--- a/src/eval/bigint.rs
+++ b/src/eval/bigint.rs
@@ -24,6 +24,15 @@ impl Evaluator {
                 }
                 BigUint::from(*n as u64)
             }
+            Value::Int(i) => {
+                if *i < 0 {
+                    self.stack.push(value);
+                    return Err(EvalError::ExecError(
+                        "to-bigint: negative numbers not supported".to_string(),
+                    ));
+                }
+                BigUint::from(*i as u64)
+            }
             Value::BigInt(n) => {
                 // Already BigInt
                 n.clone()
@@ -171,6 +180,7 @@ impl Evaluator {
         })?;
         let shift = match &n {
             Value::Number(f) => *f as u64,
+            Value::Int(i) => *i as u64,
             Value::Literal(s) | Value::Output(s) => s.trim().parse::<u64>().map_err(|_| {
                 EvalError::ExecError(format!("big-shl: invalid shift amount: {}", s))
             })?,
@@ -193,6 +203,7 @@ impl Evaluator {
         })?;
         let shift = match &n {
             Value::Number(f) => *f as u64,
+            Value::Int(i) => *i as u64,
             Value::Literal(s) | Value::Output(s) => s.trim().parse::<u64>().map_err(|_| {
                 EvalError::ExecError(format!("big-shr: invalid shift amount: {}", s))
             })?,
@@ -215,6 +226,7 @@ impl Evaluator {
         })?;
         let exp = match &n {
             Value::Number(f) => *f as u32,
+            Value::Int(i) => *i as u32,
             Value::Literal(s) | Value::Output(s) => s
                 .trim()
                 .parse::<u32>()

--- a/src/eval/combinators.rs
+++ b/src/eval/combinators.rs
@@ -163,7 +163,8 @@ impl Evaluator {
         };
 
         let max_tries = match count {
-            Value::Number(n) => n as usize,
+            Value::Number(n) if n.fract() == 0.0 && n >= 0.0 => n as usize,
+            Value::Int(i) if i >= 0 => i as usize,
             Value::Literal(s) | Value::Output(s) => {
                 s.parse::<usize>().map_err(|_| EvalError::TypeError {
                     expected: "Number".into(),
@@ -250,7 +251,8 @@ impl Evaluator {
         };
 
         let max_tries = match count {
-            Value::Number(n) => n as usize,
+            Value::Number(n) if n.fract() == 0.0 && n >= 0.0 => n as usize,
+            Value::Int(i) if i >= 0 => i as usize,
             Value::Literal(s) | Value::Output(s) => {
                 s.parse::<usize>().map_err(|_| EvalError::TypeError {
                     expected: "Number".into(),
@@ -267,6 +269,7 @@ impl Evaluator {
 
         let delay: u64 = match delay_ms {
             Value::Number(n) => n as u64,
+            Value::Int(i) => i as u64,
             Value::Literal(s) | Value::Output(s) => {
                 s.parse::<u64>().map_err(|_| EvalError::TypeError {
                     expected: "Number (milliseconds)".into(),

--- a/src/eval/command.rs
+++ b/src/eval/command.rs
@@ -2,6 +2,20 @@ use super::{EvalError, Evaluator};
 use crate::ast::Value;
 use std::process::{Command, Stdio};
 
+/// Convert captured stdout bytes to a stack value (issue #25).
+///
+/// Empty output stays `Nil`, valid UTF-8 stays `Output`, and anything else
+/// is preserved byte-for-byte as `Bytes` (no lossy mangling).
+pub(crate) fn output_to_value(bytes: Vec<u8>) -> Value {
+    if bytes.is_empty() {
+        return Value::Nil;
+    }
+    match String::from_utf8(bytes) {
+        Ok(s) => Value::Output(s),
+        Err(e) => Value::Bytes(e.into_bytes()),
+    }
+}
+
 impl Evaluator {
     /// Execute a command, popping args from stack
     pub(crate) fn execute_command(&mut self, cmd: &str) -> Result<(), EvalError> {
@@ -31,13 +45,32 @@ impl Evaluator {
         }
 
         // Execute native command
-        let (output, exit_code) = self.execute_native(cmd, args)?;
+        let argv = if args.is_empty() {
+            cmd.to_string()
+        } else {
+            format!("{} {}", cmd, args.join(" "))
+        };
+        let (stdout, stderr, exit_code) = self.execute_native_raw(cmd, args)?;
         self.last_exit_code = exit_code;
 
-        if output.is_empty() {
-            self.stack.push(Value::Nil);
+        if exit_code != 0 {
+            // Failure is a recoverable value on the stack (issue #25):
+            // a structured Error carrying stderr, exit code, and the command
+            let trimmed = String::from_utf8_lossy(&stderr).trim().to_string();
+            let message = if trimmed.is_empty() {
+                format!("exited {}", exit_code)
+            } else {
+                trimmed
+            };
+            self.stack.push(Value::Error {
+                kind: "command".to_string(),
+                message,
+                code: Some(exit_code),
+                source: None,
+                command: Some(argv),
+            });
         } else {
-            self.stack.push(Value::Output(output));
+            self.stack.push(output_to_value(stdout));
         }
 
         Ok(())
@@ -45,11 +78,27 @@ impl Evaluator {
 
     /// Execute a native command using std::process::Command
     /// Uses capture_mode to decide whether to capture output or run interactively
+    ///
+    /// Lossy text variant kept for callers that need a String (e.g. file
+    /// redirects); `execute_native_raw` preserves bytes and stderr (issue #25).
     pub(crate) fn execute_native(
         &mut self,
         cmd: &str,
         args: Vec<String>,
     ) -> Result<(String, i32), EvalError> {
+        let (stdout, _stderr, exit_code) = self.execute_native_raw(cmd, args)?;
+        Ok((String::from_utf8_lossy(&stdout).to_string(), exit_code))
+    }
+
+    /// Execute a native command, capturing raw stdout/stderr bytes (issue #25).
+    ///
+    /// Returns `(stdout, stderr, exit_code)`. In interactive (non-captured)
+    /// mode both byte buffers are empty because output goes to the terminal.
+    pub(crate) fn execute_native_raw(
+        &mut self,
+        cmd: &str,
+        args: Vec<String>,
+    ) -> Result<(Vec<u8>, Vec<u8>, i32), EvalError> {
         // Only run interactively if:
         // 1. capture_mode is false (nothing will consume the output)
         // 2. stdout is a TTY (we're in an interactive context)
@@ -66,7 +115,7 @@ impl Evaluator {
                 .status()
                 .map_err(|e| EvalError::ExecError(format!("{}: {}", cmd, e)))?;
 
-            Ok((String::new(), status.code().unwrap_or(-1)))
+            Ok((Vec::new(), Vec::new(), status.code().unwrap_or(-1)))
         } else {
             // Capture output (for piping, scripts, tests, or when output is consumed)
             let output = Command::new(cmd)
@@ -75,10 +124,9 @@ impl Evaluator {
                 .output()
                 .map_err(|e| EvalError::ExecError(format!("{}: {}", cmd, e)))?;
 
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let exit_code = output.status.code().unwrap_or(-1);
 
-            Ok((stdout, exit_code))
+            Ok((output.stdout, output.stderr, exit_code))
         }
     }
 

--- a/src/eval/command.rs
+++ b/src/eval/command.rs
@@ -623,6 +623,27 @@ impl Evaluator {
                 Ok(true)
             }
             // Structured builtins
+            // Structured-returning core builtins (issue #27)
+            "ls-t" => {
+                self.builtin_ls_t()?;
+                Ok(true)
+            }
+            "ps-t" => {
+                self.builtin_ps_t()?;
+                Ok(true)
+            }
+            "env-t" => {
+                self.builtin_env_t()?;
+                Ok(true)
+            }
+            "which-t" => {
+                self.builtin_which_t()?;
+                Ok(true)
+            }
+            "history-t" => {
+                self.builtin_history_t()?;
+                Ok(true)
+            }
             "ls-table" => {
                 self.builtin_ls_table()?;
                 Ok(true)

--- a/src/eval/command.rs
+++ b/src/eval/command.rs
@@ -502,6 +502,30 @@ impl Evaluator {
                 self.builtin_group_by()?;
                 Ok(true)
             }
+            "join-on" => {
+                self.builtin_join_on()?;
+                Ok(true)
+            }
+            "add-column" => {
+                self.builtin_add_column()?;
+                Ok(true)
+            }
+            "map-column" => {
+                self.builtin_map_column()?;
+                Ok(true)
+            }
+            "rename-column" => {
+                self.builtin_rename_column()?;
+                Ok(true)
+            }
+            "transpose" => {
+                self.builtin_transpose()?;
+                Ok(true)
+            }
+            "sort-by-desc" => {
+                self.builtin_sort_by_desc()?;
+                Ok(true)
+            }
             "unique" => {
                 self.builtin_unique()?;
                 Ok(true)

--- a/src/eval/control.rs
+++ b/src/eval/control.rs
@@ -12,6 +12,7 @@ impl Evaluator {
         match value {
             Value::Bool(b) => *b,
             Value::Number(n) => *n != 0.0,
+            Value::Int(i) => *i != 0,
             Value::Literal(s) | Value::Output(s) => !s.is_empty(),
             Value::Nil => false,
             _ => true,

--- a/src/eval/encoding.rs
+++ b/src/eval/encoding.rs
@@ -159,7 +159,7 @@ impl Evaluator {
 
         match value {
             Value::Bytes(data) => {
-                let list: Vec<Value> = data.iter().map(|&b| Value::Number(b as f64)).collect();
+                let list: Vec<Value> = data.iter().map(|&b| Value::Int(b as i64)).collect();
                 self.stack.push(Value::List(list));
                 self.last_exit_code = 0;
             }
@@ -220,7 +220,7 @@ impl Evaluator {
 
         match value {
             Value::Bytes(data) => {
-                self.stack.push(Value::Number(data.len() as f64));
+                self.stack.push(Value::Int(data.len() as i64));
                 self.last_exit_code = 0;
                 Ok(())
             }

--- a/src/eval/helpers.rs
+++ b/src/eval/helpers.rs
@@ -4,6 +4,40 @@ use glob::glob;
 use indexmap::IndexMap;
 use num_bigint::BigUint;
 
+/// A popped numeric operand, before promotion (issue #24).
+///
+/// Promotion rules (documented in docs/reference.md):
+/// - `Int op Int -> Int`, checked; on i64 overflow the result is promoted to
+///   `BigInt` when representable (non-negative), otherwise to a float.
+/// - mixed `Int`/`Float` -> `Float`
+/// - `BigInt` operands stay `BigInt` where the result is non-negative,
+///   otherwise fall back to floats.
+#[derive(Debug, Clone)]
+pub(crate) enum Num {
+    Int(i64),
+    Float(f64),
+    Big(BigUint),
+}
+
+impl Num {
+    pub(crate) fn to_f64(&self) -> f64 {
+        match self {
+            Num::Int(i) => *i as f64,
+            Num::Float(f) => *f,
+            // Lossy but monotone: good enough for comparisons/float math
+            Num::Big(b) => b.to_string().parse::<f64>().unwrap_or(f64::INFINITY),
+        }
+    }
+
+    pub(crate) fn into_value(self) -> Value {
+        match self {
+            Num::Int(i) => Value::Int(i),
+            Num::Float(f) => Value::Number(f),
+            Num::Big(b) => Value::BigInt(b),
+        }
+    }
+}
+
 impl Evaluator {
     /// Expand tilde (~) to home directory
     pub(crate) fn expand_tilde(&self, path: &str) -> String {
@@ -153,23 +187,60 @@ impl Evaluator {
         })
     }
 
-    /// Helper to pop a number from stack (handles Literal/Output too)
-    pub(crate) fn pop_number(&mut self, op: &str) -> Result<f64, EvalError> {
+    /// Pop a numeric operand for arithmetic promotion (issue #24).
+    ///
+    /// Strict: accepts `Int`, `Number`, `BigInt`, and strings that parse as
+    /// numbers. Non-numeric values are a `TypeError` (no silent 0-coercion).
+    pub(crate) fn pop_numeric(&mut self, op: &str) -> Result<Num, EvalError> {
         let value = self
             .stack
             .pop()
-            .ok_or_else(|| EvalError::ExecError(format!("{} requires a number on stack", op)))?;
+            .ok_or_else(|| EvalError::StackUnderflow(format!("{} requires a number", op)))?;
         match &value {
-            Value::Number(n) => Ok(*n),
+            Value::Int(i) => Ok(Num::Int(*i)),
+            Value::Number(n) => Ok(Num::Float(*n)),
+            Value::BigInt(b) => Ok(Num::Big(b.clone())),
             Value::Literal(s) | Value::Output(s) => {
-                // Shell compatibility: non-numeric strings parse as 0
-                Ok(s.trim().parse::<f64>().unwrap_or(0.0))
+                let t = s.trim();
+                if let Ok(i) = t.parse::<i64>() {
+                    Ok(Num::Int(i))
+                } else if let Ok(f) = t.parse::<f64>() {
+                    Ok(Num::Float(f))
+                } else if !t.is_empty() && t.bytes().all(|b| b.is_ascii_digit()) {
+                    // Huge positive integer literal beyond i64
+                    Ok(Num::Big(t.parse::<BigUint>().map_err(|_| {
+                        EvalError::TypeError {
+                            expected: format!("number ({})", op),
+                            got: value.type_name().to_string(),
+                        }
+                    })?))
+                } else {
+                    let err = EvalError::TypeError {
+                        expected: format!("number ({})", op),
+                        got: value.type_name().to_string(),
+                    };
+                    self.stack.push(value);
+                    Err(err)
+                }
             }
             _ => {
+                let err = EvalError::TypeError {
+                    expected: format!("number ({})", op),
+                    got: value.type_name().to_string(),
+                };
                 self.stack.push(value);
-                Err(EvalError::ExecError(format!("{} requires a number", op)))
+                Err(err)
             }
         }
+    }
+
+    /// Helper to pop a number from stack as f64 (strict; issue #24).
+    ///
+    /// Accepts Int/Number/BigInt and numeric strings; anything else is a
+    /// TypeError. BigInt/Int larger than 2^53 lose precision here — use
+    /// `pop_numeric` for exact arithmetic.
+    pub(crate) fn pop_number(&mut self, op: &str) -> Result<f64, EvalError> {
+        Ok(self.pop_numeric(op)?.to_f64())
     }
 
     /// Helper to pop a BigInt from stack
@@ -199,6 +270,7 @@ impl Evaluator {
                 .iter()
                 .map(|v| match v {
                     Value::Number(n) => Ok(*n),
+                    Value::Int(i) => Ok(*i as f64),
                     Value::Literal(s) | Value::Output(s) => {
                         s.trim().parse::<f64>().map_err(|_| EvalError::TypeError {
                             expected: "Number".into(),

--- a/src/eval/http.rs
+++ b/src/eval/http.rs
@@ -149,7 +149,7 @@ impl Evaluator {
         };
 
         let response = self.do_http_request(&method, &url, None, None)?;
-        self.stack.push(Value::Number(response.status as f64));
+        self.stack.push(Value::Int(response.status as i64));
         self.last_exit_code = if response.status >= 400 { 1 } else { 0 };
         Ok(())
     }
@@ -308,7 +308,9 @@ fn json_to_value(json: serde_json::Value) -> Value {
         serde_json::Value::Null => Value::Nil,
         serde_json::Value::Bool(b) => Value::Bool(b),
         serde_json::Value::Number(n) => {
-            if let Some(f) = n.as_f64() {
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else if let Some(f) = n.as_f64() {
                 Value::Number(f)
             } else {
                 Value::Literal(n.to_string())

--- a/src/eval/image.rs
+++ b/src/eval/image.rs
@@ -126,12 +126,12 @@ impl Evaluator {
             } => {
                 let mut map = indexmap::IndexMap::new();
                 map.insert("mime_type".to_string(), Value::Literal(mime_type.clone()));
-                map.insert("size".to_string(), Value::Number(data.len() as f64));
+                map.insert("size".to_string(), Value::Int(data.len() as i64));
                 if let Some(w) = width {
-                    map.insert("width".to_string(), Value::Number(w as f64));
+                    map.insert("width".to_string(), Value::Int(w as i64));
                 }
                 if let Some(h) = height {
-                    map.insert("height".to_string(), Value::Number(h as f64));
+                    map.insert("height".to_string(), Value::Int(h as i64));
                 }
                 if let Some(a) = &alt {
                     map.insert("alt".to_string(), Value::Literal(a.clone()));

--- a/src/eval/list.rs
+++ b/src/eval/list.rs
@@ -1,11 +1,13 @@
 use super::{EvalError, Evaluator};
 use crate::ast::Value;
+use indexmap::IndexMap;
 
 impl Evaluator {
     /// Spread: split a value into separate stack items
     /// - String: split by newlines
-    /// - List: push each item
-    /// - Map: push each value (order undefined)
+    /// - List: push each item (typed)
+    /// - Map: push each value (insertion order)
+    /// - Table: push each row as a Record (issue #28)
     pub(crate) fn list_spread(&mut self) -> Result<(), EvalError> {
         let value = self.pop_value_or_err()?;
 
@@ -23,6 +25,14 @@ impl Evaluator {
                 // Spread map values onto stack (insertion order)
                 for (_key, val) in map {
                     self.stack.push(val);
+                }
+            }
+            Value::Table { columns, rows } => {
+                // Spread table rows as Records (issue #28)
+                for row in rows {
+                    let record: IndexMap<String, Value> =
+                        columns.iter().cloned().zip(row).collect();
+                    self.stack.push(Value::Map(record));
                 }
             }
             _ => {
@@ -304,7 +314,11 @@ impl Evaluator {
                 self.stack.pop(); // Remove the marker
                 break;
             }
-            items.push(self.stack.pop().unwrap());
+            let item = self
+                .stack
+                .pop()
+                .ok_or_else(|| EvalError::StackUnderflow("each".into()))?;
+            items.push(item);
         }
 
         // Items are in reverse order (LIFO), so reverse them
@@ -325,7 +339,9 @@ impl Evaluator {
         Ok(())
     }
 
-    /// Collect: gather stack items until marker into a single value
+    /// Collect: gather stack items until marker into a List, preserving
+    /// each item's original type (issue #28). Stringification only happens
+    /// later at the display/serialization boundary.
     pub(crate) fn list_collect(&mut self) -> Result<(), EvalError> {
         let mut items = Vec::new();
 
@@ -334,21 +350,24 @@ impl Evaluator {
                 self.stack.pop(); // Remove the marker
                 break;
             }
-            if let Some(s) = value.as_arg() {
-                items.push(s);
+            let item = self
+                .stack
+                .pop()
+                .ok_or_else(|| EvalError::StackUnderflow("collect".into()))?;
+            // Skip Nil placeholders (matches the old behavior where
+            // valueless items didn't contribute a line)
+            if !item.is_nil() {
+                items.push(item);
             }
-            self.stack.pop();
         }
 
         // Items are in reverse order (LIFO), so reverse them
         items.reverse();
 
-        // Join with newlines and push as output
-        let collected = items.join("\n");
-        if collected.is_empty() {
+        if items.is_empty() {
             self.stack.push(Value::Nil);
         } else {
-            self.stack.push(Value::Output(collected));
+            self.stack.push(Value::List(items));
         }
 
         Ok(())
@@ -365,13 +384,19 @@ impl Evaluator {
                 self.stack.pop(); // Remove the marker
                 break;
             }
-            items.push(self.stack.pop().unwrap());
+            let item = self
+                .stack
+                .pop()
+                .ok_or_else(|| EvalError::StackUnderflow("keep".into()))?;
+            items.push(item);
         }
 
         // Items are in reverse order (LIFO), so reverse them
         items.reverse();
 
-        // Collect kept items separately, then push all at once with marker
+        // Collect kept items separately, then push all at once with marker.
+        // The original Value is retained (issue #28) - only the predicate
+        // result is consumed.
         let mut kept = Vec::new();
 
         // Test each item with predicate, keep if passes

--- a/src/eval/list.rs
+++ b/src/eval/list.rs
@@ -190,6 +190,7 @@ impl Evaluator {
 
         let n: usize = match n_val {
             Value::Number(num) => num as usize,
+            Value::Int(i) => i as usize,
             Value::Literal(s) | Value::Output(s) => {
                 s.parse().map_err(|_| EvalError::TypeError {
                     expected: "integer".into(),

--- a/src/eval/local.rs
+++ b/src/eval/local.rs
@@ -49,6 +49,7 @@ impl Evaluator {
             let string_value = match &value {
                 Value::Literal(s) | Value::Output(s) => s.clone(),
                 Value::Number(n) => n.to_string(),
+                Value::Int(i) => i.to_string(),
                 Value::Bool(b) => b.to_string(),
                 Value::Nil => String::new(),
                 _ => value.as_arg().unwrap_or_default(),

--- a/src/eval/macros.rs
+++ b/src/eval/macros.rs
@@ -49,6 +49,7 @@ macro_rules! stack_builtin {
                     .iter()
                     .filter_map(|v| match v {
                         Value::Number(n) => Some(*n),
+                        Value::Int(i) => Some(*i as f64),
                         Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                         _ => None,
                     })
@@ -79,6 +80,7 @@ macro_rules! stack_builtin {
                     .iter()
                     .filter_map(|v| match v {
                         Value::Number(n) => Some(*n),
+                        Value::Int(i) => Some(*i as f64),
                         Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                         _ => None,
                     })

--- a/src/eval/math.rs
+++ b/src/eval/math.rs
@@ -1,6 +1,180 @@
+use super::helpers::Num;
 use super::{EvalError, Evaluator};
 use crate::ast::Value;
+use num_bigint::BigUint;
+use std::cmp::Ordering;
 use std::path::Path;
+
+/// Convert a non-negative i64 to BigUint (caller must check sign)
+fn big(u: i64) -> BigUint {
+    BigUint::from(u as u64)
+}
+
+/// Push an f64 as Int when it is exactly representable as i64, else Number.
+fn float_to_value(f: f64) -> Value {
+    if f.fract() == 0.0 && f.is_finite() && f.abs() < i64::MAX as f64 {
+        Value::Int(f as i64)
+    } else {
+        Value::Number(f)
+    }
+}
+
+fn num_is_zero(n: &Num) -> bool {
+    match n {
+        Num::Int(i) => *i == 0,
+        Num::Float(f) => *f == 0.0,
+        Num::Big(b) => *b == BigUint::from(0u32),
+    }
+}
+
+/// Compare two numeric operands (exact for Int/Int and Big/Big)
+fn num_cmp(a: &Num, b: &Num) -> Ordering {
+    match (a, b) {
+        (Num::Int(x), Num::Int(y)) => x.cmp(y),
+        (Num::Big(x), Num::Big(y)) => x.cmp(y),
+        _ => a
+            .to_f64()
+            .partial_cmp(&b.to_f64())
+            .unwrap_or(Ordering::Equal),
+    }
+}
+
+fn num_eq(a: &Num, b: &Num) -> bool {
+    num_cmp(a, b) == Ordering::Equal
+}
+
+/// a + b with promotion (Int overflow -> BigInt when non-negative, else float)
+fn num_add(a: Num, b: Num) -> Num {
+    match (&a, &b) {
+        (Num::Int(x), Num::Int(y)) => match x.checked_add(*y) {
+            Some(r) => Num::Int(r),
+            None => {
+                if *x >= 0 && *y >= 0 {
+                    Num::Big(big(*x) + big(*y))
+                } else {
+                    Num::Float(*x as f64 + *y as f64)
+                }
+            }
+        },
+        (Num::Big(x), Num::Big(y)) => Num::Big(x + y),
+        (Num::Big(x), Num::Int(y)) | (Num::Int(y), Num::Big(x)) => {
+            if *y >= 0 {
+                Num::Big(x + big(*y))
+            } else {
+                {
+                    let y_big = BigUint::from(y.unsigned_abs());
+                    if *x >= y_big {
+                        Num::Big(x - y_big)
+                    } else {
+                        Num::Float(a.to_f64() + b.to_f64())
+                    }
+                }
+            }
+        }
+        _ => Num::Float(a.to_f64() + b.to_f64()),
+    }
+}
+
+/// a - b with promotion
+fn num_sub(a: Num, b: Num) -> Num {
+    match (&a, &b) {
+        (Num::Int(x), Num::Int(y)) => match x.checked_sub(*y) {
+            Some(r) => Num::Int(r),
+            None => {
+                if *x >= 0 && *y < 0 {
+                    Num::Big(big(*x) + BigUint::from(y.unsigned_abs()))
+                } else {
+                    Num::Float(*x as f64 - *y as f64)
+                }
+            }
+        },
+        (Num::Big(x), Num::Big(y)) => {
+            if x >= y {
+                Num::Big(x - y)
+            } else {
+                Num::Float(a.to_f64() - b.to_f64())
+            }
+        }
+        (Num::Big(x), Num::Int(y)) => {
+            if *y >= 0 {
+                let y_big = big(*y);
+                if *x >= y_big {
+                    Num::Big(x - y_big)
+                } else {
+                    Num::Float(a.to_f64() - b.to_f64())
+                }
+            } else {
+                Num::Big(x + BigUint::from(y.unsigned_abs()))
+            }
+        }
+        (Num::Int(x), Num::Big(y)) => {
+            let x_big = if *x >= 0 { Some(big(*x)) } else { None };
+            match x_big {
+                Some(xb) if xb >= *y => Num::Big(xb - y),
+                _ => Num::Float(a.to_f64() - b.to_f64()),
+            }
+        }
+        _ => Num::Float(a.to_f64() - b.to_f64()),
+    }
+}
+
+/// a * b with promotion
+fn num_mul(a: Num, b: Num) -> Num {
+    match (&a, &b) {
+        (Num::Int(x), Num::Int(y)) => match x.checked_mul(*y) {
+            Some(r) => Num::Int(r),
+            None => {
+                if (*x >= 0) == (*y >= 0) {
+                    Num::Big(BigUint::from(x.unsigned_abs()) * BigUint::from(y.unsigned_abs()))
+                } else {
+                    Num::Float(*x as f64 * *y as f64)
+                }
+            }
+        },
+        (Num::Big(x), Num::Big(y)) => Num::Big(x * y),
+        (Num::Big(x), Num::Int(y)) | (Num::Int(y), Num::Big(x)) => {
+            if *y >= 0 {
+                Num::Big(x * big(*y))
+            } else {
+                Num::Float(a.to_f64() * b.to_f64())
+            }
+        }
+        _ => Num::Float(a.to_f64() * b.to_f64()),
+    }
+}
+
+/// a / b with promotion: exact Int division stays Int, otherwise float
+fn num_div(a: Num, b: Num) -> Num {
+    match (&a, &b) {
+        (Num::Int(x), Num::Int(y)) => {
+            if x % y == 0 {
+                match x.checked_div(*y) {
+                    Some(r) => Num::Int(r),
+                    None => Num::Float(*x as f64 / *y as f64),
+                }
+            } else {
+                Num::Float(*x as f64 / *y as f64)
+            }
+        }
+        (Num::Big(x), Num::Big(y)) => {
+            if x % y == BigUint::from(0u32) {
+                Num::Big(x / y)
+            } else {
+                Num::Float(a.to_f64() / b.to_f64())
+            }
+        }
+        _ => Num::Float(a.to_f64() / b.to_f64()),
+    }
+}
+
+/// a % b with promotion
+fn num_mod(a: Num, b: Num) -> Num {
+    match (&a, &b) {
+        (Num::Int(x), Num::Int(y)) => Num::Int(x.checked_rem(*y).unwrap_or(0)),
+        (Num::Big(x), Num::Big(y)) => Num::Big(x % y),
+        _ => Num::Float(a.to_f64() % b.to_f64()),
+    }
+}
 
 impl Evaluator {
     // ========================================
@@ -32,9 +206,9 @@ impl Evaluator {
     /// Numeric equality (stack-native)
     /// Usage: 5 5 =? -> Bool
     pub(crate) fn builtin_num_eq_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("=?")?;
-        let a = self.pop_number("=?")?;
-        let result = a == b;
+        let b = self.pop_numeric("=?")?;
+        let a = self.pop_numeric("=?")?;
+        let result = num_eq(&a, &b);
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
         Ok(())
@@ -43,9 +217,9 @@ impl Evaluator {
     /// Numeric inequality (stack-native)
     /// Usage: 5 10 !=? -> Bool
     pub(crate) fn builtin_num_ne_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("!=?")?;
-        let a = self.pop_number("!=?")?;
-        let result = a != b;
+        let b = self.pop_numeric("!=?")?;
+        let a = self.pop_numeric("!=?")?;
+        let result = !num_eq(&a, &b);
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
         Ok(())
@@ -54,9 +228,9 @@ impl Evaluator {
     /// Numeric less than (stack-native)
     /// Usage: 5 10 lt? -> Bool
     pub(crate) fn builtin_lt_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("lt?")?;
-        let a = self.pop_number("lt?")?;
-        let result = a < b;
+        let b = self.pop_numeric("lt?")?;
+        let a = self.pop_numeric("lt?")?;
+        let result = num_cmp(&a, &b) == Ordering::Less;
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
         Ok(())
@@ -65,9 +239,9 @@ impl Evaluator {
     /// Numeric greater than (stack-native)
     /// Usage: 10 5 gt? -> Bool
     pub(crate) fn builtin_gt_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("gt?")?;
-        let a = self.pop_number("gt?")?;
-        let result = a > b;
+        let b = self.pop_numeric("gt?")?;
+        let a = self.pop_numeric("gt?")?;
+        let result = num_cmp(&a, &b) == Ordering::Greater;
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
         Ok(())
@@ -76,9 +250,9 @@ impl Evaluator {
     /// Numeric less than or equal (stack-native)
     /// Usage: 5 10 le? -> Bool
     pub(crate) fn builtin_le_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("le?")?;
-        let a = self.pop_number("le?")?;
-        let result = a <= b;
+        let b = self.pop_numeric("le?")?;
+        let a = self.pop_numeric("le?")?;
+        let result = num_cmp(&a, &b) != Ordering::Greater;
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
         Ok(())
@@ -87,9 +261,9 @@ impl Evaluator {
     /// Numeric greater than or equal (stack-native)
     /// Usage: 10 5 ge? -> Bool
     pub(crate) fn builtin_ge_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("ge?")?;
-        let a = self.pop_number("ge?")?;
-        let result = a >= b;
+        let b = self.pop_numeric("ge?")?;
+        let a = self.pop_numeric("ge?")?;
+        let result = num_cmp(&a, &b) != Ordering::Less;
         self.stack.push(Value::Bool(result));
         self.last_exit_code = if result { 0 } else { 1 };
         Ok(())
@@ -102,9 +276,9 @@ impl Evaluator {
     /// Add two numbers (stack-native)
     /// Usage: 5 3 plus -> 8
     pub(crate) fn builtin_plus_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("plus")?;
-        let a = self.pop_number("plus")?;
-        self.stack.push(Value::Number(a + b));
+        let b = self.pop_numeric("plus")?;
+        let a = self.pop_numeric("plus")?;
+        self.stack.push(num_add(a, b).into_value());
         self.last_exit_code = 0;
         Ok(())
     }
@@ -112,9 +286,9 @@ impl Evaluator {
     /// Subtract two numbers (stack-native)
     /// Usage: 10 3 minus -> 7
     pub(crate) fn builtin_minus_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("minus")?;
-        let a = self.pop_number("minus")?;
-        self.stack.push(Value::Number(a - b));
+        let b = self.pop_numeric("minus")?;
+        let a = self.pop_numeric("minus")?;
+        self.stack.push(num_sub(a, b).into_value());
         self.last_exit_code = 0;
         Ok(())
     }
@@ -122,9 +296,9 @@ impl Evaluator {
     /// Multiply two numbers (stack-native)
     /// Usage: 4 5 mul -> 20
     pub(crate) fn builtin_mul_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("mul")?;
-        let a = self.pop_number("mul")?;
-        self.stack.push(Value::Number(a * b));
+        let b = self.pop_numeric("mul")?;
+        let a = self.pop_numeric("mul")?;
+        self.stack.push(num_mul(a, b).into_value());
         self.last_exit_code = 0;
         Ok(())
     }
@@ -132,12 +306,12 @@ impl Evaluator {
     /// Divide two numbers (stack-native, float division)
     /// Usage: 10 3 div -> 3.333...
     pub(crate) fn builtin_div_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("div")?;
-        let a = self.pop_number("div")?;
-        if b == 0.0 {
+        let b = self.pop_numeric("div")?;
+        let a = self.pop_numeric("div")?;
+        if num_is_zero(&b) {
             return Err(EvalError::ExecError("div: division by zero".to_string()));
         }
-        self.stack.push(Value::Number(a / b));
+        self.stack.push(num_div(a, b).into_value());
         self.last_exit_code = 0;
         Ok(())
     }
@@ -145,12 +319,12 @@ impl Evaluator {
     /// Modulo (stack-native)
     /// Usage: 10 3 mod -> 1
     pub(crate) fn builtin_mod_stack(&mut self) -> Result<(), EvalError> {
-        let b = self.pop_number("mod")?;
-        let a = self.pop_number("mod")?;
-        if b == 0.0 {
+        let b = self.pop_numeric("mod")?;
+        let a = self.pop_numeric("mod")?;
+        if num_is_zero(&b) {
             return Err(EvalError::ExecError("mod: division by zero".to_string()));
         }
-        self.stack.push(Value::Number(a % b));
+        self.stack.push(num_mod(a, b).into_value());
         self.last_exit_code = 0;
         Ok(())
     }
@@ -185,7 +359,7 @@ impl Evaluator {
     /// Usage: 3.7 floor -> 3
     pub(crate) fn builtin_floor(&mut self) -> Result<(), EvalError> {
         let n = self.pop_number("floor")?;
-        self.stack.push(Value::Number(n.floor()));
+        self.stack.push(float_to_value(n.floor()));
         self.last_exit_code = 0;
         Ok(())
     }
@@ -194,7 +368,7 @@ impl Evaluator {
     /// Usage: 3.2 ceil -> 4
     pub(crate) fn builtin_ceil(&mut self) -> Result<(), EvalError> {
         let n = self.pop_number("ceil")?;
-        self.stack.push(Value::Number(n.ceil()));
+        self.stack.push(float_to_value(n.ceil()));
         self.last_exit_code = 0;
         Ok(())
     }
@@ -203,7 +377,7 @@ impl Evaluator {
     /// Usage: 3.5 round -> 4, 3.4 round -> 3
     pub(crate) fn builtin_round(&mut self) -> Result<(), EvalError> {
         let n = self.pop_number("round")?;
-        self.stack.push(Value::Number(n.round()));
+        self.stack.push(float_to_value(n.round()));
         self.last_exit_code = 0;
         Ok(())
     }
@@ -216,7 +390,7 @@ impl Evaluator {
         if b == 0.0 {
             return Err(EvalError::ExecError("idiv: division by zero".to_string()));
         }
-        self.stack.push(Value::Number((a / b).trunc()));
+        self.stack.push(float_to_value((a / b).trunc()));
         self.last_exit_code = 0;
         Ok(())
     }
@@ -233,6 +407,7 @@ impl Evaluator {
                 items.sort_by(|a, b| {
                     let a_num = match a {
                         Value::Number(n) => *n,
+                        Value::Int(i) => *i as f64,
                         Value::Literal(s) | Value::Output(s) => {
                             s.trim().parse().unwrap_or(f64::NAN)
                         }
@@ -240,6 +415,7 @@ impl Evaluator {
                     };
                     let b_num = match b {
                         Value::Number(n) => *n,
+                        Value::Int(i) => *i as f64,
                         Value::Literal(s) | Value::Output(s) => {
                             s.trim().parse().unwrap_or(f64::NAN)
                         }
@@ -400,8 +576,8 @@ impl Evaluator {
     /// Increment: pop number, push number+1
     /// Usage: 5 ++ -> 6
     pub(crate) fn builtin_increment(&mut self) -> Result<(), EvalError> {
-        let n = self.pop_number("++")?;
-        self.stack.push(Value::Number(n + 1.0));
+        let n = self.pop_numeric("++")?;
+        self.stack.push(num_add(n, Num::Int(1)).into_value());
         self.last_exit_code = 0;
         Ok(())
     }
@@ -409,8 +585,8 @@ impl Evaluator {
     /// Decrement: pop number, push number-1
     /// Usage: 5 -- -> 4
     pub(crate) fn builtin_decrement(&mut self) -> Result<(), EvalError> {
-        let n = self.pop_number("--")?;
-        self.stack.push(Value::Number(n - 1.0));
+        let n = self.pop_numeric("--")?;
+        self.stack.push(num_sub(n, Num::Int(1)).into_value());
         self.last_exit_code = 0;
         Ok(())
     }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -81,6 +81,14 @@ pub enum EvalError {
     IoError(#[from] std::io::Error),
     #[error("Break outside of loop")]
     BreakOutsideLoop,
+    /// An error annotated with the source position of the failing
+    /// top-level statement (issue #33)
+    #[error("{source} at line {line} col {col}")]
+    At {
+        line: usize,
+        col: usize,
+        source: Box<EvalError>,
+    },
     /// Internal: signals break from loop (not a real error)
     #[error("")]
     BreakLoop,
@@ -179,6 +187,11 @@ pub struct Evaluator {
     pub(crate) snapshots: HashMap<String, Vec<Value>>,
     /// Counter for auto-generated snapshot names
     pub(crate) snapshot_counter: u32,
+    /// Statement-level spans for the program being evaluated (issue #33);
+    /// consumed by eval_exprs at the top level
+    pub(crate) pending_statement_spans: Vec<crate::lexer::Span>,
+    /// Span of the top-level statement currently executing (issue #33)
+    pub(crate) current_span: Option<crate::lexer::Span>,
     /// Counter for generating unique future IDs
     pub(crate) future_counter: u32,
     /// Handles to background threads for futures (for cleanup)
@@ -264,6 +277,8 @@ impl Evaluator {
                 .unwrap_or(8),
             snapshots: HashMap::new(),
             snapshot_counter: 0,
+            pending_statement_spans: Vec::new(),
+            current_span: None,
             future_counter: 0,
             future_handles: HashMap::new(),
             futures: indexmap::IndexMap::new(),
@@ -695,6 +710,21 @@ impl Evaluator {
     }
 
     /// Evaluate a program
+    /// Evaluate a program with statement-level source spans (issue #33).
+    /// Runtime errors are annotated with the line/col of the failing
+    /// top-level statement.
+    pub fn eval_with_spans(
+        &mut self,
+        program: &Program,
+        spans: &[crate::lexer::Span],
+    ) -> Result<EvalResult, EvalError> {
+        self.pending_statement_spans = spans.to_vec();
+        let result = self.eval(program);
+        self.pending_statement_spans.clear();
+        self.current_span = None;
+        result
+    }
+
     pub fn eval(&mut self, program: &Program) -> Result<EvalResult, EvalError> {
         self.eval_exprs(&program.expressions)?;
 
@@ -715,7 +745,14 @@ impl Evaluator {
 
     /// Evaluate a list of expressions with look-ahead for capture mode
     pub(crate) fn eval_exprs(&mut self, exprs: &[Expr]) -> Result<(), EvalError> {
+        // Statement-level spans (issue #33): present only for the top-level
+        // program invocation via eval_with_spans; nested calls see an empty
+        // vec and inherit current_span from the enclosing statement.
+        let stmt_spans = std::mem::take(&mut self.pending_statement_spans);
         for (i, expr) in exprs.iter().enumerate() {
+            if let Some(span) = stmt_spans.get(i) {
+                self.current_span = Some(*span);
+            }
             // Debug mode: check for breakpoints and step mode
             if self.debug_mode {
                 let should_pause = self.step_mode || self.matches_breakpoint(expr);
@@ -791,11 +828,29 @@ impl Evaluator {
                         self.print_trace(expr);
                     }
                 }
-                Err(EvalError::BreakLoop) => return Err(EvalError::BreakOutsideLoop),
-                Err(e) => return Err(e),
+                Err(EvalError::BreakLoop) => {
+                    return Err(self.attach_span(EvalError::BreakOutsideLoop))
+                }
+                Err(e) => return Err(self.attach_span(e)),
             }
         }
         Ok(())
+    }
+
+    /// Annotate an error with the current statement span, if known.
+    /// Control-flow sentinels and already-annotated errors pass through.
+    pub(crate) fn attach_span(&self, err: EvalError) -> EvalError {
+        if matches!(err, EvalError::BreakLoop | EvalError::At { .. }) {
+            return err;
+        }
+        match self.current_span {
+            Some((line, col)) if line > 0 => EvalError::At {
+                line,
+                col,
+                source: Box::new(err),
+            },
+            _ => err,
+        }
     }
 
     /// Print trace output showing expression and stack state

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -417,6 +417,7 @@ impl Evaluator {
                         }
                     }
                     Value::Number(n) => format!("{}", n),
+                    Value::Int(i) => format!("{}", i),
                     Value::Bool(b) => format!("{}", b),
                     Value::Output(s) => {
                         let trimmed = s.trim();
@@ -594,6 +595,7 @@ impl Evaluator {
                     format!("f64:{}", n)
                 }
             }
+            Value::Int(i) => format!("i64:{}", i),
             Value::Bool(b) => format!("bool:{}", b),
             Value::Map(m) => {
                 let fields: Vec<_> = m.keys().take(3).cloned().collect();
@@ -672,6 +674,7 @@ impl Evaluator {
                     format!("{}", n)
                 }
             }
+            Value::Int(i) => format!("{}", i),
             Value::Bool(b) => format!("{}", b),
             Value::Nil => "nil".to_string(),
             _ => "...".to_string(),
@@ -825,6 +828,7 @@ impl Evaluator {
             .map(|v| match v {
                 Value::Literal(s) => format!("\"{}\"", s),
                 Value::Number(n) => format!("{}", n),
+                Value::Int(i) => format!("{}", i),
                 Value::Bool(b) => format!("{}", b),
                 Value::Output(s) => {
                     let trimmed = s.trim();
@@ -1022,8 +1026,9 @@ impl Evaluator {
                     // Check if it's an executable
                     self.execute_command(s)?;
                 } else {
-                    // Push as literal
-                    self.stack.push(Value::Literal(s.clone()));
+                    // Push as literal; bare numeric words become typed
+                    // numbers (Int/Number) per issue #24
+                    self.stack.push(Value::from_literal_word(s));
                 }
             }
 

--- a/src/eval/process.rs
+++ b/src/eval/process.rs
@@ -576,7 +576,7 @@ impl Evaluator {
         let list: Vec<Value> = self
             .pipestatus
             .iter()
-            .map(|&c| Value::Number(c as f64))
+            .map(|&c| Value::Int(c as i64))
             .collect();
         self.stack.push(Value::List(list));
         self.last_exit_code = 0;

--- a/src/eval/serialization.rs
+++ b/src/eval/serialization.rs
@@ -64,8 +64,10 @@ impl Evaluator {
                 line.split(',')
                     .map(|s| {
                         let trimmed = s.trim();
-                        // Try to parse as number
-                        if let Ok(n) = trimmed.parse::<f64>() {
+                        // Try to parse as number (integers become Int)
+                        if let Ok(i) = trimmed.parse::<i64>() {
+                            Value::Int(i)
+                        } else if let Ok(n) = trimmed.parse::<f64>() {
                             Value::Number(n)
                         } else {
                             Value::Literal(trimmed.to_string())

--- a/src/eval/shell_native.rs
+++ b/src/eval/shell_native.rs
@@ -498,3 +498,287 @@ impl Evaluator {
         Ok(())
     }
 }
+
+// ============================================
+// Structured-returning core builtins (issue #27)
+// ============================================
+
+impl Evaluator {
+    /// ls-t: [path] ls-t -> Table{name, type, size, modified}
+    ///
+    /// Structured directory listing. `type` is file/dir/symlink/other
+    /// (symlinks are not followed). Additive: plain `ls` is unchanged.
+    pub(crate) fn builtin_ls_t(&mut self) -> Result<(), EvalError> {
+        use std::os::unix::fs::MetadataExt;
+        use std::path::PathBuf;
+
+        let dir_path = if let Some(val) = self.stack.last() {
+            if let Some(s) = val.as_arg() {
+                if !s.starts_with('-') && (Path::new(&s).exists() || s.contains('/')) {
+                    self.stack.pop();
+                    PathBuf::from(self.expand_tilde(&s))
+                } else {
+                    self.cwd.clone()
+                }
+            } else {
+                self.cwd.clone()
+            }
+        } else {
+            self.cwd.clone()
+        };
+
+        let entries = fs::read_dir(&dir_path).map_err(|e| {
+            EvalError::IoError(std::io::Error::new(
+                e.kind(),
+                format!("{}: {}", dir_path.display(), e),
+            ))
+        })?;
+
+        let columns = vec![
+            "name".to_string(),
+            "type".to_string(),
+            "size".to_string(),
+            "modified".to_string(),
+        ];
+
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            // symlink_metadata: do not follow links, so type can be "symlink"
+            let (file_type, size, modified) = match entry.path().symlink_metadata() {
+                Ok(meta) => {
+                    let ft = if meta.file_type().is_symlink() {
+                        "symlink"
+                    } else if meta.is_dir() {
+                        "dir"
+                    } else if meta.is_file() {
+                        "file"
+                    } else {
+                        "other"
+                    };
+                    (ft.to_string(), meta.len() as i64, meta.mtime())
+                }
+                Err(_) => ("unknown".to_string(), 0, 0),
+            };
+
+            rows.push(vec![
+                Value::Literal(name),
+                Value::Literal(file_type),
+                Value::Int(size),
+                Value::Int(modified),
+            ]);
+        }
+
+        rows.sort_by(|a, b| {
+            let name_a = a.first().and_then(|v| v.as_arg()).unwrap_or_default();
+            let name_b = b.first().and_then(|v| v.as_arg()).unwrap_or_default();
+            name_a.cmp(&name_b)
+        });
+
+        self.stack.push(Value::Table { columns, rows });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// env-t: env-t -> Record of environment variables (insertion order)
+    pub(crate) fn builtin_env_t(&mut self) -> Result<(), EvalError> {
+        let map: indexmap::IndexMap<String, Value> = std::env::vars()
+            .map(|(k, v)| (k, Value::Literal(v)))
+            .collect();
+        self.stack.push(Value::Map(map));
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// which-t: "name" which-t -> Record{name, path, type}
+    ///
+    /// type is one of builtin / definition / executable / not-found;
+    /// path is Nil unless type is executable.
+    pub(crate) fn builtin_which_t(&mut self) -> Result<(), EvalError> {
+        let name = self.pop_string()?;
+
+        let (kind, path) = if crate::resolver::ExecutableResolver::is_hsab_builtin(&name) {
+            ("builtin", Value::Nil)
+        } else if self.definitions.contains_key(&name) {
+            ("definition", Value::Nil)
+        } else if let Some(p) = self.resolver.find_executable(&name) {
+            ("executable", Value::Literal(p))
+        } else {
+            ("not-found", Value::Nil)
+        };
+
+        let mut map = indexmap::IndexMap::new();
+        map.insert("name".to_string(), Value::Literal(name));
+        map.insert("path".to_string(), path);
+        map.insert("type".to_string(), Value::Literal(kind.to_string()));
+        self.stack.push(Value::Map(map));
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// history-t: history-t -> Table{index, command}
+    ///
+    /// MVP (issue #27): reads the saved REPL history file
+    /// (~/.hsab_history). The current session's in-memory entries are only
+    /// visible after they are flushed on REPL exit.
+    pub(crate) fn builtin_history_t(&mut self) -> Result<(), EvalError> {
+        let columns = vec!["index".to_string(), "command".to_string()];
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+
+        let history_path = std::env::var("HOME")
+            .map(|h| Path::new(&h).join(".hsab_history"))
+            .ok();
+
+        if let Some(path) = history_path {
+            if let Ok(content) = fs::read_to_string(&path) {
+                for (i, line) in content
+                    .lines()
+                    .filter(|l| !l.is_empty() && *l != "#V2")
+                    .enumerate()
+                {
+                    rows.push(vec![Value::Int(i as i64), Value::Literal(line.to_string())]);
+                }
+            }
+        }
+
+        self.stack.push(Value::Table { columns, rows });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// ps-t: ps-t -> Table{pid, name, cpu, mem, status}
+    ///
+    /// cpu is cumulative CPU seconds, mem is resident set size in bytes.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn builtin_ps_t(&mut self) -> Result<(), EvalError> {
+        let columns = vec![
+            "pid".to_string(),
+            "name".to_string(),
+            "cpu".to_string(),
+            "mem".to_string(),
+            "status".to_string(),
+        ];
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+
+        let clk_tck = 100.0; // standard USER_HZ on Linux
+
+        if let Ok(entries) = fs::read_dir("/proc") {
+            for entry in entries.flatten() {
+                let fname = entry.file_name().to_string_lossy().to_string();
+                let pid: i64 = match fname.parse() {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+
+                let stat = match fs::read_to_string(format!("/proc/{}/stat", pid)) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+
+                // comm is parenthesized and may contain spaces: find the
+                // enclosing parens, then split the rest
+                let (name, rest) = match (stat.find('('), stat.rfind(')')) {
+                    (Some(open), Some(close)) if close > open => (
+                        stat[open + 1..close].to_string(),
+                        stat[close + 1..].trim().to_string(),
+                    ),
+                    _ => continue,
+                };
+
+                let fields: Vec<&str> = rest.split_whitespace().collect();
+                // fields[0] is state (field 3 of stat); utime/stime are
+                // fields 14/15 of stat = fields[11]/fields[12] here;
+                // rss pages = field 24 = fields[21]
+                let status = fields.first().unwrap_or(&"?").to_string();
+                let utime: f64 = fields.get(11).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let stime: f64 = fields.get(12).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                let rss_pages: i64 = fields.get(21).and_then(|s| s.parse().ok()).unwrap_or(0);
+                let page_size = 4096i64;
+
+                rows.push(vec![
+                    Value::Int(pid),
+                    Value::Literal(name),
+                    Value::Number((utime + stime) / clk_tck),
+                    Value::Int(rss_pages * page_size),
+                    Value::Literal(status),
+                ]);
+            }
+        }
+
+        rows.sort_by_key(|row| match row.first() {
+            Some(Value::Int(pid)) => *pid,
+            _ => 0,
+        });
+
+        self.stack.push(Value::Table { columns, rows });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// ps-t (macOS): shells out to `ps` and parses the fixed columns.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn builtin_ps_t(&mut self) -> Result<(), EvalError> {
+        use std::process::Command;
+
+        let columns = vec![
+            "pid".to_string(),
+            "name".to_string(),
+            "cpu".to_string(),
+            "mem".to_string(),
+            "status".to_string(),
+        ];
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+
+        let output = Command::new("ps")
+            .args(["-axo", "pid=,cputime=,rss=,state=,comm="])
+            .output()
+            .map_err(|e| EvalError::ExecError(format!("ps-t: {}", e)))?;
+
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 5 {
+                continue;
+            }
+            let pid: i64 = fields[0].parse().unwrap_or(0);
+            // cputime is MM:SS.ss
+            let cpu: f64 = {
+                let parts: Vec<&str> = fields[1].split(':').collect();
+                let mins: f64 = parts.first().and_then(|m| m.parse().ok()).unwrap_or(0.0);
+                let secs: f64 = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                mins * 60.0 + secs
+            };
+            let mem: i64 = fields[2].parse::<i64>().unwrap_or(0) * 1024; // rss is KB
+            let status = fields[3].to_string();
+            let name = fields[4..].join(" ");
+
+            rows.push(vec![
+                Value::Int(pid),
+                Value::Literal(name),
+                Value::Number(cpu),
+                Value::Int(mem),
+                Value::Literal(status),
+            ]);
+        }
+
+        self.stack.push(Value::Table { columns, rows });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// ps-t (other platforms): graceful empty table
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    pub(crate) fn builtin_ps_t(&mut self) -> Result<(), EvalError> {
+        self.stack.push(Value::Table {
+            columns: vec![
+                "pid".to_string(),
+                "name".to_string(),
+                "cpu".to_string(),
+                "mem".to_string(),
+                "status".to_string(),
+            ],
+            rows: vec![],
+        });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+}

--- a/src/eval/shell_native.rs
+++ b/src/eval/shell_native.rs
@@ -201,7 +201,7 @@ impl Evaluator {
                 }
             }
             if count > 0 {
-                self.stack.push(Value::Number(count as f64));
+                self.stack.push(Value::Int(count as i64));
             } else {
                 self.stack.push(Value::Nil);
             }
@@ -209,7 +209,7 @@ impl Evaluator {
             // Single file
             match fs::remove_file(path) {
                 Ok(_) => {
-                    self.stack.push(Value::Number(1.0));
+                    self.stack.push(Value::Int(1));
                 }
                 Err(_) => {
                     self.stack.push(Value::Nil);
@@ -230,7 +230,7 @@ impl Evaluator {
             let count = Self::count_items(path);
             match fs::remove_dir_all(path) {
                 Ok(_) => {
-                    self.stack.push(Value::Number(count as f64));
+                    self.stack.push(Value::Int(count as i64));
                 }
                 Err(_) => {
                     self.stack.push(Value::Nil);
@@ -239,7 +239,7 @@ impl Evaluator {
         } else if path.is_file() {
             match fs::remove_file(path) {
                 Ok(_) => {
-                    self.stack.push(Value::Number(1.0));
+                    self.stack.push(Value::Int(1));
                 }
                 Err(_) => {
                     self.stack.push(Value::Nil);

--- a/src/eval/stack.rs
+++ b/src/eval/stack.rs
@@ -87,6 +87,7 @@ impl Evaluator {
                     n.to_string()
                 }
             }
+            Value::Int(i) => i.to_string(),
             Value::Bool(b) => b.to_string(),
             Value::Nil => "nil".to_string(),
             Value::Marker => "<marker>".to_string(),
@@ -126,6 +127,7 @@ impl Evaluator {
                         n.to_string()
                     }
                 }
+                Value::Int(i) => i.to_string(),
                 Value::Bool(b) => b.to_string(),
                 Value::Nil => "nil".to_string(),
                 Value::Marker => "<marker>".to_string(),

--- a/src/eval/stats.rs
+++ b/src/eval/stats.rs
@@ -10,6 +10,7 @@ fn extract_numbers(val: &Value, _op: &str) -> Result<Vec<f64>, EvalError> {
                 .iter()
                 .filter_map(|v| match v {
                     Value::Number(n) => Some(*n),
+                    Value::Int(i) => Some(*i as f64),
                     Value::Literal(s) | Value::Output(s) => s.trim().parse().ok(),
                     _ => None,
                 })

--- a/src/eval/structured.rs
+++ b/src/eval/structured.rs
@@ -14,8 +14,12 @@ impl Evaluator {
             // typeof treats numeric-looking strings as numbers (shell compat);
             // everything else defers to Value::type_name()
             Value::Literal(s) | Value::Output(s) => {
-                if s.trim().parse::<f64>().is_ok() {
-                    "number"
+                // Shell compat: numeric-looking strings report their numeric type
+                let t = s.trim();
+                if t.parse::<i64>().is_ok() {
+                    "int"
+                } else if t.parse::<f64>().is_ok() {
+                    "float"
                 } else {
                     "string"
                 }
@@ -118,7 +122,7 @@ impl Evaluator {
                 let field = match key.as_str() {
                     "kind" => Some(Value::Literal(kind)),
                     "message" => Some(Value::Literal(message)),
-                    "code" => code.map(|c| Value::Number(c as f64)),
+                    "code" => code.map(|c| Value::Int(c as i64)),
                     "source" => source.map(Value::Literal),
                     "command" => command.map(Value::Literal),
                     _ => None,
@@ -752,7 +756,7 @@ impl Evaluator {
             .ok_or_else(|| EvalError::StackUnderflow("number? requires value".into()))?;
 
         let is_number = match &val {
-            Value::Number(_) => true,
+            Value::Number(_) | Value::Int(_) => true,
             Value::Literal(s) | Value::Output(s) => s.trim().parse::<f64>().is_ok(),
             _ => false,
         };
@@ -879,6 +883,7 @@ impl Evaluator {
         match val {
             Value::Bool(b) => *b,
             Value::Number(n) => *n != 0.0,
+            Value::Int(i) => *i != 0,
             Value::Nil => false,
             Value::Literal(s) | Value::Output(s) => !s.is_empty(),
             Value::List(items) => !items.is_empty(),
@@ -1029,8 +1034,8 @@ impl Evaluator {
             rows.push(vec![
                 Value::Literal(name),
                 Value::Literal(file_type),
-                Value::Number(size as f64),
-                Value::Number(modified as f64),
+                Value::Int(size as i64),
+                Value::Int(modified),
             ]);
         }
 

--- a/src/eval/structured.rs
+++ b/src/eval/structured.rs
@@ -487,6 +487,273 @@ impl Evaluator {
         }
     }
 
+    /// sort-by-desc: Table "col" sort-by-desc -> Table (descending)
+    /// Also works on List<Record> like sort-by (issue #26).
+    pub(crate) fn builtin_sort_by_desc(&mut self) -> Result<(), EvalError> {
+        let key_val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow("sort-by-desc requires key/column".into()))?;
+
+        let data = self.stack.pop().ok_or_else(|| {
+            EvalError::StackUnderflow("sort-by-desc requires table or list".into())
+        })?;
+
+        match data {
+            Value::Table { columns, mut rows } => {
+                let col = key_val.as_arg().ok_or_else(|| EvalError::TypeError {
+                    expected: "String".into(),
+                    got: key_val.type_name().to_string(),
+                })?;
+
+                if let Some(col_idx) = columns.iter().position(|c| c == &col) {
+                    rows.sort_by(|a, b| {
+                        let av = a.get(col_idx).and_then(|v| v.as_arg()).unwrap_or_default();
+                        let bv = b.get(col_idx).and_then(|v| v.as_arg()).unwrap_or_default();
+                        Self::compare_strings(&bv, &av)
+                    });
+                }
+                self.stack.push(Value::Table { columns, rows });
+            }
+            Value::List(mut items) => {
+                let key_name = key_val.as_arg().unwrap_or_default();
+
+                items.sort_by(|a, b| {
+                    let av = Self::extract_sort_key(a, &key_name);
+                    let bv = Self::extract_sort_key(b, &key_name);
+                    Self::compare_strings(&bv, &av)
+                });
+
+                self.stack.push(Value::List(items));
+            }
+            _ => {
+                return Err(EvalError::TypeError {
+                    expected: "Table or List".into(),
+                    got: data.type_name().to_string(),
+                })
+            }
+        }
+
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// Pop a Table from the stack (helper for table ops, issue #26)
+    fn pop_table(&mut self, op: &str) -> Result<(Vec<String>, Vec<Vec<Value>>), EvalError> {
+        let val = self
+            .stack
+            .pop()
+            .ok_or_else(|| EvalError::StackUnderflow(format!("{} requires a table", op)))?;
+        match val {
+            Value::Table { columns, rows } => Ok((columns, rows)),
+            other => {
+                let err = EvalError::TypeError {
+                    expected: "Table".into(),
+                    got: other.type_name().to_string(),
+                };
+                self.stack.push(other);
+                Err(err)
+            }
+        }
+    }
+
+    /// join-on: LeftTable RightTable "leftKey" "rightKey" join-on -> Table
+    ///
+    /// Inner join: rows are combined where left[leftKey] == right[rightKey]
+    /// (string comparison via as_arg). The right table's key column is
+    /// dropped; any other right column whose name collides with a left
+    /// column is suffixed with "_right".
+    pub(crate) fn builtin_join_on(&mut self) -> Result<(), EvalError> {
+        let right_key = self.pop_string()?;
+        let left_key = self.pop_string()?;
+        let (right_cols, right_rows) = self.pop_table("join-on")?;
+        let (left_cols, left_rows) = self.pop_table("join-on")?;
+
+        let left_idx = left_cols
+            .iter()
+            .position(|c| c == &left_key)
+            .ok_or_else(|| {
+                EvalError::ExecError(format!(
+                    "join-on: column '{}' not found in left table",
+                    left_key
+                ))
+            })?;
+        let right_idx = right_cols
+            .iter()
+            .position(|c| c == &right_key)
+            .ok_or_else(|| {
+                EvalError::ExecError(format!(
+                    "join-on: column '{}' not found in right table",
+                    right_key
+                ))
+            })?;
+
+        // Output columns: left columns, then right columns minus the join key
+        // (collisions suffixed with "_right")
+        let mut columns = left_cols.clone();
+        let mut right_out_indices: Vec<usize> = Vec::new();
+        for (i, rc) in right_cols.iter().enumerate() {
+            if i == right_idx {
+                continue;
+            }
+            right_out_indices.push(i);
+            if left_cols.contains(rc) {
+                columns.push(format!("{}_right", rc));
+            } else {
+                columns.push(rc.clone());
+            }
+        }
+
+        let mut rows: Vec<Vec<Value>> = Vec::new();
+        for lrow in &left_rows {
+            let lkey = lrow.get(left_idx).and_then(|v| v.as_arg());
+            for rrow in &right_rows {
+                let rkey = rrow.get(right_idx).and_then(|v| v.as_arg());
+                if lkey.is_some() && lkey == rkey {
+                    let mut row = lrow.clone();
+                    for &i in &right_out_indices {
+                        row.push(rrow.get(i).cloned().unwrap_or(Value::Nil));
+                    }
+                    rows.push(row);
+                }
+            }
+        }
+
+        self.stack.push(Value::Table { columns, rows });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// add-column: Table Block "name" add-column -> Table
+    ///
+    /// Adds a new column computed by running Block once per row with the
+    /// row pushed as a Record; the block's result (top of stack) becomes
+    /// the cell value.
+    pub(crate) fn builtin_add_column(&mut self) -> Result<(), EvalError> {
+        let name = self.pop_string()?;
+        let block = self.pop_block()?;
+        let (mut columns, rows) = self.pop_table("add-column")?;
+
+        let mut new_rows: Vec<Vec<Value>> = Vec::with_capacity(rows.len());
+        for row in rows {
+            let record: IndexMap<String, Value> = columns
+                .iter()
+                .zip(row.iter())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            let saved_stack = std::mem::take(&mut self.stack);
+            self.stack.push(Value::Map(record));
+            for expr in &block {
+                self.eval_expr(expr)?;
+            }
+            let cell = self.stack.pop().unwrap_or(Value::Nil);
+            self.stack = saved_stack;
+
+            let mut new_row = row;
+            new_row.push(cell);
+            new_rows.push(new_row);
+        }
+
+        columns.push(name);
+        self.stack.push(Value::Table {
+            columns,
+            rows: new_rows,
+        });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// map-column: Table "col" Block map-column -> Table
+    ///
+    /// Transforms column `col` in place by running Block once per row with
+    /// the current cell value pushed; the block's result replaces the cell.
+    pub(crate) fn builtin_map_column(&mut self) -> Result<(), EvalError> {
+        let block = self.pop_block()?;
+        let col = self.pop_string()?;
+        let (columns, rows) = self.pop_table("map-column")?;
+
+        let col_idx = columns.iter().position(|c| c == &col).ok_or_else(|| {
+            EvalError::ExecError(format!("map-column: column '{}' not found", col))
+        })?;
+
+        let mut new_rows: Vec<Vec<Value>> = Vec::with_capacity(rows.len());
+        for mut row in rows {
+            let cell = row.get(col_idx).cloned().unwrap_or(Value::Nil);
+
+            let saved_stack = std::mem::take(&mut self.stack);
+            self.stack.push(cell);
+            for expr in &block {
+                self.eval_expr(expr)?;
+            }
+            let new_cell = self.stack.pop().unwrap_or(Value::Nil);
+            self.stack = saved_stack;
+
+            if col_idx < row.len() {
+                row[col_idx] = new_cell;
+            }
+            new_rows.push(row);
+        }
+
+        self.stack.push(Value::Table {
+            columns,
+            rows: new_rows,
+        });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// rename-column: Table "old" "new" rename-column -> Table
+    pub(crate) fn builtin_rename_column(&mut self) -> Result<(), EvalError> {
+        let new_name = self.pop_string()?;
+        let old_name = self.pop_string()?;
+        let (mut columns, rows) = self.pop_table("rename-column")?;
+
+        let idx = columns.iter().position(|c| c == &old_name).ok_or_else(|| {
+            EvalError::ExecError(format!("rename-column: column '{}' not found", old_name))
+        })?;
+        columns[idx] = new_name;
+
+        self.stack.push(Value::Table { columns, rows });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
+    /// transpose: Table transpose -> Table (columns and rows swapped)
+    ///
+    /// The result has a "column" column holding the original column names,
+    /// plus one column per original row (named "0", "1", ...). Column order
+    /// is deterministic (insertion order).
+    pub(crate) fn builtin_transpose(&mut self) -> Result<(), EvalError> {
+        let (columns, rows) = self.pop_table("transpose")?;
+
+        let mut new_columns: Vec<String> = Vec::with_capacity(rows.len() + 1);
+        new_columns.push("column".to_string());
+        for i in 0..rows.len() {
+            new_columns.push(i.to_string());
+        }
+
+        let new_rows: Vec<Vec<Value>> = columns
+            .iter()
+            .enumerate()
+            .map(|(col_idx, col_name)| {
+                let mut row: Vec<Value> = Vec::with_capacity(rows.len() + 1);
+                row.push(Value::Literal(col_name.clone()));
+                for r in &rows {
+                    row.push(r.get(col_idx).cloned().unwrap_or(Value::Nil));
+                }
+                row
+            })
+            .collect();
+
+        self.stack.push(Value::Table {
+            columns: new_columns,
+            rows: new_rows,
+        });
+        self.last_exit_code = 0;
+        Ok(())
+    }
+
     pub(crate) fn builtin_select(&mut self) -> Result<(), EvalError> {
         let cols_val = self
             .stack

--- a/src/eval/tests.rs
+++ b/src/eval/tests.rs
@@ -987,10 +987,10 @@ mod tests {
 
         assert!(result.is_ok(), "fetch-status should succeed: {:?}", result);
         assert_eq!(eval.stack.len(), 1);
-        if let Value::Number(n) = &eval.stack[0] {
-            assert_eq!(*n, 200.0);
+        if let Value::Int(n) = &eval.stack[0] {
+            assert_eq!(*n, 200);
         } else {
-            panic!("Expected Number for status code");
+            panic!("Expected Int for status code");
         }
     }
 
@@ -1003,10 +1003,10 @@ mod tests {
         let result = eval.eval(&program);
 
         assert!(result.is_ok(), "fetch-status should succeed: {:?}", result);
-        if let Value::Number(n) = &eval.stack[0] {
-            assert_eq!(*n, 404.0);
+        if let Value::Int(n) = &eval.stack[0] {
+            assert_eq!(*n, 404);
         } else {
-            panic!("Expected Number for status code");
+            panic!("Expected Int for status code");
         }
     }
 

--- a/src/eval/watch.rs
+++ b/src/eval/watch.rs
@@ -26,12 +26,15 @@ mod watch_impl {
             let block = self.pop_block()?;
 
             // Check for optional debounce value
-            let (pattern, debounce_ms) = if let Some(Value::Number(_)) = self.stack.last() {
+            let (pattern, debounce_ms) = if matches!(
+                self.stack.last(),
+                Some(Value::Number(_)) | Some(Value::Int(_))
+            ) {
                 let debounce = self.stack.pop().unwrap();
-                let d = if let Value::Number(n) = debounce {
-                    n as u64
-                } else {
-                    200
+                let d = match debounce {
+                    Value::Number(n) => n as u64,
+                    Value::Int(i) => i as u64,
+                    _ => 200,
                 };
                 let p = self
                     .stack

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -597,6 +597,51 @@ fn try_range_expansion(content: &str) -> Option<Vec<String>> {
     None
 }
 
+/// Source position of a token: (line, column), both 1-based
+pub type Span = (usize, usize);
+
+/// Tokenize a complete input string, attaching a (line, col) span to each
+/// token (issue #33). Columns are byte-based within the comment-stripped
+/// input; brace-expanded tokens all inherit the span of the original word.
+pub fn lex_spanned(input: &str) -> Result<Vec<(Token, Span)>, LexError> {
+    let stripped = strip_comments(input);
+    let mut rest = stripped.as_str();
+    let mut out: Vec<(Token, Span)> = Vec::new();
+
+    loop {
+        let trimmed = rest.trim_start();
+        if trimmed.is_empty() {
+            break;
+        }
+        let offset = stripped.len() - trimmed.len();
+        let before = &stripped[..offset];
+        let line = before.matches('\n').count() + 1;
+        let col = offset - before.rfind('\n').map(|i| i + 1).unwrap_or(0) + 1;
+
+        match token(trimmed) {
+            Ok((next, tok)) => {
+                if next.len() == trimmed.len() {
+                    // No progress - bail out instead of looping forever
+                    return Err(LexError::UnexpectedChar(
+                        trimmed.chars().next().unwrap_or(' '),
+                    ));
+                }
+                for t in expand_braces(tok) {
+                    out.push((t, (line, col)));
+                }
+                rest = next;
+            }
+            Err(_) => {
+                return Err(LexError::UnexpectedChar(
+                    trimmed.chars().next().unwrap_or(' '),
+                ));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
 /// Tokenize a complete input string
 pub fn lex(input: &str) -> Result<Vec<Token>, LexError> {
     // Strip inline comments first

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ pub mod util;
 // Re-export commonly used items
 pub use ast::{Expr, FutureState, Program, Value};
 pub use eval::{EvalError, EvalResult, Evaluator};
-pub use lexer::{lex, LexError, Operator, Token};
-pub use parser::{parse, ParseError};
+pub use lexer::{lex, lex_spanned, LexError, Operator, Span, Token};
+pub use parser::{parse, parse_with_spans, ParseError};
 #[cfg(feature = "plugins")]
 pub use plugin::{PluginError, PluginHost, PluginManifest};
 pub use resolver::ExecutableResolver;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,11 +165,26 @@ fn try_dynamic_pattern(word: &str) -> Option<Vec<Expr>> {
 pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
+    /// Source spans parallel to `tokens` (empty when parsing without spans)
+    token_spans: Vec<crate::lexer::Span>,
+    /// Statement-level spans parallel to the produced Program expressions
+    /// (issue #33); filled during `parse()` when `token_spans` is present
+    stmt_spans: Vec<crate::lexer::Span>,
 }
 
 impl Parser {
     pub fn new(tokens: Vec<Token>) -> Self {
-        Parser { tokens, pos: 0 }
+        Parser {
+            tokens,
+            pos: 0,
+            token_spans: Vec::new(),
+            stmt_spans: Vec::new(),
+        }
+    }
+
+    /// Span of the token at the current position (line/col, 1-based)
+    fn span_at_pos(&self) -> crate::lexer::Span {
+        self.token_spans.get(self.pos).copied().unwrap_or((0, 0))
     }
 
     /// Peek at the current token without consuming it
@@ -198,16 +213,26 @@ impl Parser {
         let mut expressions = Vec::new();
 
         // Check for scoped variable assignments: NAME=value ... ;
+        let scoped_span = self.span_at_pos();
         if let Some(scoped) = self.try_parse_scoped_block()? {
             expressions.push(scoped);
+            self.stmt_spans.push(scoped_span);
             // Parse any remaining expressions after the scoped block
             while !self.is_at_end() {
+                let span = self.span_at_pos();
                 let exprs = self.parse_expr()?;
+                for _ in 0..exprs.len() {
+                    self.stmt_spans.push(span);
+                }
                 expressions.extend(exprs);
             }
         } else {
             while !self.is_at_end() {
+                let span = self.span_at_pos();
                 let exprs = self.parse_expr()?;
+                for _ in 0..exprs.len() {
+                    self.stmt_spans.push(span);
+                }
                 expressions.extend(exprs);
             }
         }
@@ -439,6 +464,20 @@ impl Parser {
 }
 
 /// Parse tokens into a Program
+/// Parse spanned tokens (from `lex_spanned`), returning the Program plus a
+/// statement-level span per top-level expression (issue #33).
+pub fn parse_with_spans(
+    tokens: Vec<(Token, crate::lexer::Span)>,
+) -> Result<(Program, Vec<crate::lexer::Span>), ParseError> {
+    let spans: Vec<crate::lexer::Span> = tokens.iter().map(|(_, s)| *s).collect();
+    let toks: Vec<Token> = tokens.into_iter().map(|(t, _)| t).collect();
+    let mut parser = Parser::new(toks);
+    parser.token_spans = spans;
+    let program = parser.parse()?;
+    let stmt_spans = std::mem::take(&mut parser.stmt_spans);
+    Ok((program, stmt_spans))
+}
+
 pub fn parse(tokens: Vec<Token>) -> Result<Program, ParseError> {
     let mut parser = Parser::new(tokens);
     parser.parse()

--- a/src/plugin/abi.rs
+++ b/src/plugin/abi.rs
@@ -123,6 +123,7 @@ pub fn value_to_json(value: &crate::Value) -> String {
         Value::Literal(s) => serde_json::to_string(s).unwrap_or_else(|_| "null".to_string()),
         Value::Output(s) => serde_json::to_string(s).unwrap_or_else(|_| "null".to_string()),
         Value::Number(n) => n.to_string(),
+        Value::Int(i) => i.to_string(),
         Value::Bool(b) => b.to_string(),
         Value::Nil => "null".to_string(),
         Value::Block(exprs) => {
@@ -261,7 +262,9 @@ fn json_value_to_hsab_value(json: &serde_json::Value) -> crate::Value {
         serde_json::Value::Null => Value::Nil,
         serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Number(n) => {
-            if let Some(f) = n.as_f64() {
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else if let Some(f) = n.as_f64() {
                 Value::Number(f)
             } else {
                 Value::Literal(n.to_string())

--- a/src/plugin/imports.rs
+++ b/src/plugin/imports.rs
@@ -238,6 +238,7 @@ fn hsab_stack_pop_number(env: FunctionEnvMut<PluginEnv>) -> f64 {
         if let Some(value) = stack.pop() {
             match value {
                 Value::Number(n) => return n,
+                Value::Int(i) => return i as f64,
                 Value::Literal(s) | Value::Output(s) => {
                     if let Ok(n) = s.parse::<f64>() {
                         return n;
@@ -259,6 +260,7 @@ fn hsab_stack_pop_bool(env: FunctionEnvMut<PluginEnv>) -> i32 {
                     return if s == "true" || s == "1" { 1 } else { 0 };
                 }
                 Value::Number(n) => return if n != 0.0 { 1 } else { 0 },
+                Value::Int(i) => return if i != 0 { 1 } else { 0 },
                 _ => {}
             }
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -83,6 +83,7 @@ impl SharedState {
     fn is_simple_value(&self, value: &Value) -> bool {
         match value {
             Value::Number(_) => true,
+            Value::Int(_) => true,
             Value::Bool(_) => true,
             Value::BigInt(n) => n.to_string().len() <= 20, // Reasonable length bigints
             Value::Literal(s) | Value::Output(s) => {
@@ -210,6 +211,7 @@ impl SharedState {
                     Some(format!("{}", n))
                 }
             }
+            Value::Int(i) => Some(i.to_string()),
             Value::Bool(b) => Some(format!("{}", b)),
             Value::BigInt(n) => Some(n.to_string()),
             Value::Literal(s) | Value::Output(s) => Some(s.clone()),
@@ -237,6 +239,7 @@ impl SharedState {
                     format!("f64:{}", n)
                 }
             }
+            Value::Int(i) => format!("i64:{}", i),
             Value::Bool(b) => format!("bool:{}", b),
             Value::Map(m) => {
                 let fields: Vec<_> = m.keys().take(3).cloned().collect();
@@ -322,6 +325,7 @@ impl SharedState {
                         Value::Table { .. } => Some("[table](tbl)".to_string()),
                         Value::List(_) => Some("[list](lst)".to_string()),
                         Value::Number(n) => Some(format!("{}(num)", n)),
+                        Value::Int(i) => Some(format!("{}(num)", i)),
                         Value::Bool(b) => Some(format!("{}(bool)", b)),
                         Value::Error { message, .. } => Some(format!("ERR:{}", message)),
                         Value::Media { data, .. } => Some(format!("<img:{}B>(media)", data.len())),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -520,6 +520,12 @@ pub fn default_builtins() -> &'static HashSet<&'static str> {
             ".plugin-info",
             // Structured builtins
             "ls-table",
+            // Structured-returning core builtins (issue #27)
+            "ls-t",
+            "ps-t",
+            "env-t",
+            "which-t",
+            "history-t",
             "open",
             "save",
             // Media / Image operations

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -481,6 +481,12 @@ pub fn default_builtins() -> &'static HashSet<&'static str> {
             "five-num",
             // Phase 8: Extended table/list ops
             "group-by",
+            "join-on",
+            "add-column",
+            "map-column",
+            "rename-column",
+            "transpose",
+            "sort-by-desc",
             "unique",
             "reverse",
             "flatten",

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,4 +1,4 @@
-use hsab::{display, lex, parse, Evaluator, Value};
+use hsab::{display, lex_spanned, parse_with_spans, Evaluator, Value};
 
 /// Execute a single line of hsab code
 pub(crate) fn execute_line(
@@ -16,15 +16,17 @@ pub(crate) fn execute_line_with_options(
     print_output: bool,
     use_format: bool,
 ) -> Result<i32, String> {
-    let tokens = lex(input).map_err(|e| e.to_string())?;
+    let tokens = lex_spanned(input).map_err(|e| e.to_string())?;
 
     // Empty input is OK
     if tokens.is_empty() {
         return Ok(0);
     }
 
-    let program = parse(tokens).map_err(|e| e.to_string())?;
-    let result = eval.eval(&program).map_err(|e| e.to_string())?;
+    let (program, spans) = parse_with_spans(tokens).map_err(|e| e.to_string())?;
+    let result = eval
+        .eval_with_spans(&program, &spans)
+        .map_err(|e| e.to_string())?;
 
     if print_output {
         // Get terminal width for formatting

--- a/tests/test_arithmetic.rs
+++ b/tests/test_arithmetic.rs
@@ -92,7 +92,7 @@ fn test_sqrt_zero() {
 #[test]
 fn test_sort_nums_ascending() {
     let output = eval(r#"'[3,1,4,1,5,9,2,6]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[1.0,1.0,2.0,3.0,4.0,5.0,6.0,9.0]");
+    assert_eq!(output.trim(), "[1,1,2,3,4,5,6,9]");
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn test_sort_nums_with_floats() {
 #[test]
 fn test_sort_nums_negative() {
     let output = eval(r#"'[-5,3,-2,0,1]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[-5.0,-2.0,0.0,1.0,3.0]");
+    assert_eq!(output.trim(), "[-5,-2,0,1,3]");
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn test_sort_nums_empty() {
 #[test]
 fn test_sort_nums_single() {
     let output = eval(r#"'[42]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[42.0]");
+    assert_eq!(output.trim(), "[42]");
 }
 
 // === Unicode operator alias tests ===

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -300,14 +300,14 @@ fn test_parallel_preserves_order() {
 fn test_parallel_map_basic() {
     // Double each number
     let output = eval(r#"#[1 2 3] #[2 mul] 2 parallel-map to-json"#).unwrap();
-    assert_eq!(output.trim(), "[2.0,4.0,6.0]");
+    assert_eq!(output.trim(), "[2,4,6]");
 }
 
 #[test]
 fn test_parallel_map_single_thread() {
     // Limit to 1 thread (sequential)
     let output = eval(r#"#[10 20 30] #[1 plus] 1 parallel-map to-json"#).unwrap();
-    assert_eq!(output.trim(), "[11.0,21.0,31.0]");
+    assert_eq!(output.trim(), "[11,21,31]");
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn test_parallel_map_empty_list() {
 fn test_parallel_map_preserves_order() {
     // Results must be in the same order as input
     let output = eval(r#"#[5 4 3 2 1] #[10 mul] 3 parallel-map to-json"#).unwrap();
-    assert_eq!(output.trim(), "[50.0,40.0,30.0,20.0,10.0]");
+    assert_eq!(output.trim(), "[50,40,30,20,10]");
 }
 
 #[test]
@@ -344,7 +344,7 @@ fn test_parallel_map_identity() {
 fn test_parallel_map_high_concurrency() {
     // More threads than items is fine
     let output = eval(r#"#[1 2] #[3 plus] 100 parallel-map to-json"#).unwrap();
-    assert_eq!(output.trim(), "[4.0,5.0]");
+    assert_eq!(output.trim(), "[4,5]");
 }
 
 #[test]
@@ -359,7 +359,7 @@ fn test_parallel_map_error_in_block() {
 fn test_parallel_map_with_json_list() {
     // Using from-json to create a proper numeric list
     let output = eval(r#"'[1,2,3]' from-json #[2 mul] 2 parallel-map to-json"#).unwrap();
-    assert_eq!(output.trim(), "[2.0,4.0,6.0]");
+    assert_eq!(output.trim(), "[2,4,6]");
 }
 
 // ============================================

--- a/tests/test_bigint.rs
+++ b/tests/test_bigint.rs
@@ -154,7 +154,7 @@ fn test_bigint_pow() {
 #[test]
 fn test_sort_nums_single() {
     let output = eval(r#"'[42]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[42.0]");
+    assert_eq!(output.trim(), "[42]");
 }
 
 #[test]
@@ -629,9 +629,10 @@ fn test_bigint_sub_negative_result_error() {
 
 #[test]
 fn test_bigint_negative_number_error() {
+    // -5 is now a first-class Int (issue #24); to-bigint rejects negatives
     let result = eval(r#"-5 to-bigint"#);
     assert!(result.is_err());
-    assert!(result.unwrap_err().contains("Invalid decimal"));
+    assert!(result.unwrap_err().contains("negative"));
 }
 
 #[test]

--- a/tests/test_combinators.rs
+++ b/tests/test_combinators.rs
@@ -116,9 +116,11 @@ fn test_mod_by_zero() {
 
 #[test]
 fn test_arithmetic_non_numeric() {
-    // Non-numeric strings in arithmetic use 0 fallback
-    let output = eval(r#""abc" "def" plus"#).unwrap();
-    assert_eq!(output.trim(), "0");
+    // Non-numeric strings in arithmetic are a TypeError (issue #24;
+    // previously they silently coerced to 0)
+    let result = eval(r#""abc" "def" plus"#);
+    assert!(result.is_err(), "non-numeric operand must be a TypeError");
+    assert!(result.unwrap_err().contains("expected number"));
 }
 
 #[test]
@@ -192,7 +194,7 @@ fn test_compose_empty_blocks() {
 #[test]
 fn test_sort_nums_single() {
     let output = eval(r#"'[42]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[42.0]");
+    assert_eq!(output.trim(), "[42]");
 }
 
 #[test]

--- a/tests/test_encoding.rs
+++ b/tests/test_encoding.rs
@@ -209,7 +209,7 @@ fn test_empty_string_sha256() {
 #[test]
 fn test_sort_nums_single() {
     let output = eval(r#"'[42]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[42.0]");
+    assert_eq!(output.trim(), "[42]");
 }
 
 #[test]

--- a/tests/test_functional.rs
+++ b/tests/test_functional.rs
@@ -110,3 +110,60 @@ fn test_bend_then_reduce_sum() {
     let output = eval("1 #[dup 5 le?] #[dup 1 plus] bend 0 #[plus] reduce").unwrap();
     assert_eq!(output.trim(), "15");
 }
+
+// ============================================
+// Issue #28: collect/keep/spread preserve Value types
+// ============================================
+
+#[test]
+fn test_collect_preserves_list_type() {
+    let output = eval("[1 2 3] spread collect typeof").unwrap();
+    assert_eq!(output.trim(), "list");
+}
+
+#[test]
+fn test_collect_preserves_element_types() {
+    let output = eval("[1 2 3] spread collect 0 nth typeof").unwrap();
+    assert_eq!(output.trim(), "int");
+}
+
+#[test]
+fn test_keep_preserves_numeric_elements() {
+    let output = eval("[1 2 3] spread #[2 gt?] keep collect").unwrap();
+    assert_eq!(output.trim(), "3");
+}
+
+#[test]
+fn test_keep_collect_yields_list_of_numbers() {
+    let output = eval("[1 2 3 4] spread #[2 gt?] keep collect to-json").unwrap();
+    assert_eq!(output.trim(), "[3,4]");
+}
+
+#[test]
+fn test_table_spread_pushes_records() {
+    let output =
+        eval(r#"marker "n" 1 record "n" 2 record table spread collect 0 nth typeof"#).unwrap();
+    assert_eq!(output.trim(), "record");
+}
+
+#[test]
+fn test_table_spread_keep_collect_keeps_records() {
+    let output = eval(
+        r#"marker "n" 1 record "n" 2 record table spread #["n" get 1 gt?] keep collect 0 nth "n" get"#,
+    )
+    .unwrap();
+    assert_eq!(output.trim(), "2");
+}
+
+#[test]
+fn test_collect_empty_region_is_nil() {
+    let output = eval("[1 2 3] spread #[10 gt?] keep collect nil?").unwrap();
+    assert!(output.contains("true"));
+}
+
+#[test]
+fn test_string_spread_collect_still_joins_lines() {
+    // Text pipelines keep working: List.as_arg joins with newlines
+    let output = eval(r#""a\nb\nc" spread collect"#).unwrap();
+    assert_eq!(output.trim(), "a\nb\nc");
+}

--- a/tests/test_serialization_naming.rs
+++ b/tests/test_serialization_naming.rs
@@ -76,8 +76,8 @@ fn test_from_json_parses_number() {
     let output = eval(r#"'42' from-json typeof"#).unwrap();
     assert_eq!(
         output.trim(),
-        "number",
-        "from-json should parse JSON number"
+        "int",
+        "from-json should parse JSON integers as int (issue #24)"
     );
 }
 

--- a/tests/test_shell.rs
+++ b/tests/test_shell.rs
@@ -547,3 +547,94 @@ fn test_into_kv_parsing() {
     let output = eval(r#""name=Alice\nage=30" from-kv"#).unwrap();
     assert!(output.contains("name") || output.contains("Alice"));
 }
+
+// ============================================
+// Issue #25: external-command boundary
+// ============================================
+
+#[cfg(unix)]
+mod command_boundary {
+    use super::common::{lex, parse, Evaluator};
+    use hsab::Value;
+
+    fn eval_stack(input: &str) -> Vec<Value> {
+        let tokens = lex(input).expect("lex");
+        let program = parse(tokens).expect("parse");
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.eval(&program).expect("eval should not abort");
+        result.stack
+    }
+
+    #[test]
+    fn test_failed_command_pushes_structured_error() {
+        let stack = eval_stack(r#""echo oops >&2; exit 3" "-c" sh"#);
+        assert_eq!(stack.len(), 1);
+        match &stack[0] {
+            Value::Error {
+                kind,
+                message,
+                code,
+                command,
+                ..
+            } => {
+                assert_eq!(kind, "command");
+                assert_eq!(message, "oops");
+                assert_eq!(*code, Some(3));
+                assert!(command.as_deref().unwrap_or("").contains("sh"));
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_failed_command_without_stderr_reports_exit_code() {
+        let stack = eval_stack(r#""exit 7" "-c" sh"#);
+        match &stack[0] {
+            Value::Error { message, code, .. } => {
+                assert_eq!(message, "exited 7");
+                assert_eq!(*code, Some(7));
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_failed_command_error_predicate() {
+        let stack = eval_stack(r#""exit 1" "-c" sh error?"#);
+        assert_eq!(stack.last(), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn test_failed_command_keeps_exit_code() {
+        let tokens = lex(r#""exit 5" "-c" sh"#).expect("lex");
+        let program = parse(tokens).expect("parse");
+        let mut evaluator = Evaluator::new();
+        let result = evaluator.eval(&program).expect("eval should not abort");
+        assert_eq!(result.exit_code, 5);
+    }
+
+    #[test]
+    fn test_non_utf8_stdout_pushes_bytes() {
+        let stack = eval_stack(r#""printf '\377\376\375'" "-c" sh"#);
+        assert_eq!(stack.len(), 1);
+        match &stack[0] {
+            Value::Bytes(data) => assert_eq!(data, &vec![0xff, 0xfe, 0xfd]),
+            other => panic!("expected Bytes, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_utf8_stdout_still_output() {
+        let stack = eval_stack(r#""echo hi" "-c" sh"#);
+        match &stack[0] {
+            Value::Output(s) => assert_eq!(s.trim(), "hi"),
+            other => panic!("expected Output, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_empty_stdout_still_nil() {
+        let stack = eval_stack(r#""exit 0" "-c" sh"#);
+        assert_eq!(stack.last(), Some(&Value::Nil));
+    }
+}

--- a/tests/test_shell_native.rs
+++ b/tests/test_shell_native.rs
@@ -292,3 +292,112 @@ fn test_glob_returns_matches() {
     // Clean up
     let _ = fs::remove_dir_all(&tmp);
 }
+
+// ============================================
+// Structured-returning core builtins (issue #27)
+// ============================================
+
+#[test]
+fn test_ls_t_returns_table() {
+    let output = eval("ls-t typeof").unwrap();
+    assert_eq!(output.trim(), "table");
+}
+
+#[test]
+fn test_ls_t_names_and_types() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello").unwrap();
+    fs::create_dir(dir.path().join("subdir")).unwrap();
+
+    let cmd = format!(r#""{}" ls-t "name" get"#, dir.path().display());
+    let output = eval(&cmd).unwrap();
+    assert_eq!(output.trim(), "a.txt\nsubdir");
+
+    let cmd = format!(r#""{}" ls-t "type" get"#, dir.path().display());
+    let output = eval(&cmd).unwrap();
+    assert_eq!(output.trim(), "file\ndir");
+}
+
+#[test]
+fn test_ls_t_size_sum() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("a.txt"), "12345").unwrap();
+    fs::write(dir.path().join("b.txt"), "123").unwrap();
+
+    let cmd = format!(
+        r#""{}" ls-t #["type" get "file" eq?] where "size" get sum"#,
+        dir.path().display()
+    );
+    let output = eval(&cmd).unwrap();
+    assert_eq!(output.trim(), "8");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_ls_t_detects_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("real.txt"), "x").unwrap();
+    std::os::unix::fs::symlink(dir.path().join("real.txt"), dir.path().join("link.txt")).unwrap();
+
+    let cmd = format!(
+        r#""{}" ls-t #["name" get "link.txt" eq?] where "type" get"#,
+        dir.path().display()
+    );
+    let output = eval(&cmd).unwrap();
+    assert_eq!(output.trim(), "symlink");
+}
+
+#[test]
+fn test_env_t_is_record() {
+    let output = eval("env-t typeof").unwrap();
+    assert_eq!(output.trim(), "record");
+}
+
+#[test]
+fn test_env_t_path_lookup() {
+    let output = eval(r#"env-t "PATH" get"#).unwrap();
+    assert_eq!(output.trim(), std::env::var("PATH").unwrap().trim());
+}
+
+#[test]
+fn test_which_t_executable() {
+    let output = eval(r#""sh" which-t "type" get"#).unwrap();
+    assert_eq!(output.trim(), "executable");
+    let output = eval(r#""sh" which-t "path" get"#).unwrap();
+    assert!(Path::new(output.trim()).is_file(), "path: {}", output);
+}
+
+#[test]
+fn test_which_t_builtin_and_missing() {
+    let output = eval(r#""dup" which-t "type" get"#).unwrap();
+    assert_eq!(output.trim(), "builtin");
+    let output = eval(r#""zzz-no-such-cmd-xyz" which-t "type" get"#).unwrap();
+    assert_eq!(output.trim(), "not-found");
+}
+
+#[test]
+fn test_ps_t_returns_table() {
+    let output = eval("ps-t typeof").unwrap();
+    assert_eq!(output.trim(), "table");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_ps_t_contains_processes() {
+    // At least our own process should be listed
+    let output = eval("ps-t count").unwrap();
+    let count: i64 = output.trim().parse().unwrap();
+    assert!(count >= 1, "expected at least one process, got {}", count);
+
+    let output = eval(r#"ps-t 0 nth keys"#).unwrap();
+    let keys = output.trim();
+    for col in ["pid", "name", "cpu", "mem", "status"] {
+        assert!(keys.contains(col), "missing column {}: {}", col, keys);
+    }
+}
+
+#[test]
+fn test_history_t_returns_table() {
+    let output = eval("history-t typeof").unwrap();
+    assert_eq!(output.trim(), "table");
+}

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -276,7 +276,7 @@ fn test_printf_number() {
 #[test]
 fn test_sort_nums_single() {
     let output = eval(r#"'[42]' from-json sort-nums to-json"#).unwrap();
-    assert_eq!(output.trim(), "[42.0]");
+    assert_eq!(output.trim(), "[42]");
 }
 
 #[test]

--- a/tests/test_structured.rs
+++ b/tests/test_structured.rs
@@ -66,7 +66,8 @@ fn test_typeof_quoted_string() {
 fn test_typeof_number() {
     // Numbers come from JSON parsing or arithmetic
     let output = eval("'42' json typeof").unwrap();
-    assert_eq!(output.trim(), "number");
+    // JSON integers are first-class Ints (issue #24)
+    assert_eq!(output.trim(), "int");
 }
 
 #[test]
@@ -1190,7 +1191,8 @@ fn test_type_error_block_expected() {
 fn test_value_type_names() {
     use hsab::Value;
     assert_eq!(Value::Literal("x".into()).type_name(), "string");
-    assert_eq!(Value::Number(1.5).type_name(), "number");
+    assert_eq!(Value::Number(1.5).type_name(), "float");
+    assert_eq!(Value::Int(2).type_name(), "int");
     assert_eq!(Value::Bool(true).type_name(), "boolean");
     assert_eq!(Value::List(vec![]).type_name(), "list");
     assert_eq!(Value::Nil.type_name(), "nil");

--- a/tests/test_table_ops.rs
+++ b/tests/test_table_ops.rs
@@ -1,0 +1,235 @@
+//! Integration tests for table operations (issue #26):
+//! group-by, join-on, add-column, map-column, rename-column, transpose,
+//! first, last, sort-by-desc
+
+#[path = "common/mod.rs"]
+mod common;
+#[allow(unused_imports)]
+use common::{eval, eval_exit_code, lex, parse, Evaluator};
+
+/// A three-row table: t=a/n=1, t=a/n=2, t=b/n=3
+const TN_TABLE: &str =
+    r#"marker "t" "a" "n" 1 record "t" "a" "n" 2 record "t" "b" "n" 3 record table"#;
+
+/// A two-row people table (from-csv, so two tables can coexist on the stack)
+const PEOPLE: &str = r#""id,name
+1,alice
+2,bob" from-csv"#;
+
+/// A three-row orders table keyed by user id
+const ORDERS: &str = r#""uid,item
+1,book
+1,pen
+3,hat" from-csv"#;
+
+// === group-by ===
+
+#[test]
+fn test_group_by_keys() {
+    let output = eval(&format!(r#"{} "t" group-by keys"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "a\nb");
+}
+
+#[test]
+fn test_group_by_subtable_rows() {
+    // Group "a" holds two rows; count its "n" column values
+    let output = eval(&format!(
+        r#"{} "t" group-by "a" get "n" get count"#,
+        TN_TABLE
+    ))
+    .unwrap();
+    assert_eq!(output.trim(), "2");
+}
+
+#[test]
+fn test_group_by_missing_column_errors() {
+    let result = eval(&format!(r#"{} "zzz" group-by"#, TN_TABLE));
+    assert!(result.is_err());
+}
+
+// === join-on ===
+
+#[test]
+fn test_join_on_inner_join_rows() {
+    // alice (id 1) has two orders; bob (id 2) has none -> 2 joined rows
+    let output = eval(&format!(
+        r#"{} {} "id" "uid" join-on "item" get"#,
+        PEOPLE, ORDERS
+    ))
+    .unwrap();
+    assert_eq!(output.trim(), "book\npen");
+}
+
+#[test]
+fn test_join_on_drops_right_key_column() {
+    let output = eval(&format!(
+        r#"{} {} "id" "uid" join-on 0 nth keys"#,
+        PEOPLE, ORDERS
+    ))
+    .unwrap();
+    let keys = output.trim();
+    assert!(keys.contains("id"));
+    assert!(keys.contains("name"));
+    assert!(keys.contains("item"));
+    assert!(!keys.contains("uid"));
+}
+
+#[test]
+fn test_join_on_collision_suffixes_right_column() {
+    // Both tables have a "name" column; the right one is suffixed
+    let left = r#""id,name
+1,alice" from-csv"#;
+    let right = r#""rid,name
+1,right-name" from-csv"#;
+    let output = eval(&format!(
+        r#"{} {} "id" "rid" join-on 0 nth keys"#,
+        left, right
+    ))
+    .unwrap();
+    assert!(output.contains("name_right"), "keys: {}", output);
+}
+
+#[test]
+fn test_join_on_missing_key_errors() {
+    let result = eval(&format!(r#"{} {} "nope" "uid" join-on"#, PEOPLE, ORDERS));
+    assert!(result.is_err());
+}
+
+// === add-column ===
+
+#[test]
+fn test_add_column_computed_from_row() {
+    let output = eval(&format!(
+        r#"{} #["n" get 10 mul] "n10" add-column "n10" get"#,
+        TN_TABLE
+    ))
+    .unwrap();
+    assert_eq!(output.trim(), "10\n20\n30");
+}
+
+#[test]
+fn test_add_column_appears_in_keys() {
+    let output = eval(&format!(
+        r#"{} #["t" get] "t2" add-column 0 nth keys"#,
+        TN_TABLE
+    ))
+    .unwrap();
+    let keys = output.trim();
+    assert!(keys.contains("t2"));
+    assert!(keys.ends_with("t2"), "new column should be last: {}", keys);
+}
+
+// === map-column ===
+
+#[test]
+fn test_map_column_transforms_in_place() {
+    let output = eval(&format!(r#"{} "n" #[2 mul] map-column "n" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "2\n4\n6");
+}
+
+#[test]
+fn test_map_column_leaves_other_columns() {
+    let output = eval(&format!(r#"{} "n" #[2 mul] map-column "t" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "a\na\nb");
+}
+
+#[test]
+fn test_map_column_missing_column_errors() {
+    let result = eval(&format!(r#"{} "zzz" #[2 mul] map-column"#, TN_TABLE));
+    assert!(result.is_err());
+}
+
+// === rename-column ===
+
+#[test]
+fn test_rename_column_renames() {
+    let output = eval(&format!(
+        r#"{} "n" "count" rename-column 0 nth keys"#,
+        TN_TABLE
+    ))
+    .unwrap();
+    let keys = output.trim();
+    assert!(keys.contains("count"));
+    assert!(!keys.split_whitespace().any(|k| k == "n"));
+}
+
+#[test]
+fn test_rename_column_preserves_values() {
+    let output = eval(&format!(
+        r#"{} "n" "count" rename-column "count" get"#,
+        TN_TABLE
+    ))
+    .unwrap();
+    assert_eq!(output.trim(), "1\n2\n3");
+}
+
+#[test]
+fn test_rename_column_missing_errors() {
+    let result = eval(&format!(r#"{} "zzz" "count" rename-column"#, TN_TABLE));
+    assert!(result.is_err());
+}
+
+// === transpose ===
+
+#[test]
+fn test_transpose_column_names_become_rows() {
+    let output = eval(&format!(r#"{} transpose "column" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "t\nn");
+}
+
+#[test]
+fn test_transpose_cells_move() {
+    // Original row 1 (0-indexed) is t=a/n=2; transposed column "1" holds [a, 2]
+    let output = eval(&format!(r#"{} transpose "1" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "a\n2");
+}
+
+// === first / last ===
+
+#[test]
+fn test_first_n_rows() {
+    let output = eval(&format!(r#"{} 2 first "n" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "1\n2");
+}
+
+#[test]
+fn test_first_more_than_rows() {
+    let output = eval(&format!(r#"{} 10 first "n" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "1\n2\n3");
+}
+
+#[test]
+fn test_last_n_rows() {
+    let output = eval(&format!(r#"{} 2 last "n" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "2\n3");
+}
+
+#[test]
+fn test_last_single_row() {
+    let output = eval(&format!(r#"{} 1 last "t" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "b");
+}
+
+// === sort-by-desc ===
+
+#[test]
+fn test_sort_by_desc_numeric() {
+    let output = eval(&format!(r#"{} "n" sort-by-desc "n" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "3\n2\n1");
+}
+
+#[test]
+fn test_sort_by_desc_strings() {
+    let output = eval(&format!(r#"{} "t" sort-by-desc "t" get"#, TN_TABLE)).unwrap();
+    assert_eq!(output.trim(), "b\na\na");
+}
+
+#[test]
+fn test_sort_by_desc_is_reverse_of_sort_by() {
+    let asc = eval(&format!(r#"{} "n" sort-by "n" get"#, TN_TABLE)).unwrap();
+    let desc = eval(&format!(r#"{} "n" sort-by-desc "n" get"#, TN_TABLE)).unwrap();
+    let mut asc_lines: Vec<&str> = asc.trim().lines().collect();
+    asc_lines.reverse();
+    let desc_lines: Vec<&str> = desc.trim().lines().collect();
+    assert_eq!(asc_lines, desc_lines);
+}

--- a/tests/test_type_logic.rs
+++ b/tests/test_type_logic.rs
@@ -12,7 +12,7 @@ fn test_string_pred() {
 }
 #[test]
 fn test_typeof_number() {
-    assert_eq!(eval("42 typeof").unwrap().trim(), "number");
+    assert_eq!(eval("42 typeof").unwrap().trim(), "int");
 }
 #[test]
 fn test_typeof_string() {

--- a/tests/test_type_logic.rs
+++ b/tests/test_type_logic.rs
@@ -30,3 +30,49 @@ fn test_not_false() {
 fn test_empty_string() {
     assert_eq!(eval_exit_code("\"\" empty?"), 0);
 }
+
+// ============================================
+// Issue #33: source positions on runtime errors
+// ============================================
+
+#[test]
+fn test_type_error_reports_position() {
+    use hsab::{lex_spanned, parse_with_spans, Evaluator};
+    let tokens = lex_spanned(r#""abc" 3 plus"#).unwrap();
+    let (program, spans) = parse_with_spans(tokens).unwrap();
+    let mut evaluator = Evaluator::new();
+    let err = evaluator.eval_with_spans(&program, &spans).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("expected number"), "msg: {}", msg);
+    assert!(msg.contains("got string"), "msg: {}", msg);
+    assert!(msg.contains("at line 1 col 9"), "msg: {}", msg);
+}
+
+#[test]
+fn test_stack_underflow_reports_position() {
+    use hsab::{lex_spanned, parse_with_spans, Evaluator};
+    let tokens = lex_spanned("drop").unwrap();
+    let (program, spans) = parse_with_spans(tokens).unwrap();
+    let mut evaluator = Evaluator::new();
+    let err = evaluator.eval_with_spans(&program, &spans).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("at line 1 col 1"), "msg: {}", msg);
+}
+
+#[test]
+fn test_error_position_on_second_line() {
+    use hsab::{lex_spanned, parse_with_spans, Evaluator};
+    let tokens = lex_spanned("1 2 plus\n\"abc\" 3 plus").unwrap();
+    let (program, spans) = parse_with_spans(tokens).unwrap();
+    let mut evaluator = Evaluator::new();
+    let err = evaluator.eval_with_spans(&program, &spans).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("at line 2"), "msg: {}", msg);
+}
+
+#[test]
+fn test_eval_without_spans_has_no_position() {
+    // The plain eval() API is unchanged: no position annotation
+    let err = eval(r#""abc" 3 plus"#).unwrap_err();
+    assert!(!err.contains("at line"), "msg: {}", err);
+}

--- a/tests/test_unified_control.rs
+++ b/tests/test_unified_control.rs
@@ -105,7 +105,10 @@ fn test_else_after_all_false() {
 #[test]
 fn test_elseif_chain_fizzbuzz_15() {
     // Value 15 should match the first condition (15 eq? 15)
-    let program = r#"15 dup 15 eq? #[drop "fizzbuzz" echo] swap if dup 5 mod 0 eq? #[drop "buzz" echo] swap elseif #[echo] else"#;
+    // NOTE (issue #24): the elseif condition used to run `dup 5 mod` on the
+    // echoed Output string, relying on silent 0-coercion. Arithmetic is now
+    // strict, so the second condition uses a string predicate instead.
+    let program = r#"15 dup 15 eq? #[drop "fizzbuzz" echo] swap if "x" "x" ne? #[drop "buzz" echo] swap elseif #[echo] else"#;
     let output = eval(program).unwrap();
     assert_eq!(output.trim(), "fizzbuzz");
 }


### PR DESCRIPTION
Completes the structured-object-model track and the remaining robustness issue, then preps a release:

- #24 first-class `Value::Int` — strict numeric coercion, no more silent `"abc" 3 plus` → `0`
- #25 external-command boundary — structured `Error` on failure, byte-fidelity stdout, stderr capture
- #28 `collect`/`keep`/`spread` preserve structured values through pipelines (no more stringify-through-Marker)
- #26 table ops completed: `join-on`, `add-column`, `map-column`, `rename-column`, `transpose`, `sort-by-desc`
- #27 structured core builtins: `ls-t`, `ps-t`, `env-t`, `which-t`, `history-t`
- #33 statement-level source spans on runtime errors (`... at line L col C`)
- #22 reconciled `issues/000-003` against the now-much-more-complete implementation; README audited against the registry (zero drift found)
- Release prep: bump to **0.2.0**, add MIT `LICENSE`, update `Formula/hsab.rb` to point at the v0.2.0 tag

Deliberate test updates from the Int-type change are itemized in the branch history (JSON round-trip int vs float, a couple of error-message assertions, one fizzbuzz predicate that relied on silent 0-coercion).

Suite: 1306 → **1360 tests passing**; fmt + clippy(`-D warnings`) clean; both feature-gated builds green. Independently re-verified locally before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)